### PR TITLE
Fixed some buglets in SupportLogFormatter

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportLogFormatter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportLogFormatter.java
@@ -33,6 +33,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 import java.util.logging.Formatter;
 import java.util.logging.LogRecord;
 /***********************************************
@@ -46,6 +47,9 @@ import java.util.logging.LogRecord;
  * @author Stephen Connolly
  */
 public class SupportLogFormatter extends Formatter {
+
+    /** for testing */
+    static TimeZone timeZone;
     
     private final static ThreadLocal<SimpleDateFormat> threadLocalDateFormat = new ThreadLocal<SimpleDateFormat>() {
         @Override
@@ -63,7 +67,11 @@ public class SupportLogFormatter extends Formatter {
     )
     public String format(LogRecord record) {
         StringBuilder builder = new StringBuilder();
-        builder.append(threadLocalDateFormat.get().format(new Date(record.getMillis())));
+        SimpleDateFormat format = threadLocalDateFormat.get();
+        if (timeZone != null) {
+            format.setTimeZone(timeZone);
+        }
+        builder.append(format.format(new Date(record.getMillis())));
         builder.append(" [id=").append(record.getThreadID()).append("]");
 
         builder.append("\t").append(record.getLevel().getName()).append("\t");

--- a/src/main/java/com/cloudbees/jenkins/support/SupportLogFormatter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportLogFormatter.java
@@ -28,6 +28,7 @@ package com.cloudbees.jenkins.support;
  * DO NOT INCLUDE ANY NON JDK CLASSES IN HERE.
  * IT CAN DEADLOCK REMOTING - SEE JENKINS-32622
  ***********************************************/
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.text.SimpleDateFormat;
@@ -46,7 +47,7 @@ import java.util.logging.LogRecord;
  */
 public class SupportLogFormatter extends Formatter {
     
-    private final static ThreadLocal<SimpleDateFormat> threadLocalDateFormat = new ThreadLocal() {
+    private final static ThreadLocal<SimpleDateFormat> threadLocalDateFormat = new ThreadLocal<SimpleDateFormat>() {
         @Override
         protected SimpleDateFormat initialValue() {
             return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSZ");
@@ -56,7 +57,7 @@ public class SupportLogFormatter extends Formatter {
     private final Object[] args = new Object[6];
 
     @Override
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings(
+    @SuppressFBWarnings(
             value = {"DE_MIGHT_IGNORE"},
             justification = "The exception wasn't thrown on our stack frame"
     )
@@ -86,7 +87,12 @@ public class SupportLogFormatter extends Formatter {
             builder.append(abbreviateClassName(sourceClass, 40));
         }
 
-        builder.append(": ").append(formatMessage(record));
+        String message = formatMessage(record);
+        if (message != null) {
+            builder.append(": ").append(message);
+        }
+
+        builder.append("\n");
 
         if (record.getThrown() != null) {
             try {
@@ -100,7 +106,6 @@ public class SupportLogFormatter extends Formatter {
             }
         }
 
-        builder.append("\n");
         return builder.toString();
     }
 

--- a/src/test/java/com/cloudbees/jenkins/support/SupportLogFormatterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportLogFormatterTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.*;
 public class SupportLogFormatterTest {
 
     static {
-        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        SupportLogFormatter.timeZone = TimeZone.getTimeZone("UTC");
     }
 
     @Test

--- a/src/test/java/com/cloudbees/jenkins/support/SupportLogFormatterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportLogFormatterTest.java
@@ -1,0 +1,86 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cloudbees.jenkins.support;
+
+import java.util.TimeZone;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class SupportLogFormatterTest {
+
+    static {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    }
+
+    @Test
+    public void smokes() {
+        assertFormatting("1970-01-01 00:00:00.000+0000 [id=999]\tINFO\tsome.pkg.Catcher#robust: some message\n",
+            Level.INFO, "some message", null);
+        assertFormatting("1970-01-01 00:00:00.000+0000 [id=999]\tWARNING\tsome.pkg.Catcher#robust: failed to do stuff\n" +
+                         "PhonyException: oops\n" +
+                         "\tat some.other.pkg.Thrower.buggy(Thrower.java:123)\n" +
+                         "\tat some.pkg.Catcher.robust(Catcher.java:456)\n",
+            Level.WARNING, "failed to do stuff", new PhonyException());
+        assertFormatting("1970-01-01 00:00:00.000+0000 [id=999]\tWARNING\tsome.pkg.Catcher#robust\n" +
+                         "PhonyException: oops\n" +
+                         "\tat some.other.pkg.Thrower.buggy(Thrower.java:123)\n" +
+                         "\tat some.pkg.Catcher.robust(Catcher.java:456)\n",
+            Level.WARNING, null, new PhonyException());
+    }
+
+    // TODO test abbreviateClassName
+
+    private static void assertFormatting(@Nonnull String expected, @Nonnull Level level, @CheckForNull String message, @CheckForNull Throwable throwable) {
+        LogRecord lr = new LogRecord(level, message);
+        if (throwable != null) {
+            lr.setThrown(throwable);
+        }
+        // unused: lr.setLoggerName("some.pkg.Catcher");
+        lr.setThreadID(999);
+        lr.setSourceClassName("some.pkg.Catcher");
+        lr.setSourceMethodName("robust");
+        lr.setMillis(0);
+        assertEquals(expected, new SupportLogFormatter().format(lr));
+    }
+
+    private static class PhonyException extends Throwable {
+        @SuppressWarnings("OverridableMethodCallInConstructor")
+        PhonyException() {
+            setStackTrace(new StackTraceElement[] {
+                new StackTraceElement("some.other.pkg.Thrower", "buggy", "Thrower.java", 123),
+                new StackTraceElement("some.pkg.Catcher", "robust", "Catcher.java", 456),
+            });
+        }
+        @Override
+        public String toString() {
+            return "PhonyException: oops";
+        }
+    }
+
+}


### PR DESCRIPTION
See https://github.com/jenkinsci/workflow-job-plugin/pull/31 for an example.
- missing newline between header and start of exception
- gratuitous newline after stack trace
- spurious `: null` when a logger reported an exception without a message

@reviewbybees
