### PR TITLE
[JENKINS-31365] Display blocked + waiting time per thread.

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -74,6 +74,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
 import java.text.MessageFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -392,6 +394,12 @@ public class SupportPlugin extends Plugin {
         rootLogger = Logger.getLogger("");
         rootLogger.addHandler(handler);
         context = new SupportContextImpl();
+        // If thread contention monitoring is supported, then we should enable
+        // it when the plugin is started.
+        ThreadMXBean mbean= ManagementFactory.getThreadMXBean();
+        if (mbean.isThreadContentionMonitoringSupported()) {
+            mbean.setThreadContentionMonitoringEnabled(true);
+        }
     }
 
     @NonNull

--- a/src/main/java/com/cloudbees/jenkins/support/impl/ThreadDumps.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/ThreadDumps.java
@@ -273,12 +273,16 @@ public class ThreadDumps extends Component {
             x.printStackTrace(writer);
             cpuPercentage = 0;
         }
-        writer.printf("\"%s\" id=%d (0x%x) state=%s cpu=%d%%",
+
+        long time = t.getBlockedTime() + t.getWaitedTime();
+
+        writer.printf("\"%s\" id=%d (0x%x) state=%s cpu=%d%% time=%dms",
                 t.getThreadName(),
                 t.getThreadId(),
                 t.getThreadId(),
                 t.getThreadState(),
-                cpuPercentage);
+                cpuPercentage,
+                time);
         final LockInfo lock = t.getLockInfo();
         if (lock != null && t.getThreadState() != Thread.State.BLOCKED) {
             writer.printf("\n    - waiting on <0x%08x> (a %s)",


### PR DESCRIPTION
[JENKINS-31365](https://issues.jenkins-ci.org/browse/JENKINS-31365)

This PR adds to the thread-dump.txt file the blocked time + waiting time for each thread. In order for us to calculate this time we need to enable `ThreadContentionMonitoring` on the instance, so once the plugin is started, it will enable this and any _new_ threads will provide the contention information.

Example output:

``` java
"Computer.threadPoolForRemoting [#2]" id=80 (0x50) state=TIMED_WAITING cpu=68% time=13972ms
    - waiting on <0x49bd11ee> (a java.util.concurrent.SynchronousQueue$TransferStack)
    - locked <0x49bd11ee> (a java.util.concurrent.SynchronousQueue$TransferStack)
    at sun.misc.Unsafe.park(Native Method)
    at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:215)
    at java.util.concurrent.SynchronousQueue$TransferStack.awaitFulfill(SynchronousQueue.java:460)
    at java.util.concurrent.SynchronousQueue$TransferStack.transfer(SynchronousQueue.java:362)
    at java.util.concurrent.SynchronousQueue.poll(SynchronousQueue.java:941)
    at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1066)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1127)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
```

@reviewbybees @jtnord 
