### PR TITLE
Use the CB UC whenever nectar-license is installed

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
@@ -703,19 +703,20 @@ public class AboutJenkins extends Component {
         @Override
         protected void printTo(PrintWriter out) throws IOException {
 
+            PluginManager pluginManager = Jenkins.getInstance().getPluginManager();
             String fullVersion = Jenkins.getVersion().toString();
             int s = fullVersion.indexOf(' ');
             if (s > 0 && fullVersion.contains("CloudBees")) {
                 out.println("FROM cloudbees/jenkins:" + fullVersion.substring(0, s));
-
-                out.println("ENV JENKINS_UC http://jenkins-updates.cloudbees.com");
             } else {
                 out.println("FROM jenkins:" + fullVersion);
+            }
+            if (pluginManager.getPlugin("nectar-license") != null) { // even if atop an OSS WAR
+                out.println("ENV JENKINS_UC http://jenkins-updates.cloudbees.com");
             }
 
             out.println("RUN mkdir -p /usr/share/jenkins/ref/plugins/");
 
-            PluginManager pluginManager = Jenkins.getInstance().getPluginManager();
             List<PluginWrapper> plugins = pluginManager.getPlugins();
             Collections.sort(plugins);
 


### PR DESCRIPTION
Otherwise I have seen

```
FROM jenkins:1.580.2
RUN mkdir -p /usr/share/jenkins/ref/plugins/
…
RUN curl -L $JENKINS_UC/plugins/nectar-license/6.0/nectar-license.hpi -o /usr/share/jenkins/ref/plugins/nectar-license.jpi
RUN curl -L $JENKINS_UC/plugins/nectar-rbac/4.12/nectar-rbac.hpi -o /usr/share/jenkins/ref/plugins/nectar-rbac.jpi
RUN curl -L $JENKINS_UC/plugins/nectar-vmware/4.3.2/nectar-vmware.hpi -o /usr/share/jenkins/ref/plugins/nectar-vmware.jpi
…
```

which will not work.

@reviewbybees but esp. @alecharp who seems to have worked on this recently. (A new release would be in order soon, no?)