### PR TITLE
[JENKINS-22791] Record heap histograms

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/HeapHisto.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/HeapHisto.java
@@ -75,7 +75,7 @@ public class HeapHisto extends Component {
             final StringBuilder bos = new StringBuilder();
 
             bos.append("Master Heap Histogram -histo:live");
-            for (int i=1; i<limit; i++) {
+            for (int i=0; i<limit; i++) {
                 bos.append(lines[i]).append('\n');
             }
 
@@ -91,7 +91,7 @@ public class HeapHisto extends Component {
         private String getRawLiveHistogram() {
             String result;
             try {
-                ObjectName objName = new ObjectName("com.sun.management:type=DiagnosticCommand");;
+                ObjectName objName = new ObjectName("com.sun.management:type=DiagnosticCommand");
                 result = (String) ManagementFactory.getPlatformMBeanServer().invoke(objName, "gcClassHistogram", new Object[] {null}, new String[]{String[].class.getName()});
             }
             catch (InstanceNotFoundException | ReflectionException | MBeanException | MalformedObjectNameException e) {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/HeapHisto.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/HeapHisto.java
@@ -29,7 +29,7 @@ import java.util.logging.Logger;
 @Extension
 public class HeapHisto extends Component {
     private static final int OFFSET = 3;
-    private static final int MAX = 500 + OFFSET;
+    private static final int MAX = 200 + OFFSET;
 
     private static final Logger logger = Logger.getLogger(HeapHisto.class.getName());
     private final WeakHashMap<Node, String> heapHistoCache = new WeakHashMap<Node, String>();

--- a/src/main/java/com/cloudbees/jenkins/support/impl/HeapHisto.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/HeapHisto.java
@@ -11,9 +11,12 @@ import hudson.remoting.Callable;
 import hudson.security.Permission;
 import jenkins.model.Jenkins;
 import org.jenkinsci.remoting.RoleChecker;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanException;
+import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 import javax.management.ReflectionException;
@@ -26,7 +29,11 @@ import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * Heap histogram from master node.
+ */
 @Extension
+@Restricted(NoExternalUse.class)
 public class HeapHisto extends Component {
     private static final int OFFSET = 3;
     private static final int MAX = 200 + OFFSET;
@@ -43,7 +50,7 @@ public class HeapHisto extends Component {
     @NonNull
     @Override
     public String getDisplayName() {
-        return "Master Heap Histogram -histo:live";
+        return "Master Heap Histogram";
     }
 
     @Override
@@ -74,7 +81,7 @@ public class HeapHisto extends Component {
 
             final StringBuilder bos = new StringBuilder();
 
-            bos.append("Master Heap Histogram -histo:live");
+            bos.append("Master Heap Histogram");
             for (int i=0; i<limit; i++) {
                 bos.append(lines[i]).append('\n');
             }
@@ -92,11 +99,15 @@ public class HeapHisto extends Component {
             String result;
             try {
                 ObjectName objName = new ObjectName("com.sun.management:type=DiagnosticCommand");
-                result = (String) ManagementFactory.getPlatformMBeanServer().invoke(objName, "gcClassHistogram", new Object[] {null}, new String[]{String[].class.getName()});
+                MBeanServer platform = ManagementFactory.getPlatformMBeanServer();
+                if (platform == null) {
+                    return "N/A";
+                }
+                result = (String) platform.invoke(objName, "gcClassHistogram", new Object[] {null}, new String[]{String[].class.getName()});
             }
             catch (InstanceNotFoundException | ReflectionException | MBeanException | MalformedObjectNameException e) {
                 logger.log(Level.WARNING,"Could not record heap live histogram.", e);
-                result = "NA";
+                result = "N/A";
             }
             return result;
         }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/HeapHisto.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/HeapHisto.java
@@ -1,0 +1,104 @@
+package com.cloudbees.jenkins.support.impl;
+
+import com.cloudbees.jenkins.support.AsyncResultCache;
+import com.cloudbees.jenkins.support.api.Component;
+import com.cloudbees.jenkins.support.api.Container;
+import com.cloudbees.jenkins.support.api.Content;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.Node;
+import hudson.remoting.Callable;
+import hudson.security.Permission;
+import jenkins.model.Jenkins;
+import org.jenkinsci.remoting.RoleChecker;
+
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.management.ManagementFactory;
+import java.util.Collections;
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Extension
+public class HeapHisto extends Component {
+    private static final int OFFSET = 3;
+    private static final int MAX = 500 + OFFSET;
+
+    private static final Logger logger = Logger.getLogger(HeapHisto.class.getName());
+    private final WeakHashMap<Node, String> heapHistoCache = new WeakHashMap<Node, String>();
+
+    @NonNull
+    @Override
+    public Set<Permission> getRequiredPermissions() {
+        return Collections.singleton(Jenkins.ADMINISTER);
+    }
+
+    @NonNull
+    @Override
+    public String getDisplayName() {
+        return "Master Heap Histogram -histo:live";
+    }
+
+    @Override
+    public void addContents(@NonNull Container result) {
+        result.add(
+            new Content("nodes/master/heap-histogram.txt") {
+                @Override
+                public void writeTo(OutputStream os) throws IOException {
+                    os.write(getLiveHistogram(Jenkins.getInstance()).getBytes("UTF-8"));
+                }
+            }
+        );
+    }
+
+    private String getLiveHistogram(Node node) throws IOException {
+        return AsyncResultCache.get(node,
+                heapHistoCache,
+                new GetLiveHeapHistogram(),
+                "heap histogram",
+                "N/A: No connection to node, or no cache.");
+    }
+
+    private static final class GetLiveHeapHistogram implements Callable<String, RuntimeException> {
+        public String call() {
+            final String raw = getRawLiveHistogram();
+            final String[] lines = raw.split("\n");
+            final int limit = MAX <= lines.length ? MAX : lines.length;
+
+            final StringBuilder bos = new StringBuilder();
+
+            bos.append("Master Heap Histogram -histo:live");
+            for (int i=1; i<limit; i++) {
+                bos.append(lines[i]).append('\n');
+            }
+
+            return bos.toString();
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public void checkRoles(RoleChecker checker) throws SecurityException {
+            // TODO: do we have to verify some role?
+        }
+
+        private String getRawLiveHistogram() {
+            String result;
+            try {
+                ObjectName objName = new ObjectName("com.sun.management:type=DiagnosticCommand");;
+                result = (String) ManagementFactory.getPlatformMBeanServer().invoke(objName, "gcClassHistogram", new Object[] {null}, new String[]{String[].class.getName()});
+            }
+            catch (InstanceNotFoundException | ReflectionException | MBeanException | MalformedObjectNameException e) {
+                logger.log(Level.WARNING,"Could not record heap live histogram.", e);
+                result = "NA";
+            }
+            return result;
+        }
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/support/impl/HeapUsageHistogram.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/HeapUsageHistogram.java
@@ -34,11 +34,11 @@ import java.util.logging.Logger;
  */
 @Extension
 @Restricted(NoExternalUse.class)
-public class HeapHisto extends Component {
+public class HeapUsageHistogram extends Component {
     private static final int OFFSET = 3;
     private static final int MAX = 200 + OFFSET;
 
-    private static final Logger logger = Logger.getLogger(HeapHisto.class.getName());
+    private static final Logger logger = Logger.getLogger(HeapUsageHistogram.class.getName());
     private final WeakHashMap<Node, String> heapHistoCache = new WeakHashMap<Node, String>();
 
     @NonNull

--- a/src/main/java/com/cloudbees/jenkins/support/impl/HeapUsageHistogram.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/HeapUsageHistogram.java
@@ -58,21 +58,20 @@ public class HeapUsageHistogram extends Component {
             new Content("nodes/master/heap-histogram.txt") {
                 @Override
                 public void writeTo(OutputStream os) throws IOException {
-                    os.write(getLiveHistogram(Jenkins.getInstance()).getBytes("UTF-8"));
+                    os.write(getLiveHistogram().getBytes("UTF-8"));
                 }
             }
         );
     }
 
-    private String getLiveHistogram(Node node) throws IOException {
+    private String getLiveHistogram() throws IOException {
         final String raw = getRawLiveHistogram();
         final String[] lines = raw.split("\n");
         final int limit = MAX <= lines.length ? MAX : lines.length;
 
         final StringBuilder bos = new StringBuilder();
-
-        bos.append("Master Heap Histogram");
-        for (int i=0; i<limit; i++) {
+        //starting in 1 because of an empty line
+        for (int i=1; i<limit; i++) {
             bos.append(lines[i]).append('\n');
         }
 


### PR DESCRIPTION
Added heap histogram generation component using _com.sun.management:type=DiagnosticCommand_ object and _GC.class_histogram_ command.

Only for master instance currently, the new component generates nodes/master/heap-histogram.txt file. Can be disabled with the option _Master Heap Histogram -histo:live_ 

please @reviewbybees