### PR TITLE
[FIXED JENKINS-49931] Heap Histogram Collection Destabilizes Masters

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/HeapUsageHistogram.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/HeapUsageHistogram.java
@@ -33,6 +33,10 @@ public class HeapUsageHistogram extends Component {
     // first 200 classes so 203 lines required because of the header
     private static final int MAX = 203;
 
+    // disabled by default because of JENKINS-49931
+    // to be reviewed in the future.
+    private static /*final*/ boolean DISABLED = Boolean.parseBoolean(System.getProperty(HeapUsageHistogram.class.getCanonicalName() + ".DISABLED", "true"));
+
     private static final Logger logger = Logger.getLogger(HeapUsageHistogram.class.getName());
 
     @NonNull
@@ -46,6 +50,12 @@ public class HeapUsageHistogram extends Component {
     public String getDisplayName() {
         return "Master Heap Histogram";
     }
+
+    @Override
+    public boolean isSelectedByDefault() {
+        return false;
+    }
+
 
     @Override
     public void addContents(@NonNull Container result) {
@@ -74,6 +84,15 @@ public class HeapUsageHistogram extends Component {
     }
 
     private String getRawLiveHistogram() {
+        if (DISABLED) {
+            return new StringBuilder().append('\n')
+                    .append("Histogram generation is disabled. If you want to enable it, do either:")
+                    .append('\n')
+                    .append("* Add the system property: -Dcom.cloudbees.jenkins.support.impl.HeapUsageHistogram.DISABLED=false")
+                    .append('\n')
+                    .append("* Run from Script Console the line: com.cloudbees.jenkins.support.impl.HeapUsageHistogram.DISABLED=false")
+                    .toString();
+        }
         String result;
         try {
             ObjectName objName = new ObjectName("com.sun.management:type=DiagnosticCommand");


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-49931

@svanoort @reviewbybees please review.

Now the histogram is disabled by default, thus you will need to enable it either adding a system property _-Dcom.cloudbees.jenkins.support.impl.HeapUsageHistogram.DISABLED=false_ or running  from Script Console the line _com.cloudbees.jenkins.support.impl.HeapUsageHistogram.DISABLED=false_

Yes, the system property and the direct assignment have the same path/name.

