### PR TITLE
JENKINS-49668 - Root CAs component is fixed.

### DIFF
--- a/src/test/java/com/cloudbees/jenkins/support/impl/RootCAsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/RootCAsTest.java
@@ -1,0 +1,21 @@
+package com.cloudbees.jenkins.support.impl;
+
+import org.junit.Test;
+
+import java.io.StringWriter;
+
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
+
+public class RootCAsTest {
+
+    @Test
+    public void getRootCAList() {
+        final StringWriter certsWriter = new StringWriter();
+        RootCAs.getRootCAList(certsWriter);
+        final String rootCAs = certsWriter.toString();
+
+        assertThat("output doesn't start with the Exception",
+                rootCAs, startsWith("===== Trust Manager 0 =====\n"));
+    }
+}


### PR DESCRIPTION
Links below provide some explanation example as to how to get the actual
trust store for inspection. They were used to replace the current broken
code which simply tries to enumerate empty KeyStore.

https://github.com/jenkinsci/jenkins-scripts/pull/82/files
https://stackoverflow.com/questions/8884831/listing-certificates-in-jvm-trust-store