### PR TITLE
[JENKINS-52639] Remove snakeyaml dependency by switching to wordnet-random-name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,9 +111,9 @@
       <version>2.1.10</version>
     </dependency>
     <dependency>
-      <groupId>com.github.javafaker</groupId>
-      <artifactId>javafaker</artifactId>
-      <version>0.15</version>
+      <groupId>org.kohsuke</groupId>
+      <artifactId>wordnet-random-name</artifactId>
+      <version>1.3</version>
     </dependency>
     <!-- test dependencies -->
     <dependency>

--- a/src/main/java/com/cloudbees/jenkins/support/filter/DataFaker.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/DataFaker.java
@@ -37,7 +37,7 @@ import java.util.function.Supplier;
 import org.kohsuke.randname.RandomNameGenerator;
 
 /**
- * Provides a way to bind generate random names.
+ * Provides a way to generate random names.
  *
  * @since TODO
  */
@@ -52,14 +52,14 @@ public class DataFaker implements ExtensionPoint, Function<Function<String, Stri
         return ExtensionList.lookupSingleton(DataFaker.class);
     }
 
-    private final RandomNameGenerator faker = new RandomNameGenerator();
+    private final RandomNameGenerator generator = new RandomNameGenerator();
 
     /**
-     * Applies the provided name generator to a random name and normalizes it.
+     * Applies the provided function to a random name and normalizes the result.
      */
     @Override
-    public Supplier<String> apply(@Nonnull Function<String, String> generator) {
-        return () -> generator.apply(faker.next()).toLowerCase(Locale.ENGLISH).replace(' ', '_');
+    public Supplier<String> apply(@Nonnull Function<String, String> nameTransformer) {
+        return () -> nameTransformer.apply(generator.next()).toLowerCase(Locale.ENGLISH).replace(' ', '_');
     }
 
 }

--- a/src/main/java/com/cloudbees/jenkins/support/filter/DataFaker.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/DataFaker.java
@@ -24,7 +24,6 @@
 
 package com.cloudbees.jenkins.support.filter;
 
-import com.github.javafaker.Faker;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
@@ -35,15 +34,16 @@ import javax.annotation.Nonnull;
 import java.util.Locale;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import org.kohsuke.randname.RandomNameGenerator;
 
 /**
- * Provides a way to bind Faker data generators to a Faker instance.
+ * Provides a way to bind generate random names.
  *
  * @since TODO
  */
 @Extension
 @Restricted(NoExternalUse.class)
-public class DataFaker implements ExtensionPoint, Function<Function<Faker, String>, Supplier<String>> {
+public class DataFaker implements ExtensionPoint, Function<Function<String, String>, Supplier<String>> {
 
     /**
      * @return the singleton instance
@@ -52,14 +52,14 @@ public class DataFaker implements ExtensionPoint, Function<Function<Faker, Strin
         return ExtensionList.lookupSingleton(DataFaker.class);
     }
 
-    private final Faker faker = new Faker(Locale.ENGLISH);
+    private final RandomNameGenerator faker = new RandomNameGenerator();
 
     /**
-     * Binds the provided Faker generator to a configured Faker instance and normalizes the name.
+     * Applies the provided name generator to a random name and normalizes it.
      */
     @Override
-    public Supplier<String> apply(@Nonnull Function<Faker, String> generator) {
-        return () -> generator.apply(faker).toLowerCase(Locale.ENGLISH).replace(' ', '_');
+    public Supplier<String> apply(@Nonnull Function<String, String> generator) {
+        return () -> generator.apply(faker.next()).toLowerCase(Locale.ENGLISH).replace(' ', '_');
     }
 
 }

--- a/src/main/java/com/cloudbees/jenkins/support/filter/InetAddressContentFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/InetAddressContentFilter.java
@@ -76,7 +76,7 @@ public class InetAddressContentFilter implements ContentFilter {
     }
 
     private static ContentMapping newMapping(String original) {
-        String replacement = DataFaker.get().apply(faker -> "ip_" + faker.internet().domainName()).get();
+        String replacement = DataFaker.get().apply(name -> "ip_" + name).get();
         return ContentMapping.of(original, replacement);
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/filter/NameProvider.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/NameProvider.java
@@ -27,11 +27,8 @@ package com.cloudbees.jenkins.support.filter;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
-import hudson.model.Computer;
 import hudson.model.Label;
-import hudson.model.Node;
 import hudson.model.User;
-import hudson.model.View;
 import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -98,7 +95,7 @@ public class NameProvider implements ExtensionPoint {
     public static final @Extension NameProvider ITEMS = new NameProvider(
             () -> stream(Jenkins.get().allItems())
                     .flatMap(item -> Stream.of(item.getName(), item.getDisplayName())),
-            DataFaker.get().apply(faker -> "item_" + faker.space().star()));
+            DataFaker.get().apply(name -> "item_" + name));
 
     /**
      * Provides the names of view.
@@ -106,7 +103,7 @@ public class NameProvider implements ExtensionPoint {
     public static final @Extension NameProvider VIEWS = new NameProvider(
             () -> stream(Jenkins.get().getViews())
                     .flatMap(view -> Stream.of(view.getViewName(), view.getDisplayName())),
-            DataFaker.get().apply(faker -> "view_" + faker.space().moon()));
+            DataFaker.get().apply(name -> "view_" + name));
 
     /**
      * Provides the names of nodes.
@@ -114,7 +111,7 @@ public class NameProvider implements ExtensionPoint {
     public static final @Extension NameProvider NODES = new NameProvider(
             () -> stream(Jenkins.get().getNodes())
                     .flatMap(node -> Stream.of(node.getNodeName(), node.getDisplayName())),
-            DataFaker.get().apply(faker -> "node_" + faker.internet().domainWord()));
+            DataFaker.get().apply(name -> "node_" + name));
 
     /**
      * Provides the names of computers.
@@ -122,7 +119,7 @@ public class NameProvider implements ExtensionPoint {
     public static final @Extension NameProvider COMPUTERS = new NameProvider(
             () -> stream(Jenkins.get().getComputers())
                     .flatMap(computer -> Stream.of(computer.getName(), computer.getDisplayName())),
-            DataFaker.get().apply(faker -> "computer_" + faker.internet().domainWord()));
+            DataFaker.get().apply(name -> "computer_" + name));
 
     /**
      * Provides the names of users.
@@ -130,7 +127,7 @@ public class NameProvider implements ExtensionPoint {
     public static final @Extension NameProvider USERS = new NameProvider(
             () -> stream(User.getAll())
                     .flatMap(user -> Stream.of(user.getId(), user.getFullName(), user.getDisplayName())),
-            DataFaker.get().apply(faker -> "user_" + faker.name().username()));
+            DataFaker.get().apply(name -> "user_" + name));
 
     /**
      * Provides the names of labels. Note that this extension is given a lower priority than the others to avoid
@@ -139,5 +136,5 @@ public class NameProvider implements ExtensionPoint {
     public static final @Extension(ordinal = -100) NameProvider LABELS = new NameProvider(
             () -> stream(Jenkins.get().getLabels())
                     .map(Label::getDisplayName),
-            DataFaker.get().apply(faker -> "label_" + faker.internet().domainWord()));
+            DataFaker.get().apply(name -> "label_" + name));
 }

--- a/src/main/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilter.java
@@ -26,13 +26,13 @@ package com.cloudbees.jenkins.support.filter;
 
 import hudson.Extension;
 import hudson.ExtensionList;
-import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.annotation.Nonnull;
 import java.util.Locale;
 import java.util.Set;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * Filters contents based on names provided by all {@linkplain NameProvider known sources}.

--- a/src/test/java/com/cloudbees/jenkins/support/filter/FilteredOutputStreamTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/filter/FilteredOutputStreamTest.java
@@ -24,7 +24,6 @@
 
 package com.cloudbees.jenkins.support.filter;
 
-import com.github.javafaker.Faker;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.CharSequenceInputStream;
 import org.junit.Test;
@@ -36,7 +35,9 @@ import java.io.InputStream;
 import java.nio.CharBuffer;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.joining;
@@ -44,6 +45,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 public class FilteredOutputStreamTest {
+
+    public static final String FAKE_TEXT =
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor " +
+            "incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud " +
+            "exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute " +
+            "irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla " +
+            "pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia " +
+            "deserunt mollit anim id est laborum.";
 
     private final ByteArrayOutputStream testOutput = new ByteArrayOutputStream();
 
@@ -116,8 +125,7 @@ public class FilteredOutputStreamTest {
     @Test
     public void shouldSupportMultipleUsesWithReset() throws IOException {
         FilteredOutputStream out = new FilteredOutputStream(testOutput, s -> s);
-        Faker faker = new Faker();
-        List<String> paragraphs = faker.lorem().paragraphs(10);
+        List<String> paragraphs = Stream.generate(() -> FAKE_TEXT).limit(10).collect(Collectors.toList());
         StringBuilder b = new StringBuilder();
         for (String paragraph : paragraphs) {
             out.write(paragraph.getBytes(UTF_8));
@@ -134,7 +142,7 @@ public class FilteredOutputStreamTest {
     @Test
     public void shouldSupportWriterView() throws IOException {
         FilteredOutputStream out = new FilteredOutputStream(testOutput, s -> s.toUpperCase(Locale.ENGLISH));
-        String original = new Faker().lorem().paragraph();
+        String original = FAKE_TEXT;
         try (FilteredWriter writer = out.asWriter()) {
             writer.write(original);
         }

--- a/src/test/java/com/cloudbees/jenkins/support/util/OutputStreamSelectorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/util/OutputStreamSelectorTest.java
@@ -24,7 +24,7 @@
 
 package com.cloudbees.jenkins.support.util;
 
-import com.github.javafaker.Faker;
+import com.cloudbees.jenkins.support.filter.FilteredOutputStreamTest;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.junit.Test;
 
@@ -114,9 +114,7 @@ public class OutputStreamSelectorTest {
 
     @Test
     public void shouldUseTextStreamWhenAllPrintable() {
-        Faker faker = new Faker();
-        String contents = faker.lorem().paragraph();
-        assertThatContentsWriteToTextOut(contents);
+        assertThatContentsWriteToTextOut(FilteredOutputStreamTest.FAKE_TEXT);
     }
 
     @Test


### PR DESCRIPTION
Using snakeyaml without shading it is a little precarious in the current Jenkins ecosystem, see the comments in [JENKINS-50202](https://issues.jenkins-ci.org/browse/JENKINS-50202) for details.

This PR replaces the javafaker library with [wordnet-random-name](https://github.com/kohsuke/wordnet-random-name). It doesn't allow us to use different themes for different kinds of data (which might be a blocker), but it has no compile-scope dependencies.

We could also downgrade to snakeyaml 1.17 to avoid API compatibility issues for now (assuming javafaker 0.15 is compatible with snakeyaml 1.17), or we could shade it and the javafaker library to avoid conflicts with other plugins, but getting rid of it seemed like the easiest long-term solution.

@reviewbybees