### PR TITLE
Slow-requests not properly publishing entire thread dump

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/slowrequest/SlowRequestChecker.java
+++ b/src/main/java/com/cloudbees/jenkins/support/slowrequest/SlowRequestChecker.java
@@ -73,7 +73,7 @@ public class SlowRequestChecker extends PeriodicWork {
 
         long iota = System.currentTimeMillis();
 
-        final long recurrencePeriosMillis = TimeUnit.SECONDS.toMillis(RECURRENCE_PERIOD_SEC);   
+        final long recurrencePeriosMillis = TimeUnit.SECONDS.toMillis(RECURRENCE_PERIOD_SEC);
         long thresholdMillis = recurrencePeriosMillis > THRESHOLD ?
                 recurrencePeriosMillis * 2 : THRESHOLD;
 


### PR DESCRIPTION
The default implementation of `ThreadMXBean.getThreadInfo(long)` has a max depth size of 0, so the slow-request was incomplete. Previous implementations used `dumpAllThreads` which gets a depth of `Integer.MAX_VALUE`.
