### PR TITLE
Capture the full stacktrace for any deadlocked threads

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/timer/DeadlockTrackChecker.java
+++ b/src/main/java/com/cloudbees/jenkins/support/timer/DeadlockTrackChecker.java
@@ -1,5 +1,6 @@
 package com.cloudbees.jenkins.support.timer;
 
+import com.cloudbees.jenkins.support.impl.ThreadDumps;
 import hudson.Extension;
 import hudson.model.PeriodicWork;
 import jenkins.model.Jenkins;
@@ -21,7 +22,6 @@ public class DeadlockTrackChecker extends PeriodicWork {
 
     final SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd-HHmmss");
     final FileListCap logs = new FileListCap(new File(Jenkins.getInstance().getRootDir(),"deadlocks"), 50);
-    static final File deadLockFolder = new File(Jenkins.getInstance().getRootDir(), "/support");
 
     @Override
     public long getRecurrencePeriod() {
@@ -49,7 +49,7 @@ public class DeadlockTrackChecker extends PeriodicWork {
                 ThreadInfo[] deadLockThreads = mbean.getThreadInfo(deadLocks, Integer.MAX_VALUE);
 
                 for (ThreadInfo threadInfo : deadLockThreads) {
-                    builder.println(threadInfo);
+                    ThreadDumps.printThreadInfo(builder, threadInfo, mbean);
                 }
             } finally {
                 builder.close();

--- a/src/main/java/com/cloudbees/jenkins/support/timer/DeadlockTrackChecker.java
+++ b/src/main/java/com/cloudbees/jenkins/support/timer/DeadlockTrackChecker.java
@@ -49,7 +49,11 @@ public class DeadlockTrackChecker extends PeriodicWork {
                 ThreadInfo[] deadLockThreads = mbean.getThreadInfo(deadLocks, Integer.MAX_VALUE);
 
                 for (ThreadInfo threadInfo : deadLockThreads) {
-                    ThreadDumps.printThreadInfo(builder, threadInfo, mbean);
+                    try {
+                        ThreadDumps.printThreadInfo(builder, threadInfo, mbean);
+                    } catch (LinkageError e) {
+                        builder.println(threadInfo);
+                    }
                 }
             } finally {
                 builder.close();

--- a/src/test/java/com/cloudbees/jenkins/support/timer/DeadlockTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/timer/DeadlockTest.java
@@ -72,18 +72,27 @@ public class DeadlockTest {
     });
 
     t1.start();
-    t2.start();
+    try {
+      t2.start();
+      try {
 
-    Thread.sleep(1000 * 5); // Wait 5 seconds, then execute deadlock checker.
+        Thread.sleep(1000 * 5); // Wait 5 seconds, then execute deadlock checker.
 
-    // Force call deadlock checker
-    DeadlockTrackChecker dtc = new DeadlockTrackChecker();
-    dtc.doRun();
+        // Force call deadlock checker
+        DeadlockTrackChecker dtc = new DeadlockTrackChecker();
+        dtc.doRun();
 
-    // Reason for >= 1 is because depending on where the test unit is executed the deadlock detection thread could be
-    // invoked twice.
-    files = new File(j.getInstance().getRootDir(), "/deadlocks").listFiles();
-    assertNotNull("There should be at least one deadlock file", files);
-    assertThat("A deadlock was detected and a new deadlock file created", files.length, greaterThan(initialCount));
+        // Reason for >= 1 is because depending on where the test unit is executed the deadlock detection thread could be
+
+        // invoked twice.
+        files = new File(j.getInstance().getRootDir(), "/deadlocks").listFiles();
+        assertNotNull("There should be at least one deadlock file", files);
+        assertThat("A deadlock was detected and a new deadlock file created", files.length, greaterThan(initialCount));
+      } finally {
+        t2.stop();
+      }
+    } finally {
+      t1.stop();
+    }
   }
 }

--- a/src/test/java/com/cloudbees/jenkins/support/timer/DeadlockTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/timer/DeadlockTest.java
@@ -29,6 +29,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.File;
 
+import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.*;
 
 /**
@@ -48,6 +49,8 @@ public class DeadlockTest {
 
   @Test
   public void detectDeadlock() throws Exception {
+    File[] files = new File(j.getInstance().getRootDir(), "/deadlocks").listFiles();
+    int initialCount = files == null ? 0 : files.length;
     final Object object1 = new Object();
     final Object object2 = new Object();
     Thread t1 = new Thread( new Runnable() {
@@ -79,6 +82,8 @@ public class DeadlockTest {
 
     // Reason for >= 1 is because depending on where the test unit is executed the deadlock detection thread could be
     // invoked twice.
-    assertTrue("Failed to detect deadlock.", new File(j.getInstance().getRootDir(), "/deadlocks").listFiles().length >= 1);
+    files = new File(j.getInstance().getRootDir(), "/deadlocks").listFiles();
+    assertNotNull("There should be at least one deadlock file", files);
+    assertThat("A deadlock was detected and a new deadlock file created", files.length, greaterThan(initialCount));
   }
 }


### PR DESCRIPTION
Too often the actual cause of the deadlock is outside the first ThreadInfo.MAX_FRAMES (i.e. 8) thread frames.
When that happens the actual deadlock information is worse than useless.

This change uses the same formatter as the full thread dump which should result in more useful information

@reviewbybees