### PR TITLE
[JENKINS-40098] Bundle naming strategy should be able to specify an instance type

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/BundleNameInstanceTypeProvider.java
+++ b/src/main/java/com/cloudbees/jenkins/support/BundleNameInstanceTypeProvider.java
@@ -26,11 +26,11 @@ package com.cloudbees.jenkins.support;
 
 import com.cloudbees.jenkins.support.api.SupportProvider;
 import com.google.common.annotations.VisibleForTesting;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 
-import javax.annotation.Nonnull;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -57,7 +57,7 @@ public abstract class BundleNameInstanceTypeProvider implements ExtensionPoint {
 
     private static final Logger LOGGER = Logger.getLogger(BundleNameInstanceTypeProvider.class.getName());
 
-    @Nonnull
+    @NonNull
     static BundleNameInstanceTypeProvider getInstance() {
         final ExtensionList<BundleNameInstanceTypeProvider> all = ExtensionList.lookup(BundleNameInstanceTypeProvider.class);
         final int extensionCount = all.size();
@@ -91,7 +91,7 @@ public abstract class BundleNameInstanceTypeProvider implements ExtensionPoint {
      *
      * @return the instance type specification to be used for generated support bundles.
      */
-    @Nonnull
+    @NonNull
     public abstract String getInstanceType();
 
     // We want this to be always picked up last in case others are found Double.MIN_VALUE does NOT work

--- a/src/main/java/com/cloudbees/jenkins/support/BundleNameInstanceTypeProvider.java
+++ b/src/main/java/com/cloudbees/jenkins/support/BundleNameInstanceTypeProvider.java
@@ -75,7 +75,7 @@ public abstract class BundleNameInstanceTypeProvider implements ExtensionPoint {
 
         final BundleNameInstanceTypeProvider chosen = all.get(0);
         if (extensionCount > 1) {
-            LOGGER.log(Level.INFO, "Using {0} as BundleNameInstanceTypeProvider implementation", chosen.getClass().getName());
+            LOGGER.log(Level.FINE, "Using {0} as BundleNameInstanceTypeProvider implementation", chosen.getClass().getName());
         }
         return chosen;
     }

--- a/src/main/java/com/cloudbees/jenkins/support/BundleNameInstanceTypeProvider.java
+++ b/src/main/java/com/cloudbees/jenkins/support/BundleNameInstanceTypeProvider.java
@@ -1,0 +1,78 @@
+package com.cloudbees.jenkins.support;
+
+import com.cloudbees.jenkins.support.api.SupportProvider;
+import com.google.common.annotations.VisibleForTesting;
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+
+import javax.annotation.Nonnull;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * <p>Extension point allowing to customize the support bundle naming strategy.</p>
+ * <p>
+ * It will work the following way:
+ * </p>
+ * <ol>
+ * <li>If an implementation of {@link BundleNameInstanceTypeProvider} is found, it will be used.<br>
+ * <strong>WARNING: </strong>if many are found, then a warning will be issued, and the first extension found will
+ * be used.</li>
+ * <li>If not, then it will check for the presence of the {@link #SUPPORT_BUNDLE_NAMING_INSTANCE_SPEC_PROPERTY}
+ * system property, and will use its value if provided.</li>
+ * <li>If not, then will fallback to the original behaviour, which is simply an empty String</li>
+ * </ol>
+ *
+ * @see SupportProvider#getName() for prefixing.
+ */
+public abstract class BundleNameInstanceTypeProvider implements ExtensionPoint {
+
+    @VisibleForTesting
+    static final String SUPPORT_BUNDLE_NAMING_INSTANCE_SPEC_PROPERTY = SupportPlugin.class.getName() + ".instanceType";
+
+    private static final Logger LOGGER = Logger.getLogger(BundleNameInstanceTypeProvider.class.getName());
+
+    private static final BundleNameInstanceTypeProvider DEFAULT_STRATEGY = new BundleNameInstanceTypeProvider() {
+
+        @Override
+        public String getInstanceType() {
+            return System.getProperty(SUPPORT_BUNDLE_NAMING_INSTANCE_SPEC_PROPERTY, "");
+        }
+    };
+
+    /* package */
+    @Nonnull
+    static BundleNameInstanceTypeProvider getInstance() {
+        final ExtensionList<BundleNameInstanceTypeProvider> all = ExtensionList.lookup(BundleNameInstanceTypeProvider.class);
+        final int extensionCount = all.size();
+        if (extensionCount < 1) {
+            LOGGER.fine("No alternative strategy provided for support bundle prefixing.");
+            return DEFAULT_STRATEGY;
+        }
+
+        if (all.size() > 1) {
+            if (LOGGER.isLoggable(Level.WARNING)) {
+                LOGGER.warning("{0} implementations found for support bundle prefix naming strategy. " +
+                        "Can be only 0 or 1. Choosing the first found.");
+                for (BundleNameInstanceTypeProvider bundlePrefixProvider : all) {
+                    LOGGER.log(Level.WARNING, "class '{0}' found", bundlePrefixProvider.getClass().getName());
+                }
+            }
+        }
+        return all.get(0);
+    }
+
+    /**
+     * Returns the <strong>non-null</strong> instance type to be used for generated support bundle names.
+     * Aims to provide informational data about the generated bundles.
+     *
+     * <p>
+     * <p><b>Will be used for file name generation, so avoid funky characters.
+     * Please stay in <code>[a-zA-Z-_]</code></b>. Also consider the file name length, you probably want to be defensive
+     * and not return crazily long strings. Something below 20 characters or so might sound reasonable.</p>
+     *
+     * @return the instance type specification to be used for generated support bundles.
+     */
+    @Nonnull
+    public abstract String getInstanceType();
+}

--- a/src/main/java/com/cloudbees/jenkins/support/BundleNameInstanceTypeProvider.java
+++ b/src/main/java/com/cloudbees/jenkins/support/BundleNameInstanceTypeProvider.java
@@ -97,7 +97,7 @@ public abstract class BundleNameInstanceTypeProvider implements ExtensionPoint {
     public abstract String getInstanceType();
 
     // We want this to be always picked up last in case others are found Double.MIN_VALUE does NOT work
-    @Extension(ordinal = -1000000)
+    @Extension(ordinal = Integer.MIN_VALUE)
     public static final class DEFAULT_STRATEGY extends BundleNameInstanceTypeProvider {
 
         @Override

--- a/src/main/java/com/cloudbees/jenkins/support/BundleNameInstanceTypeProvider.java
+++ b/src/main/java/com/cloudbees/jenkins/support/BundleNameInstanceTypeProvider.java
@@ -81,12 +81,14 @@ public abstract class BundleNameInstanceTypeProvider implements ExtensionPoint {
     }
 
     /**
-     * Returns the <strong>non-null</strong> instance type to be used for generated support bundle names.
-     * Aims to provide informational data about the generated bundles.
-     * <p>
-     * <p>
-     * <p><b>Will be used for file name generation, so avoid funky characters.
-     * Please stay in <code>[a-zA-Z-_]</code></b>. Also consider the file name length, you probably want to be defensive
+     * Returns the <strong>non-null</strong> and non empty (default value is empty) instance type to be used for
+     * generated support bundle names.
+     *
+     * <p>Aims to provide informational data about the generated bundles.</p>
+     * <p><strong>Will be used for file name generation, so avoid funky characters.
+     * Please ideally stay in <code>[a-zA-Z-_.]</code></strong>.
+     *
+     * Also consider the file name length, you probably want to be defensive
      * and not return crazily long strings. Something below 20 characters or so might sound reasonable.</p>
      *
      * @return the instance type specification to be used for generated support bundles.

--- a/src/main/java/com/cloudbees/jenkins/support/BundleNameInstanceTypeProvider.java
+++ b/src/main/java/com/cloudbees/jenkins/support/BundleNameInstanceTypeProvider.java
@@ -1,7 +1,32 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package com.cloudbees.jenkins.support;
 
 import com.cloudbees.jenkins.support.api.SupportProvider;
 import com.google.common.annotations.VisibleForTesting;
+import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 
@@ -32,40 +57,33 @@ public abstract class BundleNameInstanceTypeProvider implements ExtensionPoint {
 
     private static final Logger LOGGER = Logger.getLogger(BundleNameInstanceTypeProvider.class.getName());
 
-    private static final BundleNameInstanceTypeProvider DEFAULT_STRATEGY = new BundleNameInstanceTypeProvider() {
-
-        @Override
-        public String getInstanceType() {
-            return System.getProperty(SUPPORT_BUNDLE_NAMING_INSTANCE_SPEC_PROPERTY, "");
-        }
-    };
-
-    /* package */
     @Nonnull
     static BundleNameInstanceTypeProvider getInstance() {
         final ExtensionList<BundleNameInstanceTypeProvider> all = ExtensionList.lookup(BundleNameInstanceTypeProvider.class);
         final int extensionCount = all.size();
-        if (extensionCount < 1) {
-            LOGGER.fine("No alternative strategy provided for support bundle prefixing.");
-            return DEFAULT_STRATEGY;
-        }
 
-        if (all.size() > 1) {
+        if (extensionCount > 2) {
             if (LOGGER.isLoggable(Level.WARNING)) {
-                LOGGER.warning("{0} implementations found for support bundle prefix naming strategy. " +
-                        "Can be only 0 or 1. Choosing the first found.");
-                for (BundleNameInstanceTypeProvider bundlePrefixProvider : all) {
-                    LOGGER.log(Level.WARNING, "class '{0}' found", bundlePrefixProvider.getClass().getName());
+                LOGGER.log(Level.WARNING, "{0} implementations found for support bundle prefix naming strategy. " +
+                        "Can be only 1 (default one) or 2 (default one, plus alternative). " +
+                        "Choosing the first found among the following:", extensionCount);
+                for (BundleNameInstanceTypeProvider nameProvider : all) {
+                    LOGGER.log(Level.WARNING, "Class {0} found", nameProvider.getClass().getName());
                 }
             }
         }
-        return all.get(0);
+
+        final BundleNameInstanceTypeProvider chosen = all.get(0);
+        if (extensionCount > 1) {
+            LOGGER.log(Level.INFO, "Using {0} as BundleNameInstanceTypeProvider implementation", chosen.getClass().getName());
+        }
+        return chosen;
     }
 
     /**
      * Returns the <strong>non-null</strong> instance type to be used for generated support bundle names.
      * Aims to provide informational data about the generated bundles.
-     *
+     * <p>
      * <p>
      * <p><b>Will be used for file name generation, so avoid funky characters.
      * Please stay in <code>[a-zA-Z-_]</code></b>. Also consider the file name length, you probably want to be defensive
@@ -75,4 +93,14 @@ public abstract class BundleNameInstanceTypeProvider implements ExtensionPoint {
      */
     @Nonnull
     public abstract String getInstanceType();
+
+    // We want this to be always picked up last in case others are found Double.MIN_VALUE does NOT work
+    @Extension(ordinal = -1000000)
+    public static final class DEFAULT_STRATEGY extends BundleNameInstanceTypeProvider {
+
+        @Override
+        public String getInstanceType() {
+            return System.getProperty(BundleNameInstanceTypeProvider.SUPPORT_BUNDLE_NAMING_INSTANCE_SPEC_PROPERTY, "");
+        }
+    }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
@@ -48,14 +48,11 @@ import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import java.util.TimeZone;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -147,18 +144,7 @@ public class SupportAction implements RootAction {
         logger.fine("Preparing response...");
         rsp.setContentType("application/zip");
 
-        String filename = "support"; // default bundle filename
-        if (supportPlugin != null) {
-            SupportProvider supportProvider = supportPlugin.getSupportProvider();
-            if (supportProvider != null) {
-                // let the provider name it
-                filename = supportProvider.getName();
-            }
-        }
-
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd_HH.mm.ss");
-        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
-        rsp.addHeader("Content-Disposition", "inline; filename=" + filename + "_" + dateFormat.format(new Date()) + ".zip;");
+        rsp.addHeader("Content-Disposition", "inline; filename=" + SupportPlugin.getBundleFileName() + ";");
         final ServletOutputStream servletOutputStream = rsp.getOutputStream();
         try {
             SupportPlugin.setRequesterAuthentication(Jenkins.getAuthentication());

--- a/src/main/java/com/cloudbees/jenkins/support/SupportCommand.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportCommand.java
@@ -27,13 +27,12 @@ package com.cloudbees.jenkins.support;
 import com.cloudbees.jenkins.support.api.Component;
 import hudson.Extension;
 import hudson.cli.CLICommand;
-import hudson.remoting.Callable;
 import hudson.remoting.RemoteOutputStream;
 import hudson.security.ACL;
 import jenkins.model.Jenkins;
+import jenkins.security.MasterToSlaveCallable;
 import org.acegisecurity.context.SecurityContext;
 import org.acegisecurity.context.SecurityContextHolder;
-import org.jenkinsci.remoting.RoleChecker;
 import org.kohsuke.args4j.Argument;
 
 import java.io.File;
@@ -90,7 +89,7 @@ public class SupportCommand extends CLICommand {
         return 0;
     }
 
-    private static class SaveBundle implements Callable<OutputStream, IOException> {
+    private static class SaveBundle extends MasterToSlaveCallable<OutputStream, IOException> {
         private final String filename;
 
         SaveBundle(String filename) {
@@ -102,11 +101,11 @@ public class SupportCommand extends CLICommand {
             System.err.println("Creating: " + f);
             return new RemoteOutputStream(new FileOutputStream(f));
         }
-
-        /** {@inheritDoc} */
         @Override
-        public void checkRoles(RoleChecker checker) throws SecurityException {
-            // TODO: do we have to verify some role?
+        public OutputStream call() throws IOException {
+            Path path = Files.createFile(Paths.get(System.getProperty("java.io.tmpDir"), filename));
+            System.err.println("Creating: " + path);
+            return new RemoteOutputStream(new FileOutputStream(path.toFile()));
         }
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/SupportCommand.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportCommand.java
@@ -25,7 +25,6 @@
 package com.cloudbees.jenkins.support;
 
 import com.cloudbees.jenkins.support.api.Component;
-import com.cloudbees.jenkins.support.api.SupportProvider;
 import hudson.Extension;
 import hudson.cli.CLICommand;
 import hudson.remoting.Callable;
@@ -81,15 +80,7 @@ public class SupportCommand extends CLICommand {
         try {
             SecurityContext old = ACL.impersonate(ACL.SYSTEM);
             try {
-                String filename = "support";
-                SupportPlugin supportPlugin = SupportPlugin.getInstance();
-                if (supportPlugin != null) {
-                    SupportProvider supportProvider = supportPlugin.getSupportProvider();
-                    if (supportProvider != null) {
-                        filename = supportProvider.getName();
-                    }
-                }
-                SupportPlugin.writeBundle(checkChannel().call(new SaveBundle(filename)), selected);
+                SupportPlugin.writeBundle(checkChannel().call(new SaveBundle(SupportPlugin.getBundleFileName())), selected);
             } finally {
                 SecurityContextHolder.setContext(old);
             }
@@ -107,7 +98,7 @@ public class SupportCommand extends CLICommand {
         }
 
         public OutputStream call() throws IOException {
-            File f = File.createTempFile(filename, ".zip");
+            File f = File.createTempFile(filename, "");
             System.err.println("Creating: " + f);
             return new RemoteOutputStream(new FileOutputStream(f));
         }

--- a/src/main/java/com/cloudbees/jenkins/support/SupportCommand.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportCommand.java
@@ -35,11 +35,13 @@ import org.acegisecurity.context.SecurityContext;
 import org.acegisecurity.context.SecurityContextHolder;
 import org.kohsuke.args4j.Argument;
 
-import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -96,14 +98,9 @@ public class SupportCommand extends CLICommand {
             this.filename = filename;
         }
 
-        public OutputStream call() throws IOException {
-            File f = File.createTempFile(filename, "");
-            System.err.println("Creating: " + f);
-            return new RemoteOutputStream(new FileOutputStream(f));
-        }
         @Override
         public OutputStream call() throws IOException {
-            Path path = Files.createFile(Paths.get(System.getProperty("java.io.tmpDir"), filename));
+            Path path = Files.createFile(Paths.get(System.getProperty("java.io.tmpdir"), filename));
             System.err.println("Creating: " + path);
             return new RemoteOutputStream(new FileOutputStream(path.toFile()));
         }

--- a/src/main/java/com/cloudbees/jenkins/support/SupportLogFormatter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportLogFormatter.java
@@ -28,7 +28,7 @@ package com.cloudbees.jenkins.support;
  * DO NOT INCLUDE ANY NON JDK CLASSES IN HERE.
  * IT CAN DEADLOCK REMOTING - SEE JENKINS-32622
  ***********************************************/
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings; // Acceptable because RetentionPolicy.CLASS
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.text.SimpleDateFormat;

--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -731,10 +731,6 @@ public class SupportPlugin extends Plugin {
                 }
                 try {
                     thread = new Thread(new Runnable() {
-                        @edu.umd.cs.findbugs.annotations.SuppressWarnings(
-                                value = {"RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"},
-                                justification = "Best effort"
-                        )
                         public void run() {
                             nextBundleWrite.set(System.currentTimeMillis() + TimeUnit2.HOURS.toMillis(AUTO_BUNDLE_PERIOD_HOURS));
                             thread.setName(String.format("%s periodic bundle generator: since %s",
@@ -774,6 +770,11 @@ public class SupportPlugin extends Plugin {
             }
         }
 
+        @edu.umd.cs.findbugs.annotations.SuppressWarnings(
+                value = {"RV_RETURN_VALUE_IGNORED_BAD_PRACTICE", "IS2_INCONSISTENT_SYNC"},
+                justification = "RV_RETURN_VALUE_IGNORED_BAD_PRACTICE=Best effort, " +
+                        "IS2_INCONSISTENT_SYNC=only called from an already synchronized method"
+        )
         private void cleanupOldBundles(File bundleDir, File justGenerated) {
             thread.setName(String.format("%s periodic bundle generator: tidying old bundles since %s",
                     SupportPlugin.class.getSimpleName(), new Date()));

--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -780,7 +780,7 @@ public class SupportPlugin extends Plugin {
                     SupportPlugin.class.getSimpleName(), new Date()));
             File[] files = bundleDir.listFiles(new FilenameFilter() {
                 public boolean accept(File dir, String name) {
-                    return name.startsWith(SupportPlugin.getBundlePrefix()) && name.endsWith(".zip");
+                    return name.endsWith(".zip");
                 }
             });
             long pivot = System.currentTimeMillis();

--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -63,7 +63,6 @@ import net.sf.json.JSONObject;
 import org.acegisecurity.Authentication;
 import org.acegisecurity.context.SecurityContext;
 import org.acegisecurity.context.SecurityContextHolder;
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.commons.lang.StringUtils;
 import org.apache.tools.zip.ZipEntry;
 import org.apache.tools.zip.ZipOutputStream;
@@ -88,7 +87,6 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Set;
 import java.util.TimeZone;
@@ -563,6 +561,42 @@ public class SupportPlugin extends Plugin {
         return Collections.emptyList();
     }
 
+    /**
+     * Returns the full bundle name.
+     *
+     * @return the full bundle name.
+     */
+    @NonNull
+    public static String getBundleFileName() {
+        StringBuilder filename = new StringBuilder();
+        filename.append(getBundlePrefix());
+
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd_HH.mm.ss");
+        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+        filename.append("_").append(dateFormat.format(new Date()));
+
+        filename.append(".zip");
+        return filename.toString();
+    }
+
+    /**
+     * Returns the prefix of the bundle name.
+     *
+     * @return the prefix of the bundle name.
+     */
+    private static String getBundlePrefix() {
+        String filename = "support"; // default bundle filename
+        final SupportPlugin instance = getInstance();
+        if (instance != null) {
+            SupportProvider supportProvider = instance.getSupportProvider();
+            if (supportProvider != null) {
+                // let the provider name it
+                filename = supportProvider.getName();
+            }
+        }
+        return filename;
+    }
+
     public static class LogHolder {
         private static final SupportLogHandler SLAVE_LOG_HANDLER = new SupportLogHandler(256, 2048, 8);
     }
@@ -710,12 +744,8 @@ public class SupportPlugin extends Plugin {
                                         return;
                                     }
                                 }
-                                SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd_HH.mm.ss");
-                                dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
 
-                                final String bundlePrefix = "support";
-                                File file = new File(bundleDir,
-                                        bundlePrefix + "_" + dateFormat.format(new Date()) + ".zip");
+                                File file = new File(bundleDir, SupportPlugin.getBundleFileName());
                                 thread.setName(String.format("%s periodic bundle generator: writing %s since %s",
                                         SupportPlugin.class.getSimpleName(), file.getName(), new Date()));
                                 FileOutputStream fos = null;

--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -594,6 +594,10 @@ public class SupportPlugin extends Plugin {
                 filename = supportProvider.getName();
             }
         }
+        final String instanceType = BundleNameInstanceTypeProvider.getInstance().getInstanceType();
+        if (StringUtils.isNotBlank(instanceType)) {
+            filename = filename + "_"+instanceType;
+        }
         return filename;
     }
 

--- a/src/test/java/com/cloudbees/jenkins/support/BundleNamePrefixTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/BundleNamePrefixTest.java
@@ -1,0 +1,71 @@
+package com.cloudbees.jenkins.support;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+
+import javax.annotation.Nonnull;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.hamcrest.core.StringStartsWith.startsWith;
+import static org.junit.Assert.assertThat;
+
+public class BundleNamePrefixTest {
+
+    private static final String CURRENT_YEAR = new SimpleDateFormat("YYYY").format(new Date());
+
+    @Rule
+    public JenkinsRule rule = new JenkinsRule();
+
+    @Test
+    public void checkOriginalBehaviour() throws Exception {
+        assertThat(SupportPlugin.getBundleFileName(), startsWith("support_" + CURRENT_YEAR));
+    }
+
+    @Test
+    public void checkWithOneProvider() throws Exception {
+        assertThat(SupportPlugin.getBundleFileName(), startsWith("support_pouet_" + CURRENT_YEAR));
+    }
+
+    @Test
+    public void tooManyProviders() throws Exception {
+        assertThat(SupportPlugin.getBundleFileName(), startsWith("support_Zis_" + CURRENT_YEAR));
+    }
+
+    @Test
+    public void withSysProp() throws Exception {
+        System.setProperty(BundleNameInstanceTypeProvider.SUPPORT_BUNDLE_NAMING_INSTANCE_SPEC_PROPERTY, "paf");
+        assertThat(SupportPlugin.getBundleFileName(), startsWith("support_paf_" + CURRENT_YEAR));
+        System.getProperties().remove(BundleNameInstanceTypeProvider.SUPPORT_BUNDLE_NAMING_INSTANCE_SPEC_PROPERTY);
+    }
+
+    @TestExtension("checkWithOneProvider")
+    public static class TestProvider extends BundleNameInstanceTypeProvider {
+
+        @Nonnull
+        @Override
+        public String getInstanceType() {
+            return "pouet";
+        }
+    }
+
+    @TestExtension("tooManyProviders")
+    public static class SpuriousProvider1 extends BundleNameInstanceTypeProvider {
+        @Nonnull
+        @Override
+        public String getInstanceType() {
+            return "Zis";
+        }
+    }
+
+    @TestExtension("tooManyProviders")
+    public static class SpuriousProvider2 extends BundleNameInstanceTypeProvider {
+        @Nonnull
+        @Override
+        public String getInstanceType() {
+            return "Zat";
+        }
+    }
+}


### PR DESCRIPTION
[JENKINS-40098](https://issues.jenkins-ci.org/browse/JENKINS-40098)

Refactored the existing code to use the same logic for choosing the bundle filename, and introduced a change enabling both overriding through using a sysprop, or implementing a new Extension Point.

The approach with Extension Points should enable more dynamic needs, when the sysprop one will be immediately usable by anyone without having to develop an extension.

Note: if found, the extension is preferred over the sysprop.

@reviewbybees esp. @jglick who pointed me to SupportProvider.getName() I had missed in the first attempt. 

Supersedes #91