### PR TITLE
Delete even if write to bundle fails.

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/api/TemporaryFileContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/TemporaryFileContent.java
@@ -56,7 +56,7 @@ public class TemporaryFileContent extends FileContent {
         try {
             Util.deleteFile(f);
         } catch (IOException e) {
-            LOGGER.log(Level.WARNING, "Failed to delete tmp file {0}", f.getAbsolutePath());
+            LOGGER.log(Level.WARNING, "Failed to delete tmp file " + f.getAbsolutePath(), e);
         }
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/api/TemporaryFileContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/TemporaryFileContent.java
@@ -45,8 +45,11 @@ public class TemporaryFileContent extends FileContent {
 
     @Override
     public void writeTo(OutputStream os) throws IOException {
-        super.writeTo(os);
-        delete();
+        try {
+            super.writeTo(os);
+        } finally {
+            delete();
+        }
     }
 
     private void delete() {


### PR DESCRIPTION
If the `writeTo` method fails we still should perform the delete no matter what happens.

@reviewbybees esp. @varmenise 