### PR TITLE
File.listFiles can return null

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/SmartLogFetcher.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SmartLogFetcher.java
@@ -248,7 +248,11 @@ class SmartLogFetcher {
 
         public Map<String, Long> invoke(File dir, VirtualChannel channel) throws IOException, InterruptedException {
             Map<String, Long> result = new LinkedHashMap<String, Long>();
-            for (File file : dir.listFiles(filter)) {
+            File[] files = dir.listFiles(filter);
+            if (files == null) {
+                return result;
+            }
+            for (File file : files) {
                 FileHash hash = cached.get(file.getName());
                 if (hash != null && hash.isPartialMatch(file)) {
                     if (file.length() == hash.getLength()) {


### PR DESCRIPTION
Observed in a bundle (ref. ZD-24585):

```
…	WARNING	c.c.j.support.impl.JenkinsLogs#addContents: Could not retrieve some of the remote node extra logs
java.util.concurrent.ExecutionException: java.lang.NullPointerException
	at java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at …
Caused by: java.lang.NullPointerException
	at com.cloudbees.jenkins.support.impl.SmartLogFetcher$LogFileHashSlurper.invoke(SmartLogFetcher.java:251)
	at com.cloudbees.jenkins.support.impl.SmartLogFetcher$LogFileHashSlurper.invoke(SmartLogFetcher.java:236)
	at …
	at ......remote call to …(Native Method)
	at …
	at com.cloudbees.jenkins.support.impl.SmartLogFetcher$ForNode.getLogFiles(SmartLogFetcher.java:100)
	at com.cloudbees.jenkins.support.impl.JenkinsLogs$4.call(JenkinsLogs.java:327)
	at com.cloudbees.jenkins.support.impl.JenkinsLogs$4.call(JenkinsLogs.java:324)
	at java.util.concurrent.FutureTask.run(FutureTask.java:262)
	... 3 more
```

@reviewbybees (esp. @kohsuke whose bug this was!)