### PR TITLE
[JENKINS-33668] Adapt to new plugin parent POM and upgrade baseline to 1.580.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.554.1</version>
+    <version>2.3</version>
   </parent>
 
   <artifactId>support-core</artifactId>
@@ -60,10 +60,6 @@
     </developer>
   </developers>
 
-  <prerequisites>
-    <maven>2.2.1</maven>
-  </prerequisites>
-
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/support-core-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/support-core-plugin.git</developerConnection>
@@ -72,11 +68,8 @@
   </scm>
 
   <properties>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <findbugs-maven-plugin.version>3.0.3</findbugs-maven-plugin.version>
-    <findbugs.failOnError>true</findbugs.failOnError>
+    <jenkins.version>1.580.1</jenkins.version>
+    <java.level>6</java.level>
   </properties>
 
   <repositories>
@@ -95,31 +88,9 @@
   <dependencies>
     <!-- regular dependencies -->
     <dependency>
-      <groupId>net.jcip</groupId>
-      <artifactId>jcip-annotations</artifactId>
-      <version>1.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
-      <version>3.0.0</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>1.3.9</version>
-    </dependency>
-    <!-- regular dependencies -->
-    <dependency>
       <groupId>net.sf.uadetector</groupId>
       <artifactId>uadetector-resources</artifactId>
       <version>2013.09</version>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.mojo</groupId>
-      <artifactId>animal-sniffer-annotations</artifactId>
-      <version>1.9</version>
     </dependency>
     <!-- plugin dependencies -->
     <dependency>
@@ -127,73 +98,6 @@
       <artifactId>metrics</artifactId>
       <version>3.0.0</version>
     </dependency>
-    <!-- jenkins dependencies -->
-    <!-- test dependencies -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.11</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <version>1.3.1</version>
-          <executions>
-            <execution>
-              <id>enforce-maven</id>
-              <goals>
-                <goal>enforce</goal>
-              </goals>
-              <configuration>
-                <rules>
-                  <requireMavenVersion>
-                    <version>(,2.1.0),(2.1.0,2.2.0),(2.2.0,)</version>
-                    <message>Maven 2.1.0 and 2.2.0 produce incorrect GPG signatures and checksums respectively.
-                    </message>
-                  </requireMavenVersion>
-                  <requireMavenVersion>
-                    <version>(,3.0),[3.0.4,)</version>
-                    <message>Maven 3.0 through 3.0.3 inclusive do not pass correct settings.xml to Maven Release
-                      Plugin.
-                    </message>
-                  </requireMavenVersion>
-                </rules>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-    <plugins>
-      <plugin>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>2.5</version>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>${findbugs-maven-plugin.version}</version>
-        <configuration>
-          <excludeFilterFile>src/findbugs/excludesFilter.xml</excludeFilterFile>
-          <failOnError>${findbugs.failOnError}</failOnError>
-          <xmlOutput>true</xmlOutput>
-        </configuration>
-        <executions>
-          <execution>
-            <id>run-findbugs</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 
 </project>

--- a/src/main/java/com/cloudbees/jenkins/support/DefaultSupportMetricsFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/DefaultSupportMetricsFilter.java
@@ -46,7 +46,7 @@ public class DefaultSupportMetricsFilter extends SupportMetricsFilter {
     /**
      * Creates a new instance of the filter.
      *
-     * @param registry
+     * @param registry Metric registry to use.
      */
     public DefaultSupportMetricsFilter(MetricRegistry registry) {
         super(registry, createMeterNamesByStatusCode(), NAME_PREFIX + "other");

--- a/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
@@ -27,6 +27,7 @@ package com.cloudbees.jenkins.support;
 import com.cloudbees.jenkins.support.api.Component;
 import com.cloudbees.jenkins.support.api.SupportProvider;
 
+import com.cloudbees.jenkins.support.util.Helper;
 import hudson.Extension;
 import hudson.model.RootAction;
 import hudson.security.ACL;
@@ -113,7 +114,7 @@ public class SupportAction implements RootAction {
     }
 
     public void doDownload(StaplerRequest req, StaplerResponse rsp) throws ServletException, IOException {
-        final Jenkins instance = Jenkins.getInstance();
+        final Jenkins instance = Helper.getActiveInstance();
         instance.getAuthorizationStrategy().getACL(instance).checkPermission(CREATE_BUNDLE);
 
         if (!"POST".equals(req.getMethod())) {

--- a/src/main/java/com/cloudbees/jenkins/support/SupportCommand.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportCommand.java
@@ -34,6 +34,7 @@ import hudson.security.ACL;
 import jenkins.model.Jenkins;
 import org.acegisecurity.context.SecurityContext;
 import org.acegisecurity.context.SecurityContextHolder;
+import org.jenkinsci.remoting.RoleChecker;
 import org.kohsuke.args4j.Argument;
 
 import java.io.File;
@@ -109,6 +110,12 @@ public class SupportCommand extends CLICommand {
             File f = File.createTempFile(filename, ".zip");
             System.err.println("Creating: " + f);
             return new RemoteOutputStream(new FileOutputStream(f));
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public void checkRoles(RoleChecker checker) throws SecurityException {
+            // TODO: do we have to verify some role?
         }
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/SupportMetricsFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportMetricsFilter.java
@@ -58,6 +58,7 @@ public class SupportMetricsFilter implements Filter {
     /**
      * Creates a new instance of the filter.
      *
+     * @param registry               Metric registry to use.
      * @param meterNamesByStatusCode A map, keyed by status code, of meter names that we are
      *                               interested in.
      * @param otherMetricName        The name used for the catch-all meter.

--- a/src/main/java/com/cloudbees/jenkins/support/api/CommandOutputContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/CommandOutputContent.java
@@ -6,6 +6,7 @@ import hudson.remoting.Callable;
 import hudson.remoting.VirtualChannel;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.IOUtils;
+import org.jenkinsci.remoting.RoleChecker;
 
 import java.io.*;
 import java.util.WeakHashMap;
@@ -43,6 +44,12 @@ public class CommandOutputContent extends StringContent {
             }
             pw.flush();
             return bos.toString();
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public void checkRoles(RoleChecker checker) throws SecurityException {
+            // TODO: do we have to verify some role?
         }
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/api/Component.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/Component.java
@@ -24,6 +24,7 @@
 
 package com.cloudbees.jenkins.support.api;
 
+import com.cloudbees.jenkins.support.util.Helper;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.security.ACL;
 import hudson.security.Permission;
@@ -85,7 +86,7 @@ public abstract class Component extends ExtensionPoint {
      * @return {@code true} if the current authentication can include this component in a bundle.
      */
     public boolean isEnabled() {
-        ACL acl = Jenkins.getInstance().getAuthorizationStrategy().getRootACL();
+        ACL acl = Helper.getActiveInstance().getAuthorizationStrategy().getRootACL();
         if (acl != null) {
             Authentication authentication = Jenkins.getAuthentication();
             assert authentication != null;
@@ -105,7 +106,11 @@ public abstract class Component extends ExtensionPoint {
     @NonNull
     public abstract String getDisplayName();
 
-    /** By default, the {@link Class#getSimpleName} of the component implementation. */
+    /**
+     * Returns the component id.
+     *
+     * @return by default, the {@link Class#getSimpleName} of the component implementation.
+     */
     @NonNull public String getId() {
         return getClass().getSimpleName();
     }

--- a/src/main/java/com/cloudbees/jenkins/support/api/SupportContext.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/SupportContext.java
@@ -35,13 +35,19 @@ import com.codahale.metrics.health.HealthCheckRegistry;
  */
 public interface SupportContext {
     /**
-     * @deprecated use {@link com.codahale.metrics.jenkins.Metrics#metricRegistry()}
+     * Returns the {@link MetricRegistry} for the current Jenkins.
+     *
+     * @return the {@link MetricRegistry} for the current Jenkins.
+     * @deprecated use {@link jenkins.metrics.api.Metrics#metricRegistry()}
      */
     @Deprecated
     MetricRegistry getMetricsRegistry();
 
     /**
-     * @deprecated use {@link com.codahale.metrics.jenkins.Metrics#healthCheckRegistry()}
+     * Returns the {@link HealthCheckRegistry} for the current.
+     *
+     * @return the {@link HealthCheckRegistry} for the current.
+     * @deprecated use {@link jenkins.metrics.api.Metrics#healthCheckRegistry()}
      */
     @Deprecated
     HealthCheckRegistry getHealthCheckRegistry();

--- a/src/main/java/com/cloudbees/jenkins/support/api/TruncatedContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/TruncatedContent.java
@@ -59,7 +59,7 @@ public abstract class TruncatedContent extends Content {
    * {$Content} that will be printed to a specific {$PrintWriter}.
    *
    * @param out PrintWriter to print to
-   * @throws IOException
+   * @throws IOException if and error occurs while performing the operation.
    */
   protected abstract void printTo(PrintWriter out) throws IOException;
 

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
@@ -532,7 +532,8 @@ public class AboutJenkins extends Component {
             } else {
                 out.println("  * Mode:    WAR");
             }
-            out.println("  * Url:     " + JenkinsLocationConfiguration.get().getUrl());
+            final JenkinsLocationConfiguration jlc = JenkinsLocationConfiguration.get();
+            out.println("  * Url:     " + (jlc != null ? jlc.getUrl() : "No JenkinsLocationConfiguration available"));
             try {
                 final ServletContext servletContext = Stapler.getCurrent().getServletContext();
                 out.println("  * Servlet container");

--- a/src/main/java/com/cloudbees/jenkins/support/impl/BuildQueue.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/BuildQueue.java
@@ -26,6 +26,7 @@ package com.cloudbees.jenkins.support.impl;
 import com.cloudbees.jenkins.support.api.Component;
 import com.cloudbees.jenkins.support.api.Container;
 import com.cloudbees.jenkins.support.api.Content;
+import com.cloudbees.jenkins.support.util.Helper;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Functions;
@@ -70,7 +71,7 @@ public class BuildQueue extends Component {
         public void writeTo(OutputStream os) throws IOException {
           PrintWriter out = new PrintWriter(new BufferedWriter(new OutputStreamWriter(os, "utf-8")));
           try {
-            List<Queue.Item> items = Jenkins.getInstance().getQueue().getApproximateItemsQuickly();
+            List<Queue.Item> items = Helper.getActiveInstance().getQueue().getApproximateItemsQuickly();
             out.println("Current build queue has " +  items.size() + " item(s).");
             out.println("---------------");
 

--- a/src/main/java/com/cloudbees/jenkins/support/impl/EnvironmentVariables.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/EnvironmentVariables.java
@@ -4,6 +4,7 @@ import com.cloudbees.jenkins.support.AsyncResultCache;
 import com.cloudbees.jenkins.support.api.Component;
 import com.cloudbees.jenkins.support.api.Container;
 import com.cloudbees.jenkins.support.api.PrintedContent;
+import com.cloudbees.jenkins.support.util.Helper;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Node;
@@ -11,6 +12,7 @@ import hudson.remoting.Callable;
 import hudson.remoting.VirtualChannel;
 import hudson.security.Permission;
 import jenkins.model.Jenkins;
+import org.jenkinsci.remoting.RoleChecker;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -57,7 +59,7 @@ public class EnvironmentVariables extends Component {
                     protected void printTo(PrintWriter out) throws IOException {
                         try {
                             for (Map.Entry<String, String> entry : getEnvironmentVariables(
-                                    Jenkins.getInstance()).entrySet()) {
+                                    Helper.getActiveInstance()).entrySet()) {
                                 out.println(entry.getKey() + "=" + entry.getValue());
                             }
                         } catch (IOException e) {
@@ -66,7 +68,7 @@ public class EnvironmentVariables extends Component {
                     }
                 }
         );
-        for (final Node node : Jenkins.getInstance().getNodes()) {
+        for (final Node node : Helper.getActiveInstance().getNodes()) {
             result.add(
                     new PrintedContent("nodes/slave/" + node.getNodeName() + "/environment.txt") {
                         @Override
@@ -108,6 +110,12 @@ public class EnvironmentVariables extends Component {
                             return System.getenv();
                         }
                     }));
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public void checkRoles(RoleChecker checker) throws SecurityException {
+            // TODO: do we have to verify some role?
         }
 
         private static final long serialVersionUID = 1L;

--- a/src/main/java/com/cloudbees/jenkins/support/impl/JVMProcessSystemMetricsContents.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/JVMProcessSystemMetricsContents.java
@@ -2,6 +2,7 @@ package com.cloudbees.jenkins.support.impl;
 
 import com.cloudbees.jenkins.support.AsyncResultCache;
 import com.cloudbees.jenkins.support.api.*;
+import com.cloudbees.jenkins.support.util.Helper;
 import com.cloudbees.jenkins.support.util.SystemPlatform;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
@@ -52,7 +53,7 @@ public class JVMProcessSystemMetricsContents extends Component {
 
     @Override
     public void addContents(@NonNull Container container) {
-        Jenkins j = Jenkins.getInstance();
+        Jenkins j = Helper.getActiveInstance();
         addUnixContents(container, j);
 
         for (Node node : j.getNodes()) {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/LoadStats.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/LoadStats.java
@@ -28,6 +28,7 @@ import com.cloudbees.jenkins.support.api.Component;
 import com.cloudbees.jenkins.support.api.Container;
 import com.cloudbees.jenkins.support.api.Content;
 import com.cloudbees.jenkins.support.api.PrintedContent;
+import com.cloudbees.jenkins.support.util.Helper;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Label;
@@ -90,7 +91,7 @@ public class LoadStats extends Component {
      */
     @Override
     public void addContents(@NonNull Container container) {
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Helper.getActiveInstance();
         add(container, "no-label", jenkins.unlabeledLoad);
         add(container, "overall", jenkins.overallLoad);
         for (Label l : jenkins.getLabels()) {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/LogRecordContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/LogRecordContent.java
@@ -24,7 +24,9 @@ public abstract class LogRecordContent extends PrintedContent {
     /**
      * Iterates {@link LogRecord}s to be printed as this content.
      *
+     * @return the {@link LogRecord}s to be printed as this content.
      * @see Lists#reverse(List)
+     * @throws IOException if an error occurs while performing the operation.
      */
     public abstract Iterable<LogRecord> getLogRecords() throws IOException;
 

--- a/src/main/java/com/cloudbees/jenkins/support/impl/Metrics.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/Metrics.java
@@ -4,6 +4,7 @@ import com.cloudbees.jenkins.support.AsyncResultCache;
 import com.cloudbees.jenkins.support.api.Component;
 import com.cloudbees.jenkins.support.api.Container;
 import com.cloudbees.jenkins.support.api.Content;
+import com.cloudbees.jenkins.support.util.Helper;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Node;
@@ -12,6 +13,7 @@ import hudson.remoting.VirtualChannel;
 import hudson.security.Permission;
 import hudson.util.IOException2;
 import jenkins.model.Jenkins;
+import org.jenkinsci.remoting.RoleChecker;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -47,7 +49,7 @@ public class Metrics extends Component {
     @Override
     public void addContents(@NonNull Container result) {
         result.add(new MetricsContent("nodes/master/metrics.json", jenkins.metrics.api.Metrics.metricRegistry()));
-        for (final Node node : Jenkins.getInstance().getNodes()) {
+        for (final Node node : Helper.getActiveInstance().getNodes()) {
             result.add(new RemoteMetricsContent("nodes/slave/" + node.getNodeName() + "/metrics.json", node,
                     metricsCache));
         }
@@ -82,6 +84,12 @@ public class Metrics extends Component {
                 throw new RuntimeException(e);
             }
             return bos.toByteArray();
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public void checkRoles(RoleChecker checker) throws SecurityException {
+            // TODO: do we have to verify some role?
         }
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/impl/NetworkInterfaces.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/NetworkInterfaces.java
@@ -27,6 +27,7 @@ import com.cloudbees.jenkins.support.AsyncResultCache;
 import com.cloudbees.jenkins.support.api.Component;
 import com.cloudbees.jenkins.support.api.Container;
 import com.cloudbees.jenkins.support.api.Content;
+import com.cloudbees.jenkins.support.util.Helper;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Functions;
@@ -38,6 +39,7 @@ import hudson.util.HexBinaryConverter;
 import jenkins.model.Jenkins;
 import org.apache.commons.codec.binary.Hex;
 import org.codehaus.groovy.runtime.StackTraceUtils;
+import org.jenkinsci.remoting.RoleChecker;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -81,7 +83,7 @@ public class NetworkInterfaces extends Component {
                 }
         );
 
-        for (final Node node : Jenkins.getInstance().getNodes()) {
+        for (final Node node : Helper.getActiveInstance().getNodes()) {
             result.add(
                     new Content("nodes/slave/" + node.getNodeName() + "/networkInterface.md") {
                         @Override
@@ -141,6 +143,12 @@ public class NetworkInterfaces extends Component {
             }
 
             return bos.toString();
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public void checkRoles(RoleChecker checker) throws SecurityException {
+            // TODO: do we have to verify some role?
         }
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/RootCAs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/RootCAs.java
@@ -27,6 +27,7 @@ import com.cloudbees.jenkins.support.AsyncResultCache;
 import com.cloudbees.jenkins.support.api.Component;
 import com.cloudbees.jenkins.support.api.Container;
 import com.cloudbees.jenkins.support.api.Content;
+import com.cloudbees.jenkins.support.util.Helper;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Functions;
@@ -40,6 +41,7 @@ import hudson.security.Permission;
 import hudson.slaves.SlaveComputer;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.exception.ExceptionUtils;
+import org.jenkinsci.remoting.RoleChecker;
 
 import java.io.*;
 import java.security.KeyStore;
@@ -76,7 +78,7 @@ public class RootCAs extends Component {
 
   @Override
   public void addContents(@NonNull Container container) {
-    Jenkins j = Jenkins.getInstance();
+    Jenkins j = Helper.getActiveInstance();
     addContents(container, j);
     for (Node node : j.getNodes()) {
       addContents(container, node);
@@ -128,6 +130,12 @@ public class RootCAs extends Component {
       StringWriter writer = new StringWriter();
       getRootCAList(writer);
       return writer.toString();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void checkRoles(RoleChecker checker) throws SecurityException {
+      // TODO: do we have to verify some role?
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SmartLogFetcher.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SmartLogFetcher.java
@@ -11,6 +11,7 @@ import hudson.remoting.VirtualChannel;
 import hudson.util.IOUtils;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.remoting.RoleChecker;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -271,6 +272,12 @@ class SmartLogFetcher {
             return result;
         }
 
+        /** {@inheritDoc} */
+        @Override
+        public void checkRoles(RoleChecker checker) throws SecurityException {
+            // TODO: do we have to verify some role?
+        }
+
     }
 
     /**
@@ -342,6 +349,12 @@ class SmartLogFetcher {
                         }
                     }
                 }
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public void checkRoles(RoleChecker checker) throws SecurityException {
+                // TODO: do we have to verify some role?
             }
         });
 

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SystemConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SystemConfiguration.java
@@ -26,6 +26,7 @@ package com.cloudbees.jenkins.support.impl;
 
 import com.cloudbees.jenkins.support.AsyncResultCache;
 import com.cloudbees.jenkins.support.api.*;
+import com.cloudbees.jenkins.support.util.Helper;
 import com.cloudbees.jenkins.support.util.SystemPlatform;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
@@ -36,6 +37,7 @@ import hudson.remoting.Callable;
 import hudson.security.Permission;
 import hudson.slaves.SlaveComputer;
 import jenkins.model.Jenkins;
+import org.jenkinsci.remoting.RoleChecker;
 
 import java.io.*;
 import java.util.*;
@@ -83,7 +85,7 @@ public class SystemConfiguration extends Component {
 
     @Override
     public void addContents(@NonNull Container container) {
-        Jenkins j = Jenkins.getInstance();
+        Jenkins j = Helper.getActiveInstance();
         addUnixContents(container, j);
 
         for (Node node : j.getNodes()) {
@@ -161,6 +163,12 @@ public class SystemConfiguration extends Component {
                 }
             }
             return sb.toString();
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public void checkRoles(RoleChecker checker) throws SecurityException {
+            // TODO: do we have to verify some role?
         }
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SystemProperties.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SystemProperties.java
@@ -4,6 +4,7 @@ import com.cloudbees.jenkins.support.AsyncResultCache;
 import com.cloudbees.jenkins.support.api.Component;
 import com.cloudbees.jenkins.support.api.Container;
 import com.cloudbees.jenkins.support.api.Content;
+import com.cloudbees.jenkins.support.util.Helper;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Node;
@@ -12,6 +13,7 @@ import hudson.remoting.VirtualChannel;
 import hudson.security.Permission;
 import hudson.util.RemotingDiagnostics;
 import jenkins.model.Jenkins;
+import org.jenkinsci.remoting.RoleChecker;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -61,7 +63,7 @@ public class SystemProperties extends Component {
                         try {
                             Properties properties = new SortedProperties();
                             properties.putAll(RemotingDiagnostics
-                                    .getSystemProperties(Jenkins.getInstance().getChannel()));
+                                    .getSystemProperties(Helper.getActiveInstance().getChannel()));
                             properties.store(os, null);
                         } catch (IOException e) {
                             logger.log(Level.WARNING, "Could not record system properties for master", e);
@@ -71,7 +73,7 @@ public class SystemProperties extends Component {
                     }
                 }
         );
-        for (final Node node : Jenkins.getInstance().getNodes()) {
+        for (final Node node : Helper.getActiveInstance().getNodes()) {
             result.add(
                     new Content("nodes/slave/" + node.getNodeName() + "/system.properties") {
                         @Override
@@ -109,6 +111,12 @@ public class SystemProperties extends Component {
                     return System.getProperties();
                 }
             }));
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public void checkRoles(RoleChecker checker) throws SecurityException {
+            // TODO: do we have to verify some role?
         }
 
         private static final long serialVersionUID = 1L;

--- a/src/main/java/com/cloudbees/jenkins/support/impl/ThreadDumps.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/ThreadDumps.java
@@ -5,6 +5,7 @@ import com.cloudbees.jenkins.support.api.Component;
 import com.cloudbees.jenkins.support.api.Container;
 import com.cloudbees.jenkins.support.api.Content;
 import com.cloudbees.jenkins.support.api.StringContent;
+import com.cloudbees.jenkins.support.util.Helper;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Functions;
@@ -36,6 +37,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
+import org.jenkinsci.remoting.RoleChecker;
 
 /**
  * Thread dumps from the nodes.
@@ -81,7 +83,7 @@ public class ThreadDumps extends Component {
                     }
                 }
         );
-        for (final Node node : Jenkins.getInstance().getNodes()) {
+        for (final Node node : Helper.getActiveInstance().getNodes()) {
             // let's start collecting thread dumps now... this gives us until the end of the bundle to finish
             final Future<String> threadDump;
             try {
@@ -186,13 +188,20 @@ public class ThreadDumps extends Component {
             }
         }
 
+        /** {@inheritDoc} */
+        @Override
+        public void checkRoles(RoleChecker checker) throws SecurityException {
+            // TODO: do we have to verify some role?
+        }
+
         private static final long serialVersionUID = 1L;
     }
 
     /**
      * Dumps all of the threads' current information to an output stream.
      *
-     * @param out an output stream
+     * @param out an output stream.
+     * @throws UnsupportedEncodingException if the utf-8 encoding is not supported.
      */
     public static void threadDump(OutputStream out) throws UnsupportedEncodingException {
         try {
@@ -206,7 +215,8 @@ public class ThreadDumps extends Component {
     /**
      * Dumps all of the threads' current information to an output stream.
      *
-     * @param out an output stream
+     * @param out an output stream.
+     * @throws UnsupportedEncodingException if the utf-8 encoding is not supported.
      */
     @IgnoreJRERequirement
     @edu.umd.cs.findbugs.annotations.SuppressWarnings(
@@ -338,7 +348,8 @@ public class ThreadDumps extends Component {
     /**
      * Dumps all of the threads' current information to an output stream.
      *
-     * @param out an output stream
+     * @param out an output stream.
+     * @throws UnsupportedEncodingException if the utf-8 encoding is not supported.
      */
     @edu.umd.cs.findbugs.annotations.SuppressWarnings(
             value = {"VA_FORMAT_STRING_USES_NEWLINE"},

--- a/src/main/java/com/cloudbees/jenkins/support/impl/WinswLogfileFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/WinswLogfileFilter.java
@@ -7,7 +7,7 @@ import java.io.Serializable;
 /**
  * Matches log files from winsw.
  *
- * @see https://github.com/kohsuke/winsw/blob/master/LogAppenders.cs
+ * @see <a href="https://github.com/kohsuke/winsw/blob/master/LogAppenders.cs">LogAppenders.cs</a>
  * @author Kohsuke Kawaguchi
  */
 class WinswLogfileFilter implements FilenameFilter, Serializable {

--- a/src/main/java/com/cloudbees/jenkins/support/slowrequest/SlowRequestChecker.java
+++ b/src/main/java/com/cloudbees/jenkins/support/slowrequest/SlowRequestChecker.java
@@ -2,6 +2,7 @@ package com.cloudbees.jenkins.support.slowrequest;
 
 import com.cloudbees.jenkins.support.timer.FileListCap;
 import com.cloudbees.jenkins.support.timer.FileListCapComponent;
+import com.cloudbees.jenkins.support.util.Helper;
 import com.google.inject.Inject;
 import hudson.Extension;
 import hudson.model.PeriodicWork;
@@ -54,7 +55,7 @@ public class SlowRequestChecker extends PeriodicWork {
     @Inject
     Jenkins jenkins;
 
-    final FileListCap logs = new FileListCap(new File(Jenkins.getInstance().getRootDir(),"slow-requests"), 50);
+    final FileListCap logs = new FileListCap(new File(Helper.getActiveInstance().getRootDir(),"slow-requests"), 50);
 
     final SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd-HHmmss.SSS");
 

--- a/src/main/java/com/cloudbees/jenkins/support/slowrequest/SlowRequestFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/slowrequest/SlowRequestFilter.java
@@ -1,5 +1,6 @@
 package com.cloudbees.jenkins.support.slowrequest;
 
+import com.cloudbees.jenkins.support.util.Helper;
 import com.google.inject.Injector;
 import hudson.Extension;
 import hudson.init.Initializer;
@@ -50,7 +51,7 @@ public class SlowRequestFilter implements Filter {
 
     @Initializer
     public static void init() throws ServletException {
-        Injector inj = Jenkins.getInstance().getInjector();
+        Injector inj = Helper.getActiveInstance().getInjector();
         if (inj == null) {
             return;
         }

--- a/src/main/java/com/cloudbees/jenkins/support/timer/DeadlockTrackChecker.java
+++ b/src/main/java/com/cloudbees/jenkins/support/timer/DeadlockTrackChecker.java
@@ -1,6 +1,7 @@
 package com.cloudbees.jenkins.support.timer;
 
 import com.cloudbees.jenkins.support.impl.ThreadDumps;
+import com.cloudbees.jenkins.support.util.Helper;
 import hudson.Extension;
 import hudson.model.PeriodicWork;
 import jenkins.model.Jenkins;
@@ -21,7 +22,7 @@ import java.util.concurrent.TimeUnit;
 public class DeadlockTrackChecker extends PeriodicWork {
 
     final SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd-HHmmss");
-    final FileListCap logs = new FileListCap(new File(Jenkins.getInstance().getRootDir(),"deadlocks"), 50);
+    final FileListCap logs = new FileListCap(new File(Helper.getActiveInstance().getRootDir(),"deadlocks"), 50);
 
     @Override
     public long getRecurrencePeriod() {

--- a/src/main/java/com/cloudbees/jenkins/support/timer/FileListCap.java
+++ b/src/main/java/com/cloudbees/jenkins/support/timer/FileListCap.java
@@ -76,7 +76,10 @@ public class FileListCap {
     }
 
     /**
-     * Creates a new file object in this directory without changing the
+     * Creates a new file object in this directory without changing the relative path.
+     *
+     * @param path Relative path.
+     * @return the created file object.
      */
     public File file(String path) {
         return new File(folder,path);

--- a/src/main/java/com/cloudbees/jenkins/support/util/Helper.java
+++ b/src/main/java/com/cloudbees/jenkins/support/util/Helper.java
@@ -1,0 +1,28 @@
+package com.cloudbees.jenkins.support.util;
+
+import jenkins.model.Jenkins;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Simple helper so we don't have to check {@code Jenkins.getInstance() != null} everywhere.
+ * TODO: replace with Jenkins.getActiveInstance() when on core {@literal >=} 1.609
+ */
+@Restricted(NoExternalUse.class)
+public final class Helper {
+    /** Not instantiable. */
+    private Helper() {
+        throw new AssertionError("Not instantiable");
+    }
+
+    @Nonnull
+    public static Jenkins getActiveInstance() {
+        Jenkins instance = Jenkins.getInstance();
+        if (instance == null) {
+            throw new IllegalStateException("Jenkins has not been started, or was already shut down");
+        }
+        return instance;
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/support/util/SystemPlatform.java
+++ b/src/main/java/com/cloudbees/jenkins/support/util/SystemPlatform.java
@@ -1,6 +1,7 @@
 package com.cloudbees.jenkins.support.util;
 
 import hudson.remoting.Callable;
+import org.jenkinsci.remoting.RoleChecker;
 
 import java.util.Locale;
 
@@ -29,6 +30,12 @@ public enum SystemPlatform {
         private static final long serialVersionUID = 1L;
         public SystemPlatform call() {
             return current();
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public void checkRoles(RoleChecker checker) throws SecurityException {
+            // TODO: do we have to verify some role?
         }
     }
 }

--- a/src/main/resources/com/cloudbees/jenkins/support/SupportAction/action.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/support/SupportAction/action.jelly
@@ -21,6 +21,7 @@
  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  ~ THE SOFTWARE.
  -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
   <l:task icon="${h.getIconFilePath(action)}" title="${action.displayName}"
           href="${h.getActionUrl(it.url,action)}"

--- a/src/main/resources/com/cloudbees/jenkins/support/SupportPlugin/GlobalConfigurationImpl/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/support/SupportPlugin/GlobalConfigurationImpl/config.jelly
@@ -21,6 +21,7 @@
  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  ~ THE SOFTWARE.
  -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"
          xmlns:f="/lib/form">
   <j:if test="${instance.selectable}">

--- a/src/main/resources/com/cloudbees/jenkins/support/api/SupportProvider/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/support/api/SupportProvider/config.jelly
@@ -21,4 +21,5 @@
  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  ~ THE SOFTWARE.
  -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"/>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -21,6 +21,7 @@
  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  ~ THE SOFTWARE.
  -->
+<?jelly escape-by-default='true'?>
 <div>
   This support plugin allows generation of a support request bundle that contains diagnostic information to
   aid with resolving issues.

--- a/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
@@ -59,7 +59,8 @@ public class SupportActionTest extends Assert {
             HtmlPage p = wc.goTo(root.getUrlName());
 
             HtmlForm form = p.getFormByName("bundle-contents");
-            Page zip = form.submit((HtmlButton) form.getHtmlElementsByTagName("button").get(0));
+            HtmlButton submit = (HtmlButton) form.getHtmlElementsByTagName("button").get(0);
+            Page zip = submit.click();
             File zipFile = File.createTempFile("test", "zip");
             IOUtils.copy(zip.getWebResponse().getContentAsStream(), zipFile);
 


### PR DESCRIPTION
See [JENKINS-33668](https://issues.jenkins-ci.org/browse/JENKINS-33380) Adapt to new parent point and upgrade baseline to 1.580.1

* [x] Parent POM 2.3
* [x] Baseline 1.580.1
* [x] Adapt to new remoting interfaces.
* [x] Fix javadocs when building with Java 8.
* [x] Jelly XSS PI
* [x] Adapt to JTH 2.1
* [x] Additional findbugs fixes needed because of the baseline change.
* [x] Check build against 1.642.2 (PCT scenario).

