### PR TITLE
[JENKINS-32622] Switch to a ThreadLocal DateFormatter

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportLogFormatter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportLogFormatter.java
@@ -24,12 +24,20 @@
 
 package com.cloudbees.jenkins.support;
 
+/***********************************************
+ * DO NOT INCLUDE ANY NON JDK CLASSES IN HERE.
+ * IT CAN DEADLOCK REMOTING - SEE JENKINS-32622
+ ***********************************************/
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.logging.Formatter;
 import java.util.logging.LogRecord;
+/***********************************************
+ * DO NOT INCLUDE ANY NON JDK CLASSES IN HERE.
+ * IT CAN DEADLOCK REMOTING - SEE JENKINS-32622
+ ***********************************************/
 
 /**
  * Format log files in a nicer format that is easier to read and search.

--- a/src/main/java/com/cloudbees/jenkins/support/SupportLogFormatter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportLogFormatter.java
@@ -24,11 +24,9 @@
 
 package com.cloudbees.jenkins.support;
 
-import org.apache.commons.lang.time.FastDateFormat;
-
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.text.MessageFormat;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.logging.Formatter;
 import java.util.logging.LogRecord;
@@ -39,7 +37,14 @@ import java.util.logging.LogRecord;
  * @author Stephen Connolly
  */
 public class SupportLogFormatter extends Formatter {
-    FastDateFormat fdf = FastDateFormat.getInstance("yyyy-MM-dd HH:mm:ss.SSSZ");
+    
+    private final static ThreadLocal<SimpleDateFormat> threadLocalDateFormat = new ThreadLocal() {
+        @Override
+        protected SimpleDateFormat initialValue() {
+            return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSZ");
+        }
+    };
+
     private final Object[] args = new Object[6];
 
     @Override
@@ -49,7 +54,7 @@ public class SupportLogFormatter extends Formatter {
     )
     public String format(LogRecord record) {
         StringBuilder builder = new StringBuilder();
-        builder.append(fdf.format(new Date(record.getMillis())));
+        builder.append(threadLocalDateFormat.get().format(new Date(record.getMillis())));
         builder.append(" [id=").append(record.getThreadID()).append("]");
 
         builder.append("\t").append(record.getLevel().getName()).append("\t");


### PR DESCRIPTION
Attempt to avoid a deadlock observed in remoting by not causing any remote
classes to be loaded when we are logging.

@reviewbybees 
[JENKINS-32622](https://issues.jenkins-ci.org/browse/JENKINS-32622)