### PR TITLE
[FIX JENKINS-32401] Record log levels

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/LoggerManager.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/LoggerManager.java
@@ -1,0 +1,59 @@
+package com.cloudbees.jenkins.support.impl;
+
+import com.cloudbees.jenkins.support.api.Component;
+import com.cloudbees.jenkins.support.api.Container;
+import com.cloudbees.jenkins.support.api.PrintedContent;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.security.Permission;
+import jenkins.model.Jenkins;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+
+/**
+ * Output the current list of loggers for the master and display the
+ * logging level. This is to diagnose if a specific logger is causing
+ * some performance issues by logging too much data.
+ *
+ * @since 2.30
+ */
+@Extension
+public class LoggerManager extends Component {
+    @NonNull
+    @Override
+    public Set<Permission> getRequiredPermissions() {
+        return Collections.singleton(Jenkins.ADMINISTER);
+    }
+
+    @NonNull
+    @Override
+    public String getDisplayName() {
+        return "All loggers currently enabled.";
+    }
+
+    @Override
+    public void addContents(@NonNull Container container) {
+        container.add(new PrintedContent("loggers.md") {
+            @Override
+            protected void printTo(PrintWriter out) throws IOException {
+                out.println("Loggers currently enabled");
+                out.println("=========================");
+                LogManager logManager = LogManager.getLogManager();
+                Enumeration<String> loggerNames = logManager.getLoggerNames();
+                while (loggerNames.hasMoreElements()) {
+                    String loggerName =  loggerNames.nextElement();
+                    Level level = logManager.getLogger(loggerName).getLevel();
+                    if (level != null) {
+                        out.println(loggerName + " - " + level);
+                    }
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
Sometimes a logger could be causing performance issues because it is far too verbose. This will display which loggers are currently enabled, and what the log level is for each logger. 

@reviewbybees @daniel-beck 