### PR TITLE
[JENKINS-30468] Add API for item-specific components

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/api/ItemComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/ItemComponent.java
@@ -1,0 +1,85 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cloudbees.jenkins.support.api;
+
+import hudson.model.Describable;
+import hudson.model.Item;
+import hudson.model.TopLevelItem;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import jenkins.model.Jenkins;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Represents a component of a support bundle that is associated with a particular
+ * {@link TopLevelItem} in Jenkins.
+ * 
+ * These components are only available when using the support link in the side panel
+ * of a specific {@link TopLevelItem}.
+ */
+public abstract class ItemComponent extends Component implements Describable<ItemComponent> {
+
+    private TopLevelItem item;
+    
+    /**
+     * All subclasses must have a constructor annotated with {@link DataBoundConstructor}.
+     */
+    public ItemComponent() {   
+    }
+
+    public TopLevelItem getItem() {
+        return item;
+    }
+
+    /**
+     * Get the item associated with this component and cast it to a particular type.
+     * Useful for subclasses who restrict the kind of items that the component applies
+     * to in their descriptor's {@link ItemComponentDescriptor#isApplicable} method.
+     */
+    public <T extends Item> T getItem(Class<T> clazz) {
+        return clazz.cast(item);
+    }
+
+    public void setItem(TopLevelItem item) {
+        this.item = item;
+    }
+
+    @Override
+    public ItemComponentDescriptor getDescriptor() {
+        return (ItemComponentDescriptor) Jenkins.get().getDescriptorOrDie(getClass());
+    }
+    
+    @Override
+    public String getDisplayName() {
+        return getDescriptor().getDisplayName();
+    }
+
+    /**
+     * @return the preferred root output destination for all support bundle components for this item. 
+     */
+    public Path getItemRootDestination() {
+        return Paths.get("items", item.getFullName());
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/support/api/ItemComponentDescriptor.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/ItemComponentDescriptor.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cloudbees.jenkins.support.api;
+
+import hudson.ExtensionList;
+import hudson.model.Descriptor;
+import hudson.model.DescriptorVisibilityFilter;
+import hudson.model.TopLevelItem;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Base class for {#link Descriptor}s of {@link ItemComponent}.
+ */
+public abstract class ItemComponentDescriptor extends Descriptor<ItemComponent> {
+
+    /**
+     * @return A description of the content that the associated {@link ItemComponent}
+     *         will add to the support bundle
+     */
+    @Override
+    public abstract String getDisplayName();
+
+    /**
+     * Used to decide whether this descriptor applies to a given {@link TopLevelItem}.
+     * @param item The {@link TopLevelItem} the descriptor would be associated with
+     * @return true if the descriptor is applicable to the item, otherwise false.
+     */
+    public abstract boolean isApplicable(TopLevelItem item);
+
+    /**
+     * Get all registered {@link ItemComponentDescriptor}s that apply to the given {@link TopLevelItem}. 
+     * Filters based on {@link ItemComponentDescriptor#isApplicable} and {@link DescriptorVisibilityFilter}.
+     * @param item the {@link TopLevelItem} that will be used to filter the descriptors
+     * @return the relevant {@link ItemComponentDescriptor}s for the given item
+     */
+    public static List<ItemComponentDescriptor> getDescriptors(TopLevelItem item) {
+        return DescriptorVisibilityFilter
+                .apply(item, ExtensionList.lookup(ItemComponentDescriptor.class))
+                .stream()
+                .filter(d -> d.isApplicable(item))
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/cloudbees/jenkins/support/configfiles/ItemConfigComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/configfiles/ItemConfigComponent.java
@@ -1,0 +1,78 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cloudbees.jenkins.support.configfiles;
+
+import com.cloudbees.jenkins.support.api.Container;
+import com.cloudbees.jenkins.support.api.ItemComponent;
+import com.cloudbees.jenkins.support.api.ItemComponentDescriptor;
+import hudson.Extension;
+import hudson.model.AbstractItem;
+import hudson.model.TopLevelItem;
+import hudson.security.Permission;
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Set;
+import jenkins.model.Jenkins;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * {@link ItemComponent} that adds config.xml of the associated item to the bundle.
+ */
+public class ItemConfigComponent extends ItemComponent {
+
+    @DataBoundConstructor
+    public ItemConfigComponent() {
+    }
+
+    @Override
+    public Set<Permission> getRequiredPermissions() {
+        return Collections.singleton(Jenkins.ADMINISTER);
+    }
+
+    @Override
+    public void addContents(Container container) {
+        AbstractItem item = getItem(AbstractItem.class);
+        File configFile = item.getConfigFile().getFile();
+        if (configFile.exists()) {
+            Path destinationPath = getItemRootDestination().resolve("config.xml");
+            container.add(new XmlRedactedSecretFileContent(destinationPath.toString(), configFile));
+        }
+    }
+
+    @Extension
+    public static class DescriptorImpl extends ItemComponentDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "Item configuration file (Encrypted secrets are redacted)";
+        }
+
+        @Override
+        public boolean isApplicable(TopLevelItem item) {
+            return item instanceof AbstractItem;
+        }
+    }
+
+}

--- a/src/main/java/com/cloudbees/jenkins/support/configfiles/JobRecentBuildDataComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/configfiles/JobRecentBuildDataComponent.java
@@ -1,0 +1,132 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cloudbees.jenkins.support.configfiles;
+
+import com.cloudbees.jenkins.support.api.Container;
+import com.cloudbees.jenkins.support.api.FileContent;
+import com.cloudbees.jenkins.support.api.ItemComponent;
+import com.cloudbees.jenkins.support.api.ItemComponentDescriptor;
+import hudson.Extension;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.model.TopLevelItem;
+import hudson.security.Permission;
+import hudson.util.DirScanner;
+import hudson.util.FileVisitor;
+import hudson.util.FormValidation;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Set;
+import jenkins.model.Jenkins;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
+/**
+ * {@link ItemComponent} that adds the build folder for a specified number of
+ * recent builds of the associated item to the support bundle.
+ */
+@Restricted(NoExternalUse.class)
+public class JobRecentBuildDataComponent extends ItemComponent {
+
+    private int recentBuildsToInclude = 1;
+
+    @DataBoundConstructor
+    public JobRecentBuildDataComponent() {
+    }
+
+    public int getRecentBuildsToInclude() {
+        return recentBuildsToInclude;
+    }
+
+    @DataBoundSetter
+    public void setRecentBuildsToInclude(int recentBuildsToInclude) {
+        this.recentBuildsToInclude = Math.max(recentBuildsToInclude, 1);
+    }
+
+    @Override
+    public Set<Permission> getRequiredPermissions() {
+        return Collections.singleton(Jenkins.ADMINISTER);
+    }
+
+    @Override
+    public void addContents(Container container) {
+        Job job = getItem(Job.class);
+        Run run = job.getLastBuild();
+        for (int i = 0; run != null && i < recentBuildsToInclude; i++, run = run.getPreviousBuild()) {
+            final Path outputDir = getItemRootDestination().resolve("builds");
+            try {
+                new DirScanner.Full().scan(run.getRootDir(), new FileVisitor() {
+                    @Override
+                    public void visit(File file, String relativePath) throws IOException {
+                        if (file.isFile()) {
+                            Path bundlePath = outputDir.resolve(relativePath);
+                            if (file.getName().endsWith(".xml")) {
+                                container.add(new XmlRedactedSecretFileContent(bundlePath.toString(), file));
+                            } else {
+                                container.add(new FileContent(bundlePath.toString(), file));
+                            }
+                        }
+                    }
+                    @Override
+                    public boolean understandsSymlink() {
+                       return true;
+                    }
+                    @Override
+                    public void visitSymlink(File link, String target, String relativePath) throws IOException {
+                        // Ignore symlinks
+                    }
+                });
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @Extension
+    public static class DescriptorImpl extends ItemComponentDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "Recent build data files and logs (Encrypted secrets are redacted from XML files)";
+        }
+
+        @Override
+        public boolean isApplicable(TopLevelItem item) {
+            return item instanceof Job;
+        }
+
+        public FormValidation doCheckRecentBuildsToInlcude(@QueryParameter int recentBuildsToInclude) {
+            if (recentBuildsToInclude <= 0) {
+                return FormValidation.error("Must be a positive number");
+            }
+            return FormValidation.ok();
+        }
+    }
+
+}

--- a/src/main/java/com/cloudbees/jenkins/support/configfiles/JobRecentBuildDataComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/configfiles/JobRecentBuildDataComponent.java
@@ -121,7 +121,7 @@ public class JobRecentBuildDataComponent extends ItemComponent {
             return item instanceof Job;
         }
 
-        public FormValidation doCheckRecentBuildsToInlcude(@QueryParameter int recentBuildsToInclude) {
+        public FormValidation doCheckRecentBuildsToInclude(@QueryParameter int recentBuildsToInclude) {
             if (recentBuildsToInclude <= 0) {
                 return FormValidation.error("Must be a positive number");
             }

--- a/src/main/resources/com/cloudbees/jenkins/support/SupportAction/index.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/support/SupportAction/index.jelly
@@ -37,7 +37,18 @@
       <p>
         ${%detail}
       </p>
+      <j:set var="descriptor" value="${it.descriptor}"/>
       <f:form name="bundle-contents" method="POST" action="generateAllBundles">
+        <j:if test="${it.item != null}">
+          <f:section title="Item-Specific Components">
+            <f:entry title="">
+              <f:hetero-list name="itemComponents" addCaption="${%Add Component}"
+                             oneEach="true" hasHeader="true" targetType="${com.cloudbees.jenkins.support.api.ItemComponent.class}"
+                             items="${it.itemComponents}" descriptors="${descriptor.getItemComponentsDescriptors(it.item)}"/>
+            </f:entry>
+          </f:section>
+        </j:if>
+        <f:section title="Global Components">
         <j:forEach var="component" items="${it.components}">
           <f:entry field="component">
             <div name="components">
@@ -58,6 +69,7 @@
             </div>
           </f:entry>
         </j:forEach>
+        </f:section>
         <f:entry>
           <f:submit value="${%Generate Bundle}"/>
         </f:entry>

--- a/src/main/resources/com/cloudbees/jenkins/support/configfiles/JobRecentBuildDataComponent/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/support/configfiles/JobRecentBuildDataComponent/config.jelly
@@ -1,0 +1,30 @@
+<!--
+The MIT License
+
+Copyright 2018 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="${%Number of recent builds to include}">
+        <f:number field="recentBuildsToInclude" value="1"/>
+    </f:entry>
+</j:jelly>

--- a/src/test/java/com/cloudbees/jenkins/support/configfiles/ItemConfigComponentTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/configfiles/ItemConfigComponentTest.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.support.configfiles;
+
+import com.cloudbees.jenkins.support.util.TestContainer;
+import com.cloudbees.jenkins.support.api.ItemComponentDescriptor;
+import hudson.model.AbstractItem;
+import hudson.model.FreeStyleProject;
+import hudson.model.TopLevelItem;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockFolder;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+public class ItemConfigComponentTest {
+
+    private static final String DESCRIPTION = "test-description";
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void generateForJob() throws Exception {
+        FreeStyleProject job = r.createFreeStyleProject("job1");
+        job.setDescription(DESCRIPTION);
+        assertThat(generateContentsForItem(job), hasItem(containsString("<description>"+ DESCRIPTION)));
+    }
+
+    @Test
+    public void generateForFolder() throws Exception {
+        MockFolder job = r.createFolder("folder1");
+        job.setDescription(DESCRIPTION);
+        assertThat(generateContentsForItem(job), hasItem(containsString("<description>"+ DESCRIPTION)));
+    }
+
+    private <T extends AbstractItem & TopLevelItem> List<String> generateContentsForItem(T item) {
+        assertThat("Descriptor should be applicable to the item", ItemComponentDescriptor.getDescriptors(item),
+                hasItem(instanceOf(ItemConfigComponent.DescriptorImpl.class)));
+        ItemConfigComponent component = new ItemConfigComponent();
+        component.setItem(item);
+        TestContainer container = new TestContainer();
+        component.addContents(container);
+        return container.getContents();
+    }
+
+}

--- a/src/test/java/com/cloudbees/jenkins/support/configfiles/JobRecentBuildDataComponentTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/configfiles/JobRecentBuildDataComponentTest.java
@@ -1,0 +1,74 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.support.configfiles;
+
+import com.cloudbees.jenkins.support.api.ItemComponentDescriptor;
+import com.cloudbees.jenkins.support.util.TestContainer;
+import hudson.Functions;
+import hudson.model.AbstractItem;
+import hudson.model.FreeStyleProject;
+import hudson.model.TopLevelItem;
+import hudson.tasks.BatchFile;
+import hudson.tasks.Shell;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+public class JobRecentBuildDataComponentTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void generateForJob() throws Exception {
+        FreeStyleProject job = r.createFreeStyleProject("job1");
+        job.getBuildersList().add(Functions.isWindows()
+                ? new BatchFile("echo \"Running build #%BUILD_NUMBER%\"")
+                : new Shell("echo \"Running build #$BUILD_NUMBER\""));
+        r.buildAndAssertSuccess(job);
+        r.buildAndAssertSuccess(job);
+        assertThat(generateContentsForItem(job, 2), allOf(
+                hasItem(containsString("Running build #1")),
+                hasItem(containsString("Running build #2"))));
+    }
+
+    private <T extends AbstractItem & TopLevelItem> List<String> generateContentsForItem(T item, int buildsToInclude) {
+        assertThat("Descriptor should be applicable to the item", ItemComponentDescriptor.getDescriptors(item),
+                hasItem(instanceOf(JobRecentBuildDataComponent.DescriptorImpl.class)));
+        JobRecentBuildDataComponent component = new JobRecentBuildDataComponent();
+        component.setItem(item);
+        component.setRecentBuildsToInclude(buildsToInclude);
+        TestContainer container = new TestContainer();
+        component.addContents(container);
+        return container.getContents();
+    }
+
+}

--- a/src/test/java/com/cloudbees/jenkins/support/util/TestContainer.java
+++ b/src/test/java/com/cloudbees/jenkins/support/util/TestContainer.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cloudbees.jenkins.support.util;
+
+import com.cloudbees.jenkins.support.api.Container;
+import com.cloudbees.jenkins.support.api.Content;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestContainer extends Container {
+
+    private final List<String> contents = new ArrayList<>();
+
+    public List<String> getContents() {
+        return contents;
+    }
+
+    @Override
+    public void add(Content content) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try {
+            content.writeTo(baos);
+            contents.add(baos.toString(StandardCharsets.UTF_8.toString()));
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+}


### PR DESCRIPTION
See [JENKINS-30468](https://issues.jenkins-ci.org/browse/JENKINS-30468). 

Adds an API for item-specific support bundle components, an implementation that includes the config.xml of AbstractItems, and an implementation that includes recent builds folders for Jobs.

To do:
- [ ] Decide if it makes sense for the `ItemComponent` classes to be configurable. If not, then the API could be simplified and the UI would just need to show checkboxes for the item-specific components (which would be consistent with the current global component UI).
- [ ] Add `ItemComponent` implementation for `Job` that gives a summary of the `Job` and its build history.
- [ ] Hide/disable/filter `ItemComponent`s from the UI when the user does not have the required permission.
- [ ] Allow multiple items to be added to a single support bundle each with their own set of item-specific components. Should work from whether the action is accessed from the root or a specific item.

Current screenshot:

<img width="1440" alt="screen shot 2018-05-11 at 15 36 50" src="https://user-images.githubusercontent.com/1068968/39943532-30f53746-5531-11e8-9cf1-648cbc0d9bf6.png">

@reviewbybees 