### PR TITLE
[JENKINS-54688] Operating System informations are anonymized

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/filter/ContentMappings.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/ContentMappings.java
@@ -95,10 +95,13 @@ public class ContentMappings extends ManagementLink implements Saveable, Iterabl
             stopWords.add(Jenkins.VERSION);
         }
 
+        // JENKINS-54688
+        //stopWords.addAll(getAllowedOSName());
+
         mappings = proxy.mappings == null
                 ? new ConcurrentSkipListMap<>(COMPARATOR)
                 : proxy.mappings.stream()
-                    .filter(mapping -> !stopWords.contains(mapping.getOriginal()))
+                    .filter(mapping -> !stopWords.contains(mapping.getOriginal().toLowerCase(Locale.ENGLISH)))
                     .collect(toConcurrentMap(ContentMapping::getOriginal, Function.identity(), (a, b) -> {throw new IllegalArgumentException();}, () -> new ConcurrentSkipListMap<>(COMPARATOR)));
     }
 
@@ -109,6 +112,13 @@ public class ContentMappings extends ManagementLink implements Saveable, Iterabl
                 "user", "anonymous", "authenticated",
                 "everyone", "system", "admin",
                 Jenkins.VERSION
+        ));
+    }
+
+    private static Set<String> getAllowedOSName() {
+        return new HashSet<>(Arrays.asList(
+                "linux", "windows", "win", "mac", "macos", "macosx",
+                "mac os x", "ubuntu", "debian", "fedora"
         ));
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/filter/ContentMappings.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/ContentMappings.java
@@ -118,7 +118,8 @@ public class ContentMappings extends ManagementLink implements Saveable, Iterabl
     private static Set<String> getAllowedOSName() {
         return new HashSet<>(Arrays.asList(
                 "linux", "windows", "win", "mac", "macos", "macosx",
-                "mac os x", "ubuntu", "debian", "fedora"
+                "mac os x", "ubuntu", "debian", "fedora", "red hat",
+                "sunos", "freebsd"
         ));
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/filter/ContentMappings.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/ContentMappings.java
@@ -96,7 +96,7 @@ public class ContentMappings extends ManagementLink implements Saveable, Iterabl
         }
 
         // JENKINS-54688
-        //stopWords.addAll(getAllowedOSName());
+        stopWords.addAll(getAllowedOSName());
 
         mappings = proxy.mappings == null
                 ? new ConcurrentSkipListMap<>(COMPARATOR)

--- a/src/test/java/com/cloudbees/jenkins/support/filter/ContentMappingsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/filter/ContentMappingsTest.java
@@ -119,4 +119,19 @@ public class ContentMappingsTest {
         });
     }
 
+    @Issue("JENKINS-54688")
+    @Test
+    @LocalData
+    public void operatingSystemIncludedAsStopWord() {
+        rr.then(r -> {
+            String os = "Linux";
+            ContentMappings mappings = ContentMappings.get();
+
+            // The Operating system is added to stop words
+            assertTrue(mappings.getStopWords().contains(os.toLowerCase(Locale.ENGLISH)));
+
+            // Previous mappings with the operating system are ignored
+            assertTrue(mappings.getMappings().isEmpty());
+        });
+    }
 }

--- a/src/test/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilterTest.java
@@ -31,6 +31,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.LocalData;
 
 import java.io.IOException;
 
@@ -97,5 +98,17 @@ public class SensitiveContentFilterTest {
         String gibson = filter.filter("gibson");
 
         assertThat(gibson).startsWith("user_").doesNotContain("gibson");
+    }
+
+    @Issue("JENKINS-54688")
+    @Test
+    public void shouldNotFilterOperatingSystem() throws Exception {
+        final String os = "Linux";
+        final String label = "fake";
+        SensitiveContentFilter filter = SensitiveContentFilter.get();
+        jenkins.createSlave("foo", String.format("%s %s", os, label), null);
+        filter.reload();
+        assertThat(filter.filter(os)).isEqualTo(os);
+        assertThat(filter.filter(label)).startsWith("label_").isNotEqualTo(label);
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilterTest.java
@@ -31,7 +31,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.recipes.LocalData;
 
 import java.io.IOException;
 

--- a/src/test/resources/com/cloudbees/jenkins/support/filter/ContentMappingsTest/operatingSystemIncludedAsStopWord/com.cloudbees.jenkins.support.filter.ContentFilters.xml
+++ b/src/test/resources/com/cloudbees/jenkins/support/filter/ContentMappingsTest/operatingSystemIncludedAsStopWord/com.cloudbees.jenkins.support.filter.ContentFilters.xml
@@ -1,0 +1,4 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<com.cloudbees.jenkins.support.filter.ContentFilters plugin="support-core@2.51">
+  <enabled>true</enabled>
+</com.cloudbees.jenkins.support.filter.ContentFilters>

--- a/src/test/resources/com/cloudbees/jenkins/support/filter/ContentMappingsTest/operatingSystemIncludedAsStopWord/com.cloudbees.jenkins.support.filter.ContentMappings.xml
+++ b/src/test/resources/com/cloudbees/jenkins/support/filter/ContentMappingsTest/operatingSystemIncludedAsStopWord/com.cloudbees.jenkins.support.filter.ContentMappings.xml
@@ -1,0 +1,36 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<com.cloudbees.jenkins.support.filter.ContentMappings resolves-to="com.cloudbees.jenkins.support.filter.ContentMappings$XmlProxy">
+  <stopWords>
+    <string>authenticated</string>
+    <string>admin</string>
+    <string>mac</string>
+    <string>unknown</string>
+    <string>computer</string>
+    <string>view</string>
+    <string>linux</string>
+    <string>debian</string>
+    <string>jenkins</string>
+    <string>win</string>
+    <string>macos</string>
+    <string>all</string>
+    <string>macosx</string>
+    <string>item</string>
+    <string>everyone</string>
+    <string>ubuntu</string>
+    <string>label</string>
+    <string>windows</string>
+    <string>mac os x</string>
+    <string>master</string>
+    <string>node</string>
+    <string>system</string>
+    <string>fedora</string>
+    <string>anonymous</string>
+    <string>user</string>
+  </stopWords>
+  <mappings>
+    <com.cloudbees.jenkins.support.filter.ContentMapping resolves-to="com.cloudbees.jenkins.support.filter.ContentMapping$SerializationProxy">
+      <original>Linux</original>
+      <replacement>label_characteristic_chocolate</replacement>
+    </com.cloudbees.jenkins.support.filter.ContentMapping>
+  </mappings>
+</com.cloudbees.jenkins.support.filter.ContentMappings>

--- a/src/test/resources/com/cloudbees/jenkins/support/filter/ContentMappingsTest/operatingSystemIncludedAsStopWord/com.cloudbees.jenkins.support.filter.ContentMappings.xml
+++ b/src/test/resources/com/cloudbees/jenkins/support/filter/ContentMappingsTest/operatingSystemIncludedAsStopWord/com.cloudbees.jenkins.support.filter.ContentMappings.xml
@@ -1,29 +1,19 @@
 <?xml version='1.1' encoding='UTF-8'?>
 <com.cloudbees.jenkins.support.filter.ContentMappings resolves-to="com.cloudbees.jenkins.support.filter.ContentMappings$XmlProxy">
   <stopWords>
-    <string>authenticated</string>
-    <string>admin</string>
-    <string>mac</string>
-    <string>unknown</string>
-    <string>computer</string>
-    <string>view</string>
-    <string>linux</string>
-    <string>debian</string>
-    <string>jenkins</string>
-    <string>win</string>
-    <string>macos</string>
     <string>all</string>
-    <string>macosx</string>
+    <string>authenticated</string>
     <string>item</string>
     <string>everyone</string>
-    <string>ubuntu</string>
+    <string>admin</string>
     <string>label</string>
-    <string>windows</string>
-    <string>mac os x</string>
     <string>master</string>
+    <string>unknown</string>
     <string>node</string>
+    <string>computer</string>
+    <string>view</string>
     <string>system</string>
-    <string>fedora</string>
+    <string>jenkins</string>
     <string>anonymous</string>
     <string>user</string>
   </stopWords>


### PR DESCRIPTION
See [JENKINS-54688](https://issues.jenkins-ci.org/browse/JENKINS-54688)

Due to [JENKINS-21670](https://issues.jenkins-ci.org/browse/JENKINS-21670) the Operating System information from the master node in _about.md_ or any nodes in _nodes.md_ could be anonymised if they are used as label (a classical practice), causing confusion and making difficult to get deeper information in the support bundle. This PR tries to be a quick win so adding the common operating systems' names as stop words avoid the anonymisation.

@reviewbybees spec. @varyvol @jvz @aheritier 