### PR TITLE
[FIXED JENKINS-26409] ClientAbortException logged when cancelling a support bundle download

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
@@ -167,7 +167,6 @@ public class SupportAction implements RootAction {
                 SupportPlugin.clearRequesterAuthentication();
             }
         } finally {
-            servletOutputStream.close();
             logger.fine("Response completed");
         }
     }


### PR DESCRIPTION
I think that if we didn't create ServletOutputStream then we don't need to close it. I think it should me managed by the container and we shouldn't force a close. This was creating `ClientAbortException`.