### PR TITLE
Add reportID to bundle reports in about.md

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
@@ -65,7 +65,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Random;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.WeakHashMap;
@@ -536,6 +538,8 @@ public class AboutJenkins extends Component {
     }
 
     private static class AboutContent extends PrintedContent {
+        private static final Random RANDOM = new Random(System.currentTimeMillis());
+
         AboutContent() {
             super("about.md");
         }
@@ -543,6 +547,7 @@ public class AboutJenkins extends Component {
             final Jenkins jenkins = Helper.getActiveInstance();
             out.println("Jenkins");
             out.println("=======");
+            out.println("Report ID: " + getReportId());
             out.println();
             out.println("Version details");
             out.println("---------------");
@@ -601,6 +606,14 @@ public class AboutJenkins extends Component {
                     }
                 }
             }
+        }
+
+        private String getReportId() {
+            DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
+            String utcNow = df.format(new Date());
+
+            return Jenkins.getActiveInstance().getLegacyInstanceId() + "-" + utcNow + "-" + RANDOM.nextInt(1000);
         }
     }
 


### PR DESCRIPTION
Can sometimes cause some headache to have a simple way to uniquely refer to a bundle when discussing them.
This change aims to resolve this issue.

Generates `about.md` this way now:

```
Jenkins
=======
Report ID: 824d2ab4d1bb1fba69bee1e2cbd894ce-2017-02-17T09:49:22Z-731
...
```

@reviewbybees 