### PR TITLE
Suppress PeriodicWorkImpl during functional tests

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -38,6 +38,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.FilePath;
+import hudson.Main;
 import hudson.Plugin;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
@@ -723,6 +724,9 @@ public class SupportPlugin extends Plugin {
 
         @Override
         protected synchronized void doRun() throws Exception {
+            if (Main.isUnitTest) {
+                return;
+            }
             final SupportPlugin plugin = getInstance();
             if (plugin == null) {
                 return;


### PR DESCRIPTION
Otherwise, in plugins which depend on this one (like `workflow-cps`), every now and then the bundle generator will start to run while the test is running. Sometimes that is harmless (if a waste of time); sometimes it starts to run while Jenkins is shutting down, resulting in various stupid exceptions and the like being printed to the console. Harmless but confusing.

@reviewbybees