### PR TITLE
[JENKINS-49578] Improve deletion button warning

### DIFF
--- a/src/main/resources/com/cloudbees/jenkins/support/SupportAction/index.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/support/SupportAction/index.jelly
@@ -75,7 +75,11 @@
           </f:entry>
         </j:forEach>
         <f:entry>
-          <f:submit value="${%Delete Bundle}"/>
+          <span class="yui-button yui-submit-button submit-button danger">
+            <span class="first-child">
+              <button type="submit">${%Delete Bundle}</button>
+            </span>
+          </span>
         </f:entry>
       </f:form>
       </f:section>


### PR DESCRIPTION
The deletion is definitive and having a visual warning can help prevent human errors.

Here's the result:
![2018-05-24-14-09-38_277x397](https://user-images.githubusercontent.com/985955/40484580-5e512990-5f5c-11e8-9cfe-23da297bf485.png)

@jtnord @reviewbybees 