### PR TITLE
[FIX JENKINS-39607] GC logs should be collected

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,12 @@
       <version>1.7.8</version>
       <optional>true</optional>
     </dependency>
+      <dependency>
+          <groupId>org.mockito</groupId>
+          <artifactId>mockito-core</artifactId>
+          <version>2.2.15</version>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 
 </project>

--- a/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
@@ -1,0 +1,110 @@
+package com.cloudbees.jenkins.support.impl;
+
+import com.cloudbees.jenkins.support.api.Component;
+import com.cloudbees.jenkins.support.api.Container;
+import com.cloudbees.jenkins.support.api.FileContent;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.security.Permission;
+import jenkins.model.Jenkins;
+
+import javax.annotation.CheckForNull;
+import java.io.File;
+import java.lang.management.ManagementFactory;
+import java.util.Collections;
+import java.util.Set;
+import java.util.logging.Logger;
+
+/**
+ * GC Logs Retriever.
+ * <p>
+ * <p>Introspects the running VM for <code>-Xloggc:blah.log</code> option and so on to propose including those if
+ * found</p>
+ * <p>
+ * NOTE: currently only tested on OpenJDK / HotSpot.
+ * </p>
+ */
+@Extension(ordinal = 90.0) // probably big too, see JenkinsLogs
+public class GCLogs extends Component {
+
+    static final String GCLOG_JRE_SWITCH = "-Xloggc:";
+
+    private static final Logger LOGGER = Logger.getLogger(GCLogs.class.getName());
+
+    private final VmArgumentFinder vmArgumentFinder;
+
+    public GCLogs() {
+        this(new VmArgumentFinder());
+    }
+
+    /**
+     * Designed for testing use only.
+     *
+     * @param vmArgumentFinder pass the impl you want to override the default one.
+     */
+    GCLogs(VmArgumentFinder vmArgumentFinder) {
+        this.vmArgumentFinder = vmArgumentFinder;
+    }
+
+    @NonNull
+    @Override
+    public Set<Permission> getRequiredPermissions() {
+        return Collections.singleton(Jenkins.ADMINISTER);
+    }
+
+    @NonNull
+    @Override
+    public String getDisplayName() {
+        return "Garbage Collection Logs";
+    }
+
+    @Override
+    public boolean isEnabled() {
+        boolean gcLogsConfigured = getGcLogFileLocation() != null;
+        LOGGER.fine("GC logs configured: " + gcLogsConfigured);
+        return super.isEnabled() && gcLogsConfigured;
+    }
+
+    @Override
+    public void addContents(@NonNull Container result) {
+        LOGGER.fine("Trying to gather GC logs for support bundle");
+        String gcLogFileLocation = getGcLogFileLocation();
+        assert gcLogFileLocation != null; // non nullable here 'cause isEnabled() already checks it
+
+        // TODO : log rotation improved logic
+
+        File file = new File(gcLogFileLocation);
+        if (!file.exists()) {
+            LOGGER.warning("[Support Bundle] GC Logging apparently configured, " +
+                    "but file '" + gcLogFileLocation + "' not found");
+            return;
+        }
+        result.add(new FileContent("/nodes/master/logs/gc.log", file));
+    }
+
+    @CheckForNull
+    private String getGcLogFileLocation() {
+
+        String gcLogSwitch = vmArgumentFinder.findVmArgument(GCLOG_JRE_SWITCH);
+        if (gcLogSwitch == null) {
+            LOGGER.fine("No GC Logging switch found, no GC logs will be gathered.");
+            return null;
+        }
+        return gcLogSwitch.substring(GCLOG_JRE_SWITCH.length());
+    }
+
+    /**
+     * Isolated code to make it testable
+     */
+    static class VmArgumentFinder {
+        @CheckForNull
+        public String findVmArgument(String argName) {
+            for (String argument : ManagementFactory.getRuntimeMXBean().getInputArguments()) {
+                if (argument.startsWith(argName)) {
+                    return argument;
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/support/impl/GCLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/GCLogsTest.java
@@ -1,0 +1,49 @@
+package com.cloudbees.jenkins.support.impl;
+
+import com.cloudbees.jenkins.support.api.Container;
+import com.cloudbees.jenkins.support.api.Content;
+import com.google.common.io.Files;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class GCLogsTest {
+
+    @Test
+    public void testSimpleFile() throws Exception {
+        File tmpFile = File.createTempFile("gclogs", "");
+        Files.touch(tmpFile);
+
+        GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
+        System.out.println(tmpFile.exists());
+        System.out.println(tmpFile);
+        when(finder.findVmArgument(GCLogs.GCLOG_JRE_SWITCH)).thenReturn(GCLogs.GCLOG_JRE_SWITCH + tmpFile.getAbsolutePath());
+
+        TestContainer container = new TestContainer();
+
+        new GCLogs(finder).addContents(container);
+
+        assertEquals(1, container.getContents().size());
+    }
+
+    private static class TestContainer extends Container {
+        List<Content> contents = new ArrayList<Content>();
+
+        public List<Content> getContents() {
+            return contents;
+        }
+
+        @Override
+        public void add(@CheckForNull Content content) {
+            contents.add(content);
+        }
+
+    }
+}


### PR DESCRIPTION
>When diagnosing an issue, having GC logs when enabled can be critical. It would be both simpler for everyone and useful to have them added to the bundle automatically too.

The code here introspects the VM and parses `-Xloggc` and so on to find and gather those logs.

https://issues.jenkins-ci.org/browse/JENKINS-39607

@jenkinsci/code-reviewers 

Possibly for more eyes: @reviewbybees esp. @svanoort 