### PR TITLE
Prevent NPE in unit test

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -381,7 +381,9 @@ public class SupportPlugin extends Plugin {
 
     @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED, before = InitMilestone.JOB_LOADED)
     public static void loadConfig() throws IOException {
-        getInstance().load();
+        SupportPlugin instance = getInstance();
+        if (instance != null)
+            instance.load();
     }
 
     @Override


### PR DESCRIPTION
Fix a NPE when running unit tests at the start of the test:

```
Caused by: java.lang.NullPointerException
	at com.cloudbees.jenkins.support.SupportPlugin.loadConfig(SupportPlugin.java:384)
``` 

@reviewbybees