### PR TITLE
[FIXED JENKINS-47779] Could not attach 'plugins/active.txt' to support bundle

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
@@ -583,8 +583,7 @@ public class AboutJenkins extends Component {
             out.println("Active Plugins");
             out.println("--------------");
             out.println();
-            PluginManager pluginManager = jenkins.getPluginManager();
-            Iterable<PluginWrapper> plugins = getSorted(pluginManager.getPlugins());
+            Iterable<PluginWrapper> plugins = getPluginsSorted();
             for (PluginWrapper w : plugins) {
                 if (w.isActive()) {
                     out.println("  * " + w.getShortName() + ":" + w.getVersion() + (w.hasUpdate()
@@ -704,8 +703,7 @@ public class AboutJenkins extends Component {
 
         @Override
         protected void printTo(PrintWriter out) throws IOException {
-            PluginManager pluginManager = Helper.getActiveInstance().getPluginManager();
-            Iterable<PluginWrapper> plugins = getSorted(pluginManager.getPlugins());
+            Iterable<PluginWrapper> plugins = getPluginsSorted();
             for (PluginWrapper w : plugins) {
                 if (w.isActive()) {
                     out.println(w.getShortName() + ":" + w.getVersion() + ":" + (w.isPinned() ? "pinned" : "not-pinned"));
@@ -721,8 +719,7 @@ public class AboutJenkins extends Component {
 
         @Override
         protected void printTo(PrintWriter out) throws IOException {
-            PluginManager pluginManager = Helper.getActiveInstance().getPluginManager();
-            Iterable<PluginWrapper> plugins = getSorted(pluginManager.getPlugins());
+            Iterable<PluginWrapper> plugins = getPluginsSorted();
             for (PluginWrapper w : plugins) {
                 if (!w.isActive()) {
                     out.println(w.getShortName() + ":" + w.getVersion() + ":" + (w.isPinned() ? "pinned" : "not-pinned"));
@@ -769,7 +766,7 @@ public class AboutJenkins extends Component {
 
             out.println("RUN mkdir -p /usr/share/jenkins/ref/plugins/");
 
-            Iterable<PluginWrapper> plugins = getSorted(pluginManager.getPlugins());
+            Iterable<PluginWrapper> plugins = getPluginsSorted(pluginManager);
 
             List<PluginWrapper> activated = new ArrayList<PluginWrapper>();
             List<PluginWrapper> disabled = new ArrayList<PluginWrapper>();
@@ -1010,11 +1007,20 @@ public class AboutJenkins extends Component {
     /**
      * Fixes JENKINS-47779 caused by JENKINS-47713
      * Not using SortedSet because of PluginWrapper doesn't implements equals and hashCode.
-     * @param list original list, probably an unmodifiableList
-     * @return new copy of the list sorted
+     * @return new copy of the PluginManager.getPlugins sorted
      */
-    private static Iterable<PluginWrapper> getSorted(List<PluginWrapper> list) {
-        final List<PluginWrapper> sorted = new LinkedList<PluginWrapper>(list);
+    private static Iterable<PluginWrapper> getPluginsSorted() {
+        PluginManager pluginManager = Helper.getActiveInstance().getPluginManager();
+        return getPluginsSorted(pluginManager);
+    }
+
+    private static Iterable<PluginWrapper> getPluginsSorted(PluginManager pluginManager) {
+        return listToSortedIterable(pluginManager.getPlugins());
+    }
+
+
+    private static <T extends Comparable<T>> Iterable<T> listToSortedIterable(List<T> list) {
+        final List<T> sorted = new LinkedList<T>(list);
         Collections.sort(sorted);
         return sorted;
     }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
@@ -62,6 +62,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -583,8 +584,7 @@ public class AboutJenkins extends Component {
             out.println("--------------");
             out.println();
             PluginManager pluginManager = jenkins.getPluginManager();
-            List<PluginWrapper> plugins = new ArrayList<PluginWrapper>(pluginManager.getPlugins());
-            Collections.sort(plugins);
+            Iterable<PluginWrapper> plugins = getSorted(pluginManager.getPlugins());
             for (PluginWrapper w : plugins) {
                 if (w.isActive()) {
                     out.println("  * " + w.getShortName() + ":" + w.getVersion() + (w.hasUpdate()
@@ -705,8 +705,7 @@ public class AboutJenkins extends Component {
         @Override
         protected void printTo(PrintWriter out) throws IOException {
             PluginManager pluginManager = Helper.getActiveInstance().getPluginManager();
-            List<PluginWrapper> plugins = pluginManager.getPlugins();
-            Collections.sort(plugins);
+            Iterable<PluginWrapper> plugins = getSorted(pluginManager.getPlugins());
             for (PluginWrapper w : plugins) {
                 if (w.isActive()) {
                     out.println(w.getShortName() + ":" + w.getVersion() + ":" + (w.isPinned() ? "pinned" : "not-pinned"));
@@ -723,8 +722,7 @@ public class AboutJenkins extends Component {
         @Override
         protected void printTo(PrintWriter out) throws IOException {
             PluginManager pluginManager = Helper.getActiveInstance().getPluginManager();
-            List<PluginWrapper> plugins = pluginManager.getPlugins();
-            Collections.sort(plugins);
+            Iterable<PluginWrapper> plugins = getSorted(pluginManager.getPlugins());
             for (PluginWrapper w : plugins) {
                 if (!w.isActive()) {
                     out.println(w.getShortName() + ":" + w.getVersion() + ":" + (w.isPinned() ? "pinned" : "not-pinned"));
@@ -771,8 +769,7 @@ public class AboutJenkins extends Component {
 
             out.println("RUN mkdir -p /usr/share/jenkins/ref/plugins/");
 
-            List<PluginWrapper> plugins = pluginManager.getPlugins();
-            Collections.sort(plugins);
+            Iterable<PluginWrapper> plugins = getSorted(pluginManager.getPlugins());
 
             List<PluginWrapper> activated = new ArrayList<PluginWrapper>();
             List<PluginWrapper> disabled = new ArrayList<PluginWrapper>();
@@ -1010,4 +1007,15 @@ public class AboutJenkins extends Component {
         }
     }
 
+    /**
+     * Fixes JENKINS-47779 caused by JENKINS-47713
+     * Not using SortedSet because of PluginWrapper doesn't implements equals and hashCode.
+     * @param list original list, probably an unmodifiableList
+     * @return new copy of the list sorted
+     */
+    private static Iterable<PluginWrapper> getSorted(List<PluginWrapper> list) {
+        final List<PluginWrapper> sorted = new LinkedList<PluginWrapper>(list);
+        Collections.sort(sorted);
+        return sorted;
+    }
 }


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-47779

Since Jenkins 2.86, pluginManager is returning an unmodifiable list each time getPlugins is called. 

Support core plugin was sorting the list by using Collections.sort thus currently is throwing UnsupportedOperationException.

Please, @reviewbybees @christ66 @andresrc @oleg-nenashev 