### PR TITLE
Sort thread dumps by name rather than ID

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/ThreadDumps.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/ThreadDumps.java
@@ -29,7 +29,9 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.MonitorInfo;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -240,8 +242,14 @@ public class ThreadDumps extends Component {
             threads = new ThreadInfo[0];
         }
 
-        for (int ti = threads.length - 1; ti >= 0; ti--) {
-            printThreadInfo(writer, threads[ti], mbean);
+        Arrays.sort(threads, new Comparator<ThreadInfo>() {
+            @Override
+            public int compare(ThreadInfo t1, ThreadInfo t2) {
+                return t1.getThreadName().compareTo(t2.getThreadName());
+            }
+        });
+        for (ThreadInfo t : threads) {
+            printThreadInfo(writer, t, mbean);
         }
 
         // Print any information about deadlocks.


### PR DESCRIPTION
Otherwise it is cumbersome to find threads of a particular kind, like all `Executor`s. The ID is still recorded in the file; this just changes the display order to something I think will be more helpful for humans.

@reviewbybees