### PR TITLE
Simply ignore if the GC logging options are not enabled

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
@@ -66,17 +66,11 @@ public class GCLogs extends Component {
     }
 
     @Override
-    public boolean isEnabled() {
-        boolean gcLogsConfigured = getGcLogFileLocation() != null;
-        LOGGER.fine("GC logs configured: " + gcLogsConfigured);
-        return super.isEnabled() && gcLogsConfigured;
-    }
-
-    @Override
     public void addContents(@NonNull Container result) {
         LOGGER.fine("Trying to gather GC logs for support bundle");
         String gcLogFileLocation = getGcLogFileLocation();
         if (gcLogFileLocation == null) {
+            LOGGER.config("No GC logging enabled, nothing about it will be retrieved for support bundle.");
             return;
         }
 


### PR DESCRIPTION
@reviewbybees esp. @jglick as you rightly advised for that change in https://github.com/jenkinsci/support-core-plugin/pull/89#issuecomment-264277965

State currently:
![image](https://cloud.githubusercontent.com/assets/223853/20923420/a7c44468-bbac-11e6-808f-df1297b60bf9.png)
