### PR TITLE
[JENKINS-40098] The support bundle naming strategy should be modifiable

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/BundleNamePrefixProvider.java
+++ b/src/main/java/com/cloudbees/jenkins/support/BundleNamePrefixProvider.java
@@ -1,0 +1,67 @@
+package com.cloudbees.jenkins.support;
+
+import com.google.common.annotations.VisibleForTesting;
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+
+import javax.annotation.Nonnull;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * <p>Extension point allowing to customize the support bundle name prefixing strategy.</p>
+ * It will work the following way:
+ * <ol>
+ * <li>If an implementation of {@link BundleNamePrefixProvider} is found, it will be used.<br>
+ * <strong>WARNING: </strong>if many are found, then a warning will be issued, and the first extension found will
+ * be used.</li>
+ * <li>If not, then it will check for the presence of the {@link #SUPPORT_BUNDLE_NAMING_PREFIX_PROPERTY}
+ * system property, and will use its value if provided.</li>
+ * <li>If not, then will fallback to the original behaviour, simply using <em>support</em> as a prefix</li>
+ * </ol>
+ */
+public abstract class BundleNamePrefixProvider implements ExtensionPoint {
+
+    private static final Logger LOGGER = Logger.getLogger(BundleNamePrefixProvider.class.getName());
+
+    @VisibleForTesting
+    static final String SUPPORT_BUNDLE_NAMING_PREFIX_PROPERTY = SupportPlugin.class.getName() + ".bundlePrefix";
+
+    private static final BundleNamePrefixProvider DEFAULT_STRATEGY = new BundleNamePrefixProvider() {
+
+        @Override
+        public String getPrefix() {
+            return System.getProperty(SUPPORT_BUNDLE_NAMING_PREFIX_PROPERTY, "support");
+        }
+    };
+
+    /* package */
+    static BundleNamePrefixProvider getInstance() {
+        final ExtensionList<BundleNamePrefixProvider> all = ExtensionList.lookup(BundleNamePrefixProvider.class);
+        final int extensionCount = all.size();
+        System.out.println(extensionCount);
+        if (extensionCount < 1) {
+            LOGGER.fine("No alternative strategy provided for support bundle prefixing.");
+            return DEFAULT_STRATEGY;
+        }
+
+        if (all.size() > 1) {
+            if (LOGGER.isLoggable(Level.WARNING)) {
+                LOGGER.warning("{0} implementations found for support bundle prefix naming strategy. " +
+                        "Can be only 0 or 1. Choosing the first found.");
+                for (BundleNamePrefixProvider bundlePrefixProvider : all) {
+                    LOGGER.log(Level.WARNING, "class '{0}' found", bundlePrefixProvider.getClass().getName());
+                }
+            }
+        }
+        return all.get(0);
+    }
+
+    /**
+     * Returns the <strong>non-null</strong> prefix to be used for generated support bundles.
+     *
+     * @return the prefix to be used for generated support bundles.
+     */
+    @Nonnull
+    public abstract String getPrefix();
+}

--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -713,7 +713,7 @@ public class SupportPlugin extends Plugin {
                                 SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd_HH.mm.ss");
                                 dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
 
-                                final String bundlePrefix = "support";
+                                final String bundlePrefix = BundleNamePrefixProvider.getInstance().getPrefix();
                                 File file = new File(bundleDir,
                                         bundlePrefix + "_" + dateFormat.format(new Date()) + ".zip");
                                 thread.setName(String.format("%s periodic bundle generator: writing %s since %s",

--- a/src/test/java/com/cloudbees/jenkins/support/BundleNamePrefixProviderTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/BundleNamePrefixProviderTest.java
@@ -1,0 +1,66 @@
+package com.cloudbees.jenkins.support;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+
+import javax.annotation.Nonnull;
+
+import static org.junit.Assert.assertEquals;
+
+public class BundleNamePrefixProviderTest {
+
+    @Rule
+    public JenkinsRule rule = new JenkinsRule();
+
+    @Test
+    public void checkOriginalBehaviour() throws Exception {
+        assertEquals("support", BundleNamePrefixProvider.getInstance().getPrefix());
+    }
+
+    @Test
+    public void checkWithOneProvider() throws Exception {
+        assertEquals("pouet", BundleNamePrefixProvider.getInstance().getPrefix());
+    }
+
+    @Test
+    public void tooManyProviders() throws Exception {
+        assertEquals("this", BundleNamePrefixProvider.getInstance().getPrefix());
+    }
+
+    @Test
+    public void withSysProp() throws Exception {
+        System.setProperty(BundleNamePrefixProvider.SUPPORT_BUNDLE_NAMING_PREFIX_PROPERTY, "paf");
+        assertEquals("paf", BundleNamePrefixProvider.getInstance().getPrefix());
+        System.getProperties().remove(BundleNamePrefixProvider.SUPPORT_BUNDLE_NAMING_PREFIX_PROPERTY);
+    }
+
+    @TestExtension("checkWithOneProvider")
+    public static class TestProvider extends BundleNamePrefixProvider {
+
+        @Nonnull
+        @Override
+        public String getPrefix() {
+            return "pouet";
+        }
+    }
+
+    @TestExtension("tooManyProviders")
+    public static class SpuriousProvider extends BundleNamePrefixProvider {
+        @Nonnull
+        @Override
+        public String getPrefix() {
+            return "this";
+        }
+    }
+
+    @TestExtension("tooManyProviders")
+    public static class SpuriousProvider2 extends BundleNamePrefixProvider {
+        @Nonnull
+        @Override
+        public String getPrefix() {
+            return "that";
+        }
+    }
+}


### PR DESCRIPTION
[JENKINS-40098](https://issues.jenkins-ci.org/browse/JENKINS-40098)

Introduced a change enabling both overriding through using a sysprop,
or implementing a new Extension Point.

The approach with Extension Points should enable more dynamic needs,
when the sysprop one will be immediately usable by anyone without
having to develop an extension.

Note: if found, the extension is preferred over the sysprop.

@reviewbybees