### PR TITLE
Separate slave logs, and master logs.

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/JenkinsLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/JenkinsLogs.java
@@ -60,9 +60,9 @@ import org.jenkinsci.remoting.RoleChecker;
 import org.apache.commons.io.FileUtils;
 
 /**
- * Log files from the different nodes
+ * Log files from the master node only.
  */
-@Extension(ordinal = 100.0) // put this first as largest content and can let the slower ones complete
+@Extension
 public class JenkinsLogs extends Component {
 
     private static final Logger LOGGER = Logger.getLogger(JenkinsLogs.class.getName());
@@ -79,7 +79,7 @@ public class JenkinsLogs extends Component {
     @NonNull
     @Override
     public String getDisplayName() {
-        return "Log Recorders";
+        return "Master Log Recorders";
     }
 
     @Override
@@ -93,260 +93,6 @@ public class JenkinsLogs extends Component {
         addMasterJulLogRecords(result);
         addOtherMasterLogs(result);
         addLogRecorders(result);
-        addSlaveLaunchLog(result);
-
-        SmartLogFetcher logFetcher = new SmartLogFetcher("cache", new LogFilenameFilter()); // id is awkward because of backward compatibility
-        SmartLogFetcher winswLogFetcher = new SmartLogFetcher("winsw", new WinswLogfileFilter());
-        final boolean needHack = SlaveLogFetcher.isRequired();
-
-        // expensive remote computation are pooled together and executed later concurrently across all the slaves
-        List<java.util.concurrent.Callable<List<FileContent>>> tasks = Lists.newArrayList();
-
-        for (final Node node : Helper.getActiveInstance().getNodes()) {
-            if (node.toComputer() instanceof SlaveComputer) {
-                result.add(
-                        new PrintedContent("nodes/slave/" + node.getNodeName() + "/jenkins.log") {
-                            @Override
-                            protected void printTo(PrintWriter out) throws IOException {
-                                Computer computer = node.toComputer();
-                                if (computer == null) {
-                                    out.println("N/A");
-                                } else {
-                                    try {
-                                        List<LogRecord> records = null;
-                                        if (needHack) {
-                                            VirtualChannel channel = computer.getChannel();
-                                            if (channel != null) {
-                                                Future<List<LogRecord>> future = SlaveLogFetcher.getLogRecords(channel);
-                                                records = future.get(REMOTE_OPERATION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-                                            }
-                                        }
-
-                                        if (records == null) {
-                                            records = computer.getLogRecords();
-                                        }
-
-                                        for (ListIterator<LogRecord> iterator = records.listIterator(records.size());
-                                             iterator.hasPrevious(); ) {
-                                            LogRecord logRecord = iterator.previous();
-                                            out.print(LOG_FORMATTER.format(logRecord));
-                                        }
-                                    } catch (Throwable e) {
-                                        out.println();
-                                        e.printStackTrace(out);
-                                    }
-                                }
-                                out.flush();
-
-                            }
-                        }
-                );
-            }
-            addSlaveJulLogRecords(result, tasks, node, logFetcher);
-            addWinsStdoutStderrLog(tasks, node, winswLogFetcher);
-        }
-
-        // execute all the expensive computations in parallel to speed up the time
-        if (!tasks.isEmpty()) {
-            ExecutorService service = Executors.newFixedThreadPool(
-                    Math.max(1, Math.min(Runtime.getRuntime().availableProcessors() * 2, tasks.size())),
-                    new ExceptionCatchingThreadFactory(new DaemonThreadFactory())
-            );
-            try {
-                long expiresNanoTime =
-                        System.nanoTime() + TimeUnit.SECONDS.toNanos(SupportPlugin.REMOTE_OPERATION_CACHE_TIMEOUT_SEC);
-                for (java.util.concurrent.Future<List<FileContent>> r : service
-                        .invokeAll(tasks, SupportPlugin.REMOTE_OPERATION_CACHE_TIMEOUT_SEC,
-                                TimeUnit.SECONDS)) {
-                    try {
-                        for (FileContent c : r
-                                .get(Math.max(1, expiresNanoTime - System.nanoTime()), TimeUnit.NANOSECONDS)) {
-                            result.add(c);
-                        }
-                    } catch (ExecutionException e) {
-                        LOGGER.log(Level.WARNING, "Could not retrieve some of the remote node extra logs", e);
-                    } catch (TimeoutException e) {
-                        LOGGER.log(Level.WARNING, "Could not retrieve some of the remote node extra logs", e);
-                        r.cancel(false);
-                    }
-                }
-            } catch (InterruptedException e) {
-                LOGGER.log(Level.WARNING, "Could not retrieve some of the remote node extra logs", e);
-            } finally {
-                service.shutdown();
-            }
-        }
-    }
-
-    /**
-     * Adds slave launch logs, which captures the current and past running connections to the slave.
-     *
-     * <p>
-     * In the presence of {@link Cloud} plugins like EC2, we want to find past slaves, not just current ones.
-     * So we don't try to loop through {@link Node} here but just try to look at the file systems to find them
-     * all.
-     *
-     * <p>
-     * Generally these cloud plugins do not clean up old logs, so if run for a long time, the log directory
-     * will be full of old files that are not very interesting. Use some heuristics to cut off logs
-     * that are old.
-     */
-    private void addSlaveLaunchLog(Container result) {
-        class Slave implements Comparable<Slave> {
-            /**
-             * Launch log directory of the slave: logs/slaves/NAME
-             */
-            File dir;
-            long time;
-
-            Slave(File dir, File lastLog) {
-                this.dir = dir;
-                this.time = lastLog.lastModified();
-            }
-
-            /** Slave name */
-            String getName() { return dir.getName(); }
-
-            /**
-             * Use the primary log file's timestamp to compare newer slaves from older slaves.
-             *
-             * sort in descending order; newer ones first.
-             */
-            public int compareTo(Slave that) {
-                long lhs = this.time;
-                long rhs = that.time;
-                if (lhs<rhs)    return 1;
-                if (lhs>rhs)    return -1;
-                return 0;
-            }
-
-            @Override
-            public boolean equals(Object o) {
-                if (this == o) return true;
-                if (o == null || getClass() != o.getClass()) return false;
-
-                Slave slave = (Slave) o;
-
-                if (time != slave.time) return false;
-
-                return true;
-            }
-
-            @Override
-            public int hashCode() {
-                return (int) (time ^ (time >>> 32));
-            }
-
-            /**
-             * If the file is more than a year old, can't imagine how that'd be of any interest.
-             */
-            public boolean isTooOld() {
-                return time < System.currentTimeMillis()-TimeUnit.DAYS.toMillis(365);
-            }
-        }
-
-        List<Slave> all = new ArrayList<Slave>();
-
-        {// find all the slave launch log files and sort them newer ones first
-
-            File slaveLogsDir = new File(Helper.getActiveInstance().getRootDir(), "logs/slaves");
-            File[] logs = slaveLogsDir.listFiles();
-            if (logs!=null) {
-                for (File dir : logs) {
-                    File lastLog = new File(dir, "slave.log");
-                    if (lastLog.exists()) {
-                        Slave s = new Slave(dir, lastLog);
-                        if (s.isTooOld()) continue;   // we don't care
-                        all.add(s);
-                    }
-                }
-            }
-
-            Collections.sort(all);
-        }
-
-        {// this might be still too many, so try to cap them.
-            int acceptableSize = Math.max(256, Helper.getActiveInstance().getNodes().size() * 5);
-
-            if (all.size() > acceptableSize)
-                all = all.subList(0, acceptableSize);
-        }
-
-        // now add them all
-        for (Slave s : all) {
-            File[] files = s.dir.listFiles(ROTATED_LOGFILE_FILTER);
-            if (files!=null)
-                for (File f : files) {
-                    result.add(new FileContent("nodes/slave/" + s.getName() + "/launchLogs/"+f.getName() , f));
-                }
-        }
-    }
-
-    /**
-     * Captures a "recent" (but still fairly large number of) j.u.l entries written on this slave.
-     *
-     * @see #addMasterJulLogRecords(Container)
-     */
-    private void addSlaveJulLogRecords(Container result, List<java.util.concurrent.Callable<List<FileContent>>> tasks, final Node node, final SmartLogFetcher logFetcher) {
-        final FilePath rootPath = node.getRootPath();
-        if (rootPath != null) {
-            // rotated log files stored on the disk
-            tasks.add(new java.util.concurrent.Callable<List<FileContent>>(){
-                public List<FileContent> call() throws Exception {
-                    List<FileContent> result = new ArrayList<FileContent>();
-                    FilePath supportPath = rootPath.child(SUPPORT_DIRECTORY_NAME);
-                    if (supportPath.isDirectory()) {
-                        final Map<String, File> logFiles = logFetcher.forNode(node).getLogFiles(supportPath);
-                        for (Map.Entry<String, File> entry : logFiles.entrySet()) {
-                            result.add(new FileContent(
-                                            "nodes/slave/" + node.getNodeName() + "/logs/" + entry.getKey(),
-                                            entry.getValue())
-                            );
-                        }
-                    }
-                    return result;
-                }
-            });
-        }
-
-        // this file captures the most recent of those that are still kept around in memory.
-        // this overlaps with Jenkins.logRecords, and also overlaps with what's written in files,
-        // but added nonetheless just in case.
-        //
-        // should be ignorable.
-        result.add(new LogRecordContent("nodes/slave/" + node.getNodeName() + "/logs/all_memory_buffer.log") {
-            @Override
-            public Iterable<LogRecord> getLogRecords() throws IOException {
-                try {
-                    return SupportPlugin.getInstance().getAllLogRecords(node);
-                } catch (InterruptedException e) {
-                    throw (IOException)new InterruptedIOException().initCause(e);
-                }
-            }
-        });
-    }
-
-    /**
-     * Captures stdout/stderr log files produced by winsw.
-     */
-    private void addWinsStdoutStderrLog(List<java.util.concurrent.Callable<List<FileContent>>> tasks, final Node node, final SmartLogFetcher logFetcher) {
-        final FilePath rootPath = node.getRootPath();
-        if (rootPath != null) {
-            // rotated log files stored on the disk
-            tasks.add(new java.util.concurrent.Callable<List<FileContent>>(){
-                public List<FileContent> call() throws Exception {
-                    List<FileContent> result = new ArrayList<FileContent>();
-                    final Map<String, File> logFiles = logFetcher.forNode(node).getLogFiles(rootPath);
-                    for (Map.Entry<String, File> entry : logFiles.entrySet()) {
-                        result.add(new FileContent(
-                                        "nodes/slave/" + node.getNodeName() + "/logs/winsw/" + entry.getKey(),
-                                        entry.getValue(), FileListCapComponent.MAX_FILE_SIZE)
-                        );
-                    }
-                    return result;
-                }
-            });
-        }
     }
 
     /**
@@ -449,71 +195,6 @@ public class JenkinsLogs extends Component {
         }
     }
 
-    private static class SlaveLogFetcher implements Callable<List<LogRecord>, RuntimeException> {
-
-        public static boolean isRequired() {
-            try {
-                SlaveComputer.class.getClassLoader().loadClass(SlaveComputer.class.getName() + "$SlaveLogFetcher");
-                return false;
-            } catch (ClassNotFoundException e) {
-                return true;
-            }
-        }
-
-        public List<LogRecord> call() throws RuntimeException {
-            try {
-                Class<?> aClass =
-                        SlaveComputer.class.getClassLoader().loadClass(SlaveComputer.class.getName() + "$LogHolder");
-                Field logHandler = aClass.getDeclaredField("SLAVE_LOG_HANDLER");
-                boolean accessible = logHandler.isAccessible();
-                try {
-                    if (!accessible) {
-                        logHandler.setAccessible(true);
-                    }
-                    Object instance = logHandler.get(null);
-                    if (instance instanceof RingBufferLogHandler) {
-                        RingBufferLogHandler handler = (RingBufferLogHandler) instance;
-                        return new ArrayList<LogRecord>(handler.getView());
-                    }
-                } finally {
-                    if (!accessible) {
-                        logHandler.setAccessible(accessible);
-                    }
-                }
-                throw new RuntimeException("Could not retrieve logs");
-            } catch (IllegalAccessException e) {
-                throw new RuntimeException(e);
-            } catch (ClassNotFoundException e) {
-                throw new RuntimeException(e);
-            } catch (NoSuchFieldException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        /** {@inheritDoc} */
-        @Override
-        public void checkRoles(RoleChecker checker) throws SecurityException {
-            // TODO: do we have to verify some role?
-        }
-
-        public static Future<List<LogRecord>> getLogRecords(@NonNull VirtualChannel channel) throws IOException {
-            return channel.callAsync(new SlaveLogFetcher());
-        }
-
-        /**
-         * @deprecated Please use getLogRecords(Channel) instead. This method is synchronous which could cause
-         * the channel to block.
-         */
-        @Deprecated
-        public static List<LogRecord> getLogRecords(Computer computer) throws IOException, InterruptedException {
-            VirtualChannel channel = computer.getChannel();
-            if (channel == null) {
-                return Collections.emptyList();
-            } else {
-                return channel.call(new SlaveLogFetcher());
-            }
-        }
-    }
 
     @SuppressWarnings(value="SIC_INNER_SHOULD_BE_STATIC_NEEDS_THIS", justification="customLogs is not static, so this is a bug in FB")
     private final class LogFile {
@@ -623,7 +304,7 @@ public class JenkinsLogs extends Component {
     /**
      * Matches log files and their rotated names, such as "foo.log" or "foo.log.1"
      */
-    private static final FileFilter ROTATED_LOGFILE_FILTER = new FileFilter() {
+    protected static final FileFilter ROTATED_LOGFILE_FILTER = new FileFilter() {
         final Pattern pattern = Pattern.compile("^.*\\.log(\\.\\d+)?$");
 
         public boolean accept(File f) {
@@ -631,5 +312,5 @@ public class JenkinsLogs extends Component {
         }
     };
 
-    private static final Formatter LOG_FORMATTER = new SupportLogFormatter();
+    protected static final Formatter LOG_FORMATTER = new SupportLogFormatter();
 }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/JenkinsLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/JenkinsLogs.java
@@ -62,7 +62,7 @@ import org.apache.commons.io.FileUtils;
 /**
  * Log files from the master node only.
  */
-@Extension
+@Extension(ordinal = 100.0) // put this first as largest content and can let the slower ones complete
 public class JenkinsLogs extends Component {
 
     private static final Logger LOGGER = Logger.getLogger(JenkinsLogs.class.getName());

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLaunchLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLaunchLogs.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package com.cloudbees.jenkins.support.impl;
 
 import com.cloudbees.jenkins.support.api.Component;

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLaunchLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLaunchLogs.java
@@ -1,0 +1,147 @@
+package com.cloudbees.jenkins.support.impl;
+
+import com.cloudbees.jenkins.support.api.Component;
+import com.cloudbees.jenkins.support.api.Container;
+import com.cloudbees.jenkins.support.api.FileContent;
+import com.cloudbees.jenkins.support.util.Helper;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.Node;
+import hudson.security.Permission;
+import hudson.slaves.Cloud;
+import jenkins.model.Jenkins;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static com.cloudbees.jenkins.support.impl.JenkinsLogs.ROTATED_LOGFILE_FILTER;
+
+/**
+ * Adds slave launch logs, which captures the current and past running connections to the slave.
+ *
+ */
+public class SlaveLaunchLogs extends Component{
+
+    @NonNull
+    @Override
+    public Set<Permission> getRequiredPermissions() {
+        return Collections.singleton(Jenkins.ADMINISTER);
+    }
+
+    @NonNull
+    @Override
+    public String getDisplayName() {
+        return "Slave Launch Logs";
+    }
+
+    @Override
+    public void addContents(@NonNull Container container) {
+        addSlaveLaunchLog(container);
+    }
+
+    /**
+     *
+     * <p>
+     * In the presence of {@link Cloud} plugins like EC2, we want to find past slaves, not just current ones.
+     * So we don't try to loop through {@link Node} here but just try to look at the file systems to find them
+     * all.
+     *
+     * <p>
+     * Generally these cloud plugins do not clean up old logs, so if run for a long time, the log directory
+     * will be full of old files that are not very interesting. Use some heuristics to cut off logs
+     * that are old.
+     */
+    private void addSlaveLaunchLog(Container result) {
+        class Slave implements Comparable<Slave> {
+            /**
+             * Launch log directory of the slave: logs/slaves/NAME
+             */
+            File dir;
+            long time;
+
+            Slave(File dir, File lastLog) {
+                this.dir = dir;
+                this.time = lastLog.lastModified();
+            }
+
+            /** Slave name */
+            String getName() { return dir.getName(); }
+
+            /**
+             * Use the primary log file's timestamp to compare newer slaves from older slaves.
+             *
+             * sort in descending order; newer ones first.
+             */
+            public int compareTo(Slave that) {
+                long lhs = this.time;
+                long rhs = that.time;
+                if (lhs<rhs)    return 1;
+                if (lhs>rhs)    return -1;
+                return 0;
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) return true;
+                if (o == null || getClass() != o.getClass()) return false;
+
+                Slave slave = (Slave) o;
+
+                if (time != slave.time) return false;
+
+                return true;
+            }
+
+            @Override
+            public int hashCode() {
+                return (int) (time ^ (time >>> 32));
+            }
+
+            /**
+             * If the file is more than a year old, can't imagine how that'd be of any interest.
+             */
+            public boolean isTooOld() {
+                return time < System.currentTimeMillis()- TimeUnit.DAYS.toMillis(365);
+            }
+        }
+
+        List<Slave> all = new ArrayList<Slave>();
+
+        {// find all the slave launch log files and sort them newer ones first
+
+            File slaveLogsDir = new File(Helper.getActiveInstance().getRootDir(), "logs/slaves");
+            File[] logs = slaveLogsDir.listFiles();
+            if (logs!=null) {
+                for (File dir : logs) {
+                    File lastLog = new File(dir, "slave.log");
+                    if (lastLog.exists()) {
+                        Slave s = new Slave(dir, lastLog);
+                        if (s.isTooOld()) continue;   // we don't care
+                        all.add(s);
+                    }
+                }
+            }
+
+            Collections.sort(all);
+        }
+
+        {// this might be still too many, so try to cap them.
+            int acceptableSize = Math.max(256, Helper.getActiveInstance().getNodes().size() * 5);
+
+            if (all.size() > acceptableSize)
+                all = all.subList(0, acceptableSize);
+        }
+
+        // now add them all
+        for (Slave s : all) {
+            File[] files = s.dir.listFiles(ROTATED_LOGFILE_FILTER);
+            if (files!=null)
+                for (File f : files) {
+                    result.add(new FileContent("nodes/slave/" + s.getName() + "/launchLogs/"+f.getName() , f));
+                }
+        }
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLogs.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package com.cloudbees.jenkins.support.impl;
 
 import com.cloudbees.jenkins.support.SupportPlugin;

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLogs.java
@@ -1,0 +1,287 @@
+package com.cloudbees.jenkins.support.impl;
+
+import com.cloudbees.jenkins.support.SupportPlugin;
+import com.cloudbees.jenkins.support.api.Component;
+import com.cloudbees.jenkins.support.api.Container;
+import com.cloudbees.jenkins.support.api.FileContent;
+import com.cloudbees.jenkins.support.api.PrintedContent;
+import com.cloudbees.jenkins.support.timer.FileListCapComponent;
+import com.cloudbees.jenkins.support.util.Helper;
+import com.google.common.collect.Lists;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.Computer;
+import hudson.model.Node;
+import hudson.remoting.*;
+import hudson.security.Permission;
+import hudson.slaves.SlaveComputer;
+import hudson.util.DaemonThreadFactory;
+import hudson.util.ExceptionCatchingThreadFactory;
+import hudson.util.RingBufferLogHandler;
+import jenkins.model.Jenkins;
+import org.jenkinsci.remoting.RoleChecker;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.io.PrintWriter;
+import java.lang.reflect.Field;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import static com.cloudbees.jenkins.support.SupportPlugin.REMOTE_OPERATION_TIMEOUT_MS;
+import static com.cloudbees.jenkins.support.SupportPlugin.SUPPORT_DIRECTORY_NAME;
+import static com.cloudbees.jenkins.support.impl.JenkinsLogs.LOG_FORMATTER;
+
+/**
+ * Adds the slave logs from all of the machines
+ */
+@Extension(ordinal = 100.0) // put this first as largest content and can let the slower ones complete.
+public class SlaveLogs extends Component {
+    private static final Logger LOGGER = Logger.getLogger(SlaveLogs.class.getCanonicalName());
+
+    @NonNull
+    @Override
+    public Set<Permission> getRequiredPermissions() {
+        return Collections.singleton(Jenkins.ADMINISTER);
+    }
+
+    @NonNull
+    @Override
+    public String getDisplayName() {
+        return "Slave Log Recorders";
+    }
+
+    @Override
+    public boolean isSelectedByDefault() {
+        return false;
+    }
+
+
+
+    @Override
+    public void addContents(@NonNull Container container) {
+        // expensive remote computation are pooled together and executed later concurrently across all the slaves
+        List<java.util.concurrent.Callable<List<FileContent>>> tasks = Lists.newArrayList();
+        SmartLogFetcher logFetcher = new SmartLogFetcher("cache", new LogFilenameFilter()); // id is awkward because of backward compatibility
+        SmartLogFetcher winswLogFetcher = new SmartLogFetcher("winsw", new WinswLogfileFilter());
+        final boolean needHack = SlaveLogFetcher.isRequired();
+
+        for (final Node node : Helper.getActiveInstance().getNodes()) {
+            if (node.toComputer() instanceof SlaveComputer) {
+                container.add(
+                        new PrintedContent("nodes/slave/" + node.getNodeName() + "/jenkins.log") {
+                            @Override
+                            protected void printTo(PrintWriter out) throws IOException {
+                                Computer computer = node.toComputer();
+                                if (computer == null) {
+                                    out.println("N/A");
+                                } else {
+                                    try {
+                                        List<LogRecord> records = null;
+                                        if (needHack) {
+                                            VirtualChannel channel = computer.getChannel();
+                                            if (channel != null) {
+                                                hudson.remoting.Future<List<LogRecord>> future = SlaveLogFetcher.getLogRecords(channel);
+                                                records = future.get(REMOTE_OPERATION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+                                            }
+                                        }
+
+                                        if (records == null) {
+                                            records = computer.getLogRecords();
+                                        }
+
+                                        for (ListIterator<LogRecord> iterator = records.listIterator(records.size());
+                                             iterator.hasPrevious(); ) {
+                                            LogRecord logRecord = iterator.previous();
+                                            out.print(LOG_FORMATTER.format(logRecord));
+                                        }
+                                    } catch (Throwable e) {
+                                        out.println();
+                                        e.printStackTrace(out);
+                                    }
+                                }
+                                out.flush();
+
+                            }
+                        }
+                );
+            }
+
+            addSlaveJulLogRecords(container, tasks, node, logFetcher);
+            addWinsStdoutStderrLog(tasks, node, winswLogFetcher);
+        }
+
+        // execute all the expensive computations in parallel to speed up the time
+        if (!tasks.isEmpty()) {
+            ExecutorService service = Executors.newFixedThreadPool(
+                    Math.max(1, Math.min(Runtime.getRuntime().availableProcessors() * 2, tasks.size())),
+                    new ExceptionCatchingThreadFactory(new DaemonThreadFactory())
+            );
+            try {
+                long expiresNanoTime =
+                        System.nanoTime() + TimeUnit.SECONDS.toNanos(SupportPlugin.REMOTE_OPERATION_CACHE_TIMEOUT_SEC);
+                for (java.util.concurrent.Future<List<FileContent>> r : service
+                        .invokeAll(tasks, SupportPlugin.REMOTE_OPERATION_CACHE_TIMEOUT_SEC,
+                                TimeUnit.SECONDS)) {
+                    try {
+                        for (FileContent c : r
+                                .get(Math.max(1, expiresNanoTime - System.nanoTime()), TimeUnit.NANOSECONDS)) {
+                            container.add(c);
+                        }
+                    } catch (ExecutionException e) {
+                        LOGGER.log(Level.WARNING, "Could not retrieve some of the remote node extra logs", e);
+                    } catch (TimeoutException e) {
+                        LOGGER.log(Level.WARNING, "Could not retrieve some of the remote node extra logs", e);
+                        r.cancel(false);
+                    }
+                }
+            } catch (InterruptedException e) {
+                LOGGER.log(Level.WARNING, "Could not retrieve some of the remote node extra logs", e);
+            } finally {
+                service.shutdown();
+            }
+        }
+
+    }
+
+
+    /**
+     * Captures a "recent" (but still fairly large number of) j.u.l entries written on this slave.
+     *
+     * @see JenkinsLogs#addMasterJulLogRecords(Container)
+     */
+    private void addSlaveJulLogRecords(Container result, List<java.util.concurrent.Callable<List<FileContent>>> tasks, final Node node, final SmartLogFetcher logFetcher) {
+        final FilePath rootPath = node.getRootPath();
+        if (rootPath != null) {
+            // rotated log files stored on the disk
+            tasks.add(new java.util.concurrent.Callable<List<FileContent>>(){
+                public List<FileContent> call() throws Exception {
+                    List<FileContent> result = new ArrayList<FileContent>();
+                    FilePath supportPath = rootPath.child(SUPPORT_DIRECTORY_NAME);
+                    if (supportPath.isDirectory()) {
+                        final Map<String, File> logFiles = logFetcher.forNode(node).getLogFiles(supportPath);
+                        for (Map.Entry<String, File> entry : logFiles.entrySet()) {
+                            result.add(new FileContent(
+                                    "nodes/slave/" + node.getNodeName() + "/logs/" + entry.getKey(),
+                                    entry.getValue())
+                            );
+                        }
+                    }
+                    return result;
+                }
+            });
+        }
+
+        // this file captures the most recent of those that are still kept around in memory.
+        // this overlaps with Jenkins.logRecords, and also overlaps with what's written in files,
+        // but added nonetheless just in case.
+        //
+        // should be ignorable.
+        result.add(new LogRecordContent("nodes/slave/" + node.getNodeName() + "/logs/all_memory_buffer.log") {
+            @Override
+            public Iterable<LogRecord> getLogRecords() throws IOException {
+                try {
+                    return SupportPlugin.getInstance().getAllLogRecords(node);
+                } catch (InterruptedException e) {
+                    throw (IOException)new InterruptedIOException().initCause(e);
+                }
+            }
+        });
+    }
+
+    /**
+     * Captures stdout/stderr log files produced by winsw.
+     */
+    private void addWinsStdoutStderrLog(List<java.util.concurrent.Callable<List<FileContent>>> tasks, final Node node, final SmartLogFetcher logFetcher) {
+        final FilePath rootPath = node.getRootPath();
+        if (rootPath != null) {
+            // rotated log files stored on the disk
+            tasks.add(new java.util.concurrent.Callable<List<FileContent>>(){
+                public List<FileContent> call() throws Exception {
+                    List<FileContent> result = new ArrayList<FileContent>();
+                    final Map<String, File> logFiles = logFetcher.forNode(node).getLogFiles(rootPath);
+                    for (Map.Entry<String, File> entry : logFiles.entrySet()) {
+                        result.add(new FileContent(
+                                "nodes/slave/" + node.getNodeName() + "/logs/winsw/" + entry.getKey(),
+                                entry.getValue(), FileListCapComponent.MAX_FILE_SIZE)
+                        );
+                    }
+                    return result;
+                }
+            });
+        }
+    }
+
+    private static class SlaveLogFetcher implements hudson.remoting.Callable<List<LogRecord>, RuntimeException> {
+
+        public static boolean isRequired() {
+            try {
+                SlaveComputer.class.getClassLoader().loadClass(SlaveComputer.class.getName() + "$SlaveLogFetcher");
+                return false;
+            } catch (ClassNotFoundException e) {
+                return true;
+            }
+        }
+
+        public List<LogRecord> call() throws RuntimeException {
+            try {
+                Class<?> aClass =
+                        SlaveComputer.class.getClassLoader().loadClass(SlaveComputer.class.getName() + "$LogHolder");
+                Field logHandler = aClass.getDeclaredField("SLAVE_LOG_HANDLER");
+                boolean accessible = logHandler.isAccessible();
+                try {
+                    if (!accessible) {
+                        logHandler.setAccessible(true);
+                    }
+                    Object instance = logHandler.get(null);
+                    if (instance instanceof RingBufferLogHandler) {
+                        RingBufferLogHandler handler = (RingBufferLogHandler) instance;
+                        return new ArrayList<LogRecord>(handler.getView());
+                    }
+                } finally {
+                    if (!accessible) {
+                        logHandler.setAccessible(accessible);
+                    }
+                }
+                throw new RuntimeException("Could not retrieve logs");
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException(e);
+            } catch (NoSuchFieldException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public void checkRoles(RoleChecker checker) throws SecurityException {
+            // TODO: do we have to verify some role?
+        }
+
+        public static hudson.remoting.Future<List<LogRecord>> getLogRecords(@NonNull VirtualChannel channel) throws IOException {
+            return channel.callAsync(new SlaveLogFetcher());
+        }
+
+        /**
+         * @deprecated Please use getLogRecords(Channel) instead. This method is synchronous which could cause
+         * the channel to block.
+         */
+        @Deprecated
+        public static List<LogRecord> getLogRecords(Computer computer) throws IOException, InterruptedException {
+            VirtualChannel channel = computer.getChannel();
+            if (channel == null) {
+                return Collections.emptyList();
+            } else {
+                return channel.call(new SlaveLogFetcher());
+            }
+        }
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
@@ -16,6 +16,7 @@ import org.jvnet.hudson.test.JenkinsRule.WebClient;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -70,14 +71,17 @@ public class SupportActionTest extends Assert {
             // TODO: emit some log entries and see if it gets captured here
             assertNotNull(z.getEntry("about.md"));
             assertNotNull(z.getEntry("nodes.md"));
-            assertNotNull(z.getEntry("nodes/slave/slave1/system.properties"));
             assertNotNull(z.getEntry("nodes/master/thread-dump.txt"));
-            assertNotNull(z.getEntry("nodes/slave/slave2/launchLogs/slave.log"));
         } finally {
             logger.removeHandler(checker);
             for (LogRecord r : checker.getView()) {
-                if (r.getLevel().intValue() >= Level.WARNING.intValue())
+                if (r.getLevel().intValue() >= Level.WARNING.intValue()) {
+                    Throwable thrown = r.getThrown();
+                    if (thrown != null)
+                        thrown.printStackTrace(System.err);
+
                     fail(r.getMessage());
+                }
             }
         }
     }


### PR DESCRIPTION
This should help improve the performance of generating a support bundle and the size if you do not require logs from each individual slave. Some Jenkins masters have a few hundred slaves, so generating a support bundle might take a long time. Also some of the machines might have logs which might be several MB in size.

This pull request disables obtaining slave logs by default. Unless the user(s) have had issues with the slave machines, the log information for each individual slave is most likely is not required.

@reviewbybees 