### PR TITLE
Attempt at Fixing the Windows Test Run

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
@@ -101,11 +101,13 @@ public class GCLogs extends Component {
      * @see https://bugs.openjdk.java.net/browse/JDK-7164841
      */
     private void handleRotatedLogs(@Nonnull final String gcLogFileLocation, Container result) {
+        File gcLogFile = new File(gcLogFileLocation);
+
         // always add .* in the end because this is where the numbering is going to happen
-        String regex = gcLogFileLocation.replaceAll("%[pt]", ".*") + ".*";
+        String regex = gcLogFile.getName().replaceAll("%[pt]", ".*") + ".*";
         final Pattern gcLogFilesPattern = Pattern.compile(regex);
 
-        File parentDirectory = new File(gcLogFileLocation).getParentFile();
+        File parentDirectory = gcLogFile.getParentFile();
 
         if (parentDirectory == null || !parentDirectory.exists()) {
             LOGGER.warning("[Support Bundle] " + parentDirectory + " does not exist, cannot collect gc logging files.");
@@ -115,7 +117,7 @@ public class GCLogs extends Component {
         File[] gcLogs = parentDirectory.listFiles(new FilenameFilter() {
             @Override
             public boolean accept(File dir, String name) {
-                return gcLogFilesPattern.matcher(dir + "/" + name).matches();
+                return gcLogFilesPattern.matcher(name).matches();
             }
         });
         if (gcLogs == null || gcLogs.length == 0) {

--- a/src/test/java/com/cloudbees/jenkins/support/SupportLogFormatterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportLogFormatterTest.java
@@ -29,6 +29,8 @@ import java.util.logging.LogRecord;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
 import static org.junit.Assert.*;
 
 public class SupportLogFormatterTest {
@@ -61,7 +63,7 @@ public class SupportLogFormatterTest {
         lr.setSourceClassName("some.pkg.Catcher");
         lr.setSourceMethodName("robust");
         lr.setMillis(0);
-        assertEquals(expected, new SupportLogFormatter().format(lr));
+        assertThat(new SupportLogFormatter().format(lr), equalToIgnoringWhiteSpace(expected));
     }
 
     private static class PhonyException extends Throwable {

--- a/src/test/java/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponentTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponentTest.java
@@ -10,7 +10,9 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.File;
 
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 /**
  * Created by valentina on 28/10/16.
@@ -88,7 +90,7 @@ public class OtherConfigFilesComponentTest {
         File file = File.createTempFile("test", ".xml");
         FileUtils.writeStringToFile(file, xml);
         String patchedXml = SecretHandler.findSecrets(file);
-        assertEquals(expectedXml, patchedXml);
+        assertThat(patchedXml, equalToIgnoringWhiteSpace(expectedXml));
     }
 }
 


### PR DESCRIPTION
- [x] [Plugins/support-core-plugin/master #2 test - smokes [Jenkins]](https://ci.jenkins.io/job/Plugins/job/support-core-plugin/job/master/2/testReport/com.cloudbees.jenkins.support/SupportLogFormatterTest/smokes/)
- [x] [Plugins/support-core-plugin/master #2 test - shouldPutAPlaceHolderInsteadOfSecret [Jenkins]](https://ci.jenkins.io/job/Plugins/job/support-core-plugin/job/master/2/testReport/com.cloudbees.jenkins.support.configfiles/OtherConfigFilesComponentTest/shouldPutAPlaceHolderInsteadOfSecret/)

The contents of actual and expected value are still equal except for the windows line endings in the actual value which results in assertion error. 

Need an advice on how to better fix this. At the moment, I just used a Hamcrest matcher that ignores the whitespaces.

- [x] [Plugins/support-core-plugin/master #2 test - rotatedFiles [Jenkins]](https://ci.jenkins.io/job/Plugins/job/support-core-plugin/job/master/2/testReport/com.cloudbees.jenkins.support.impl/GCLogsTest/rotatedFiles/)

This seems to have identified Windows compatibility defect in the GCLogs collector. The full path of the file was used to form a RegEx pattern. Due to path separator difference, the logic fails on Windows but works fine on Linux, i.e. `\` is an escape character in RegEx so windows path causes a compilation error.

@reviewbybees 