### PR TITLE
Verifying full stack traces in deadlocks

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/ThreadDumps.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/ThreadDumps.java
@@ -252,6 +252,7 @@ public class ThreadDumps extends Component {
         writer.flush();
     }
 
+    // TODO Functions.sortThreadsAndGetGroupMap + Functions.Functions.dumpThreadInfo not showing lock owners in some cases
     /**
      * Prints the {@link ThreadInfo} (because {@link ThreadInfo#toString()} caps out the stack trace at 8 frames)
      *


### PR DESCRIPTION
Saw a support bundle from someone presumably using this plugin <2.28 and was annoyed by a deadlock file which hinted at [JENKINS-31614](https://issues.jenkins-ci.org/browse/JENKINS-31614) yet lacked the crucial detail of the caller of `Queue.schedule`.

#41 seems to have fixed this, but included no test addition to prove it. Doing so now.

I originally fixed this against an older version of the plugin using the methods already available in `Functions` in Jenkins core. For some reason these do not seem to be showing full lock information in this context, though. Original display:

```
==============
Deadlock Found
==============
"Thread-12" Id=45 BLOCKED on java.lang.Object@7c60aaa5 owned by "Thread-11" Id=44
	at com.cloudbees.jenkins.support.timer.DeadlockTest$2.run(DeadlockTest.java:78)
	-  blocked on java.lang.Object@7c60aaa5
	at java.lang.Thread.run(Thread.java:745)


"Thread-11" Id=44 BLOCKED on java.lang.Object@72a74b59 owned by "Thread-12" Id=45
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:69)
	-  blocked on java.lang.Object@72a74b59
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:67)
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:67)
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:67)
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:67)
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:67)
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:67)
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:67)
	...
```

After my initial attempt:

```
==============
Deadlock Found
==============
"Thread-11" Id=44 Group=main BLOCKED on java.lang.Object@76f6d06b owned by "Thread-12" Id=45
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:69)
	-  blocked on java.lang.Object@76f6d06b
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:67)
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:67)
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:67)
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:67)
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:67)
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:67)
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:67)
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:67)
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:67)
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:67)
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:67)
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:67)
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:67)
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:67)
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:67)
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:67)
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:67)
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:67)
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:67)
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:67)
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.firstMethod(DeadlockTest.java:63)
	at com.cloudbees.jenkins.support.timer.DeadlockTest$1.run(DeadlockTest.java:59)
	at java.lang.Thread.run(Thread.java:745)


"Thread-12" Id=45 Group=main BLOCKED on java.lang.Object@28e9c20a owned by "Thread-11" Id=44
	at com.cloudbees.jenkins.support.timer.DeadlockTest$2.run(DeadlockTest.java:78)
	-  blocked on java.lang.Object@28e9c20a
	at java.lang.Thread.run(Thread.java:745)
```

Current plugin output:

```
==============
Deadlock Found
==============
"Thread-12" id=45 (0x2d) state=BLOCKED cpu=0%
    - waiting to lock <0x3847f429> (a java.lang.Object)
      owned by "Thread-11" id=44 (0x2c)
    at com.cloudbees.jenkins.support.timer.DeadlockTest$2.run(DeadlockTest.java:81)
    at java.lang.Thread.run(Thread.java:745)

"Thread-11" id=44 (0x2c) state=BLOCKED cpu=0%
    - waiting to lock <0x40826664> (a java.lang.Object)
      owned by "Thread-12" id=45 (0x2d)
    at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:72)
    at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:70)
    at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:70)
    at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:70)
    at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:70)
    at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:70)
    at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:70)
    at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:70)
    at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:70)
    at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:70)
    at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:70)
    at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:70)
    at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:70)
    at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:70)
    at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:70)
    at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:70)
    at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:70)
    at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:70)
    at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:70)
    at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:70)
    at com.cloudbees.jenkins.support.timer.DeadlockTest$1.secondMethod(DeadlockTest.java:70)
    at com.cloudbees.jenkins.support.timer.DeadlockTest$1.firstMethod(DeadlockTest.java:66)
    at com.cloudbees.jenkins.support.timer.DeadlockTest$1.run(DeadlockTest.java:62)
    at java.lang.Thread.run(Thread.java:745)
```

@reviewbybees esp. @stephenc, @christ66