### PR TITLE
Limit slow-request file size to 2MB.

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/slowrequest/SlowRequestChecker.java
+++ b/src/main/java/com/cloudbees/jenkins/support/slowrequest/SlowRequestChecker.java
@@ -1,6 +1,7 @@
 package com.cloudbees.jenkins.support.slowrequest;
 
 import com.cloudbees.jenkins.support.timer.FileListCap;
+import com.cloudbees.jenkins.support.timer.FileListCapComponent;
 import com.google.inject.Inject;
 import hudson.Extension;
 import hudson.model.PeriodicWork;
@@ -96,6 +97,8 @@ public class SlowRequestChecker extends PeriodicWork {
                         logs.touch(req.record);
                     }
 
+                    if (req.record.length() >= FileListCapComponent.MAX_FILE_SIZE)
+                      continue;
                     ThreadInfo lockedThread = ManagementFactory.getThreadMXBean().getThreadInfo(req.thread.getId());
                     if (lockedThread != null ) {
                         w.println(lockedThread);

--- a/src/main/java/com/cloudbees/jenkins/support/timer/FileListCapComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/timer/FileListCapComponent.java
@@ -21,7 +21,7 @@ import jenkins.model.Jenkins;
 public abstract class FileListCapComponent extends Component {
 
     /** Maximum file size to pack is 2Mb. */
-    private static final int MAX_FILE_SIZE = 2 * 1000000;
+    public static final int MAX_FILE_SIZE = 2 * 1000000;
 
     @NonNull
     @Override


### PR DESCRIPTION
Currently slow-requests are not limited, so they could potentially grow very large in size if executing something via the script console. This will limit the slow-requests to 2MB.
