### PR TITLE
[FIXED JENKINS-20863] SupportLogHandler has int that needs to be reset.

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportLogHandler.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportLogHandler.java
@@ -105,7 +105,7 @@ public class SupportLogHandler extends Handler {
             int maxCount = records.length;
             records[(position + count) % maxCount] = record;
             if (count == maxCount) {
-                position++;
+                position = (position + 1) % maxCount;
             } else {
                 count++;
             }


### PR DESCRIPTION
This is the same issue (and same fix) as JENKINS-9120. The 'position' integer is being incremented indefinitely and will eventually overflow, leading to a crash.
