### PR TITLE
Fixing a ClassCastException

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/ThreadDumps.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/ThreadDumps.java
@@ -36,7 +36,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
@@ -87,8 +86,7 @@ public class ThreadDumps extends Component {
                         } catch (ExecutionException | InterruptedException x) {
                             logger.log(Level.WARNING, null, x);
                         } catch (TimeoutException x) {
-                            ScheduledThreadPoolExecutor timer = (ScheduledThreadPoolExecutor) Timer.get();
-                            out.println("*WARNING*: jenkins.util.Timer is unresponsive; pool size " + timer.getPoolSize() + " vs. active count " + timer.getActiveCount());
+                            out.println("*WARNING*: jenkins.util.Timer is unresponsive");
                         }
                         try {
                             threadDump(os);


### PR DESCRIPTION
Seems that diagnostics in #100 cause an error as of https://github.com/jenkinsci/jenkins/pull/2792; observed in a support bundle a `manifest/errors.txt`:

```
Could not attach 'nodes/master/thread-dump.txt' to support bundle
-----------------------------------------------------------------------

java.lang.ClassCastException: jenkins.security.ImpersonatingScheduledExecutorService cannot be cast to java.util.concurrent.ScheduledThreadPoolExecutor
	at com.cloudbees.jenkins.support.impl.ThreadDumps$1.writeTo(ThreadDumps.java:90)
	at com.cloudbees.jenkins.support.SupportPlugin.writeBundle(SupportPlugin.java:359)
	at com.cloudbees.jenkins.support.SupportPlugin.writeBundle(SupportPlugin.java:273)
	at com.cloudbees.jenkins.support.SupportPlugin$PeriodicWorkImpl$1.run(SupportPlugin.java:761)
	at java.lang.Thread.run(Thread.java:745)
```

@reviewbybees