### PR TITLE
Upgrade plugin parent to 3.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.2</version>
+    <version>3.19</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
This helps fix some annoying development issues amongst plenty of other
goodies since the previously used version (3.2).

@reviewbybees @dwnusbaum 