### PR TITLE
[JENKINS-30117] Support bundle blocks with lots of data

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportLogFormatter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportLogFormatter.java
@@ -48,12 +48,11 @@ public class SupportLogFormatter extends Formatter {
             justification = "The exception wasn't thrown on our stack frame"
     )
     public String format(LogRecord record) {
-        StringBuffer buffer = new StringBuffer();
-        fdf.format(new Date(record.getMillis()), buffer);
+        StringBuilder builder = new StringBuilder();
+        builder.append(fdf.format(new Date(record.getMillis())));
+        builder.append(" [id=").append(record.getThreadID()).append("]");
 
-        buffer.append(" [id=").append(record.getThreadID()).append("]");
-
-        buffer.append("\t").append(record.getLevel().getName()).append("\t");
+        builder.append("\t").append(record.getLevel().getName()).append("\t");
 
         if (record.getSourceMethodName() != null) {
             String sourceClass;
@@ -63,7 +62,7 @@ public class SupportLogFormatter extends Formatter {
                 sourceClass = record.getSourceClassName();
             }
 
-            buffer.append(abbreviateClassName(sourceClass, 32)).append("#").append(record.getSourceMethodName());
+            builder.append(abbreviateClassName(sourceClass, 32)).append("#").append(record.getSourceMethodName());
         } else {
             String sourceClass;
             if (record.getSourceClassName() == null) {
@@ -71,10 +70,10 @@ public class SupportLogFormatter extends Formatter {
             } else {
                 sourceClass = record.getSourceClassName();
             }
-            buffer.append(abbreviateClassName(sourceClass, 40));
+            builder.append(abbreviateClassName(sourceClass, 40));
         }
 
-        buffer.append(": ").append(formatMessage(record));
+        builder.append(": ").append(formatMessage(record));
 
         if (record.getThrown() != null) {
             try {
@@ -82,14 +81,14 @@ public class SupportLogFormatter extends Formatter {
                 PrintWriter out = new PrintWriter(writer);
                 record.getThrown().printStackTrace(out);
                 out.close();
-                buffer.append(writer.toString());
+                builder.append(writer.toString());
             } catch (Exception e) {
                 // ignore
             }
         }
 
-        buffer.append("\n");
-        return buffer.toString();
+        builder.append("\n");
+        return builder.toString();
     }
 
     public String abbreviateClassName(String fqcn, int targetLength) {

--- a/src/main/java/com/cloudbees/jenkins/support/SupportLogFormatter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportLogFormatter.java
@@ -24,6 +24,8 @@
 
 package com.cloudbees.jenkins.support;
 
+import org.apache.commons.lang.time.FastDateFormat;
+
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.text.MessageFormat;
@@ -37,9 +39,7 @@ import java.util.logging.LogRecord;
  * @author Stephen Connolly
  */
 public class SupportLogFormatter extends Formatter {
-    private final Date date = new Date();
-    private final MessageFormat formatter =
-            new MessageFormat("{0,date,yyyy-MM-dd} {0,time,HH:mm:ss.SSSZ} {1}\t{2}\t{3}: {4}\n");
+    FastDateFormat fdf = FastDateFormat.getInstance("yyyy-MM-dd HH:mm:ss.SSSZ");
     private final Object[] args = new Object[6];
 
     @Override
@@ -47,32 +47,49 @@ public class SupportLogFormatter extends Formatter {
             value = {"DE_MIGHT_IGNORE"},
             justification = "The exception wasn't thrown on our stack frame"
     )
-    public synchronized String format(LogRecord record) {
-        date.setTime(record.getMillis());
-        args[0] = date;
-        args[1] = "[id=" + record.getThreadID() + "]";
-        args[2] = record.getLevel().getName();
-        args[3] = record.getSourceMethodName() != null
-                ? abbreviateClassName(
-                record.getSourceClassName() == null ? record.getLoggerName() : record.getSourceClassName(), 32)
-                + "#" + record.getSourceMethodName()
-                : abbreviateClassName(
-                        record.getSourceClassName() == null ? record.getLoggerName() : record.getSourceClassName(),
-                        40);
-        args[4] = formatMessage(record);
-        StringBuffer buf = formatter.format(args, new StringBuffer(), null);
+    public String format(LogRecord record) {
+        StringBuffer buffer = new StringBuffer();
+        fdf.format(new Date(record.getMillis()), buffer);
+
+        buffer.append(" [id=").append(record.getThreadID()).append("]");
+
+        buffer.append("\t").append(record.getLevel().getName()).append("\t");
+
+        if (record.getSourceMethodName() != null) {
+            String sourceClass;
+            if (record.getSourceClassName() == null) {
+                sourceClass = record.getLoggerName();
+            } else {
+                sourceClass = record.getSourceClassName();
+            }
+
+            buffer.append(abbreviateClassName(sourceClass, 32)).append("#").append(record.getSourceMethodName());
+        } else {
+            String sourceClass;
+            if (record.getSourceClassName() == null) {
+                sourceClass = record.getLoggerName();
+            } else {
+                sourceClass = record.getSourceClassName();
+            }
+            buffer.append(abbreviateClassName(sourceClass, 40));
+        }
+
+        buffer.append(": ").append(formatMessage(record));
+
         if (record.getThrown() != null) {
             try {
                 StringWriter writer = new StringWriter();
                 PrintWriter out = new PrintWriter(writer);
                 record.getThrown().printStackTrace(out);
                 out.close();
-                buf.append(writer.toString());
+                buffer.append(writer.toString());
             } catch (Exception e) {
                 // ignore
             }
         }
-        return buf.toString();
+
+        buffer.append("\n");
+        return buffer.toString();
     }
 
     public String abbreviateClassName(String fqcn, int targetLength) {


### PR DESCRIPTION
The format method should be thread safe as it could be invoked from
multiple threads. Instead of using a MessageFormatter which is not thread safe we
use the FastDateFormatter, and a StringBuffer both of which are thread
safe.

@reviewbybees 