### PR TITLE
Use UTC for all timestamps

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportLogFormatter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportLogFormatter.java
@@ -51,13 +51,12 @@ import java.util.logging.LogRecord;
  */
 public class SupportLogFormatter extends Formatter {
 
-    /** for testing */
-    static TimeZone timeZone;
-    
     private final static ThreadLocal<SimpleDateFormat> threadLocalDateFormat = new ThreadLocal<SimpleDateFormat>() {
         @Override
         protected SimpleDateFormat initialValue() {
-            return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSZ");
+            SimpleDateFormat f = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSZ");
+            f.setTimeZone(TimeZone.getTimeZone("UTC"));
+            return f;
         }
     };
 
@@ -71,9 +70,6 @@ public class SupportLogFormatter extends Formatter {
     public String format(LogRecord record) {
         StringBuilder builder = new StringBuilder();
         SimpleDateFormat format = threadLocalDateFormat.get();
-        if (timeZone != null) {
-            format.setTimeZone(timeZone);
-        }
         builder.append(format.format(new Date(record.getMillis())));
         builder.append(" [id=").append(record.getThreadID()).append("]");
 

--- a/src/main/java/com/cloudbees/jenkins/support/SupportLogHandler.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportLogHandler.java
@@ -78,7 +78,7 @@ public class SupportLogHandler extends Handler {
         this.fileSize = fileSize;
         setFormatter(new SupportLogFormatter());
         dateFormat = new SimpleDateFormat("yyyy-MM-dd_HH.mm.ss");
-        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
     }
 
     public void setDirectory(File directory, String namePrefix) {

--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -294,8 +294,10 @@ public class SupportPlugin extends Plugin {
         manifest.append(bundleName).append('\n');
         manifest.append(StringUtils.repeat("=", bundleName.length())).append('\n');
         manifest.append("\n");
+        SimpleDateFormat f = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSZ");
+        f.setTimeZone(TimeZone.getTimeZone("UTC"));
         manifest.append("Generated on ")
-                .append(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSZ").format(new Date()))
+                .append(f.format(new Date()))
                 .append("\n");
         manifest.append("\n");
         manifest.append("Requested components:\n\n");
@@ -413,6 +415,7 @@ public class SupportPlugin extends Plugin {
     public static void threadDumpStartup() throws Exception {
         if (!logStartupPerformanceIssues) return;
         final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd_HH.mm.ss");
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
         final File f = new File(getRootDirectory(), "/startup-threadDump" + dateFormat.format(new Date())+ ".txt");
         if (!f.exists()) {
             try {
@@ -572,7 +575,7 @@ public class SupportPlugin extends Plugin {
         filename.append(getBundlePrefix());
 
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd_HH.mm.ss");
-        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
         filename.append("_").append(dateFormat.format(new Date()));
 
         filename.append(".zip");

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
@@ -66,6 +66,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.WeakHashMap;
@@ -427,8 +428,10 @@ public class AboutJenkins extends Component {
                 result.append(maj).append(" Process ID: ").append(processId).append(" (0x")
                         .append(Integer.toHexString(processId)).append(")\n");
             }
+            SimpleDateFormat f = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSZ");
+            f.setTimeZone(TimeZone.getTimeZone("UTC"));
             result.append(maj).append(" Process started: ")
-                    .append(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSZ").format(new Date(mBean.getStartTime())))
+                    .append(f.format(new Date(mBean.getStartTime())))
                     .append('\n');
             result.append(maj).append(" Process uptime: ")
                     .append(Util.getTimeSpanString(mBean.getUptime())).append('\n');
@@ -616,6 +619,7 @@ public class AboutJenkins extends Component {
             Map<String,Stats> containerStats = new HashMap<String,Stats>();
             // RunMap.createDirectoryFilter protected, so must do it by hand:
             DateFormat BUILD_FORMAT = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
+            // historically did not use a consistent time zone, so use default
             for (Item i : jenkins.getAllItems()) {
                 String key = i.getClass().getName();
                 Integer cnt = containerCounts.get(key);

--- a/src/main/java/com/cloudbees/jenkins/support/impl/LoadStats.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/LoadStats.java
@@ -191,7 +191,7 @@ public class LoadStats extends Component {
         @Override
         protected void printTo(PrintWriter out) throws IOException {
             SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
-            dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+            dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
 
             out.print("time");
             int maxLen = 0;

--- a/src/main/java/com/cloudbees/jenkins/support/slowrequest/SlowRequestChecker.java
+++ b/src/main/java/com/cloudbees/jenkins/support/slowrequest/SlowRequestChecker.java
@@ -17,6 +17,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -58,6 +59,9 @@ public class SlowRequestChecker extends PeriodicWork {
     final FileListCap logs = new FileListCap(new File(Helper.getActiveInstance().getRootDir(),"slow-requests"), 50);
 
     final SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd-HHmmss.SSS");
+    {
+        format.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
 
     @Override
     public long getRecurrencePeriod() {

--- a/src/main/java/com/cloudbees/jenkins/support/timer/DeadlockTrackChecker.java
+++ b/src/main/java/com/cloudbees/jenkins/support/timer/DeadlockTrackChecker.java
@@ -12,6 +12,7 @@ import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -21,6 +22,9 @@ import java.util.concurrent.TimeUnit;
 public class DeadlockTrackChecker extends PeriodicWork {
 
     final SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd-HHmmss");
+    {
+        format.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
     final FileListCap logs = new FileListCap(new File(Helper.getActiveInstance().getRootDir(),"deadlocks"), 50);
 
     @Override

--- a/src/test/java/com/cloudbees/jenkins/support/SupportLogFormatterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportLogFormatterTest.java
@@ -24,7 +24,6 @@
 
 package com.cloudbees.jenkins.support;
 
-import java.util.TimeZone;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import javax.annotation.CheckForNull;
@@ -33,10 +32,6 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 public class SupportLogFormatterTest {
-
-    static {
-        SupportLogFormatter.timeZone = TimeZone.getTimeZone("UTC");
-    }
 
     @Test
     public void smokes() {


### PR DESCRIPTION
When trying to evaluate a complex support bundle, or series of bundles, perhaps attempting to align different log files to determine the root cause of a single event, possibly crossing machines…it is very tricky to keep track of multiple local timezones plus UTC. This patch just forces the support bundle to use UTC consistently: most importantly, in log timestamps, and in the name of the bundle ZIP itself.

@reviewbybees