### PR TITLE
NPE in GCLogs.addContents

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
@@ -76,7 +76,9 @@ public class GCLogs extends Component {
     public void addContents(@NonNull Container result) {
         LOGGER.fine("Trying to gather GC logs for support bundle");
         String gcLogFileLocation = getGcLogFileLocation();
-        assert gcLogFileLocation != null; // non nullable here 'cause isEnabled() already checks it
+        if (gcLogFileLocation == null) {
+            return;
+        }
 
         if (isGcLogRotationConfigured()) {
             handleRotatedLogs(gcLogFileLocation, result);


### PR DESCRIPTION
Observed by just installing this plugin and restarting Jenkins.

```
… com.cloudbees.jenkins.support.SupportPlugin writeBundle
WARNING: Could not get content from 'Garbage Collection Logs' for support bundle
java.lang.NullPointerException
	at java.io.File.<init>(File.java:277)
	at com.cloudbees.jenkins.support.impl.GCLogs.addContents(GCLogs.java:84)
	at com.cloudbees.jenkins.support.SupportPlugin.writeBundle(SupportPlugin.java:311)
	at com.cloudbees.jenkins.support.SupportPlugin.writeBundle(SupportPlugin.java:274)
	at com.cloudbees.jenkins.support.SupportPlugin$PeriodicWorkImpl$1.run(SupportPlugin.java:724)
	at java.lang.Thread.run(Thread.java:745)
```

`Component.isEnabled` is ignored by `SupportPlugin.writeBundle(OutputStream)`. Possibly `GCLogs` should not even bother overriding it—just treat it as “enabled” but do nothing if `-Xloggc` is not currently passed.

@reviewbybees esp. @batmat