### PR TITLE
[JENKINS-54922] Markdown

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
@@ -12,6 +12,7 @@ import com.cloudbees.jenkins.support.api.Container;
 import com.cloudbees.jenkins.support.api.PrintedContent;
 import com.cloudbees.jenkins.support.api.SupportProvider;
 import com.cloudbees.jenkins.support.filter.ContentFilters;
+import com.cloudbees.jenkins.support.util.Markdown;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Snapshot;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -327,8 +328,8 @@ public class AboutJenkins extends Component {
             StringBuilder result = new StringBuilder();
             Runtime runtime = Runtime.getRuntime();
             result.append(maj).append(" Java\n");
-            result.append(min).append(" Home:           `").append(System.getProperty("java.home").replaceAll("`",
-                    "&#96;")).append("`\n");
+            result.append(min).append(" Home:           `").append(
+                    Markdown.escapeBacktick(System.getProperty("java.home"))).append("`\n");
             result.append(min).append(" Vendor:           ").append(System.getProperty("java.vendor")).append("\n");
             result.append(min).append(" Version:          ").append(System.getProperty("java.version")).append("\n");
             long maxMem = runtime.maxMemory();
@@ -430,15 +431,15 @@ public class AboutJenkins extends Component {
             result.append(maj).append(" JVM startup parameters:\n");
             if (mBean.isBootClassPathSupported()) {
                 result.append(min).append(" Boot classpath: `")
-                        .append(mBean.getBootClassPath().replaceAll("`", "&#96;")).append("`\n");
+                        .append(Markdown.escapeBacktick(mBean.getBootClassPath())).append("`\n");
             }
-            result.append(min).append(" Classpath: `").append(mBean.getClassPath().replaceAll("`", "&#96;"))
+            result.append(min).append(" Classpath: `").append(Markdown.escapeBacktick(mBean.getClassPath()))
                     .append("`\n");
-            result.append(min).append(" Library path: `").append(mBean.getLibraryPath().replaceAll("`", "&#96;"))
+            result.append(min).append(" Library path: `").append(Markdown.escapeBacktick(mBean.getLibraryPath()))
                     .append("`\n");
             int count = 0;
             for (String arg : mBean.getInputArguments()) {
-                result.append(min).append(" arg[").append(count++).append("]: `").append(arg.replaceAll("`", "&#96;"))
+                result.append(min).append(" arg[").append(count++).append("]: `").append(Markdown.escapeBacktick(arg))
                         .append("`\n");
             }
             return result.toString();
@@ -539,7 +540,7 @@ public class AboutJenkins extends Component {
             out.println("Version details");
             out.println("---------------");
             out.println();
-            out.println("  * Version: `" + Jenkins.VERSION.replaceAll("`", "&#96;") + "`");
+            out.println("  * Version: `" + Markdown.escapeBacktick(Jenkins.VERSION) + "`");
             File jenkinsWar = Lifecycle.get().getHudsonWar();
             if (jenkinsWar == null) {
                 out.println("  * Mode:    Webapp Directory");
@@ -554,7 +555,7 @@ public class AboutJenkins extends Component {
                 out.println("      - Specification: " + servletContext.getMajorVersion() + "." + servletContext
                         .getMinorVersion());
                 out.println(
-                        "      - Name:          `" + servletContext.getServerInfo().replaceAll("`", "&#96;") + "`");
+                        "      - Name:          `" + Markdown.escapeBacktick(servletContext.getServerInfo()) + "`");
             } catch (NullPointerException e) {
                 // pity Stapler.getCurrent() throws an NPE when outside of a request
             }
@@ -844,11 +845,11 @@ public class AboutJenkins extends Component {
             out.println("===========");
             out.println();
             out.println("  * master (Jenkins)");
-            out.println("      - Description:    _" + Util.fixNull(jenkins.getNodeDescription())
-                    .replaceAll("_", "&#95;") + "_");
+            out.println("      - Description:    _" +
+                    Markdown.escapeUnderscore(Util.fixNull(jenkins.getNodeDescription())) + "_");
             out.println("      - Executors:      " + jenkins.getNumExecutors());
-            out.println("      - FS root:        `" + jenkins.getRootDir().getAbsolutePath()
-                    .replaceAll("`", "&#96;") + "`");
+            out.println("      - FS root:        `" +
+                    Markdown.escapeBacktick(jenkins.getRootDir().getAbsolutePath()) + "`");
             out.println("      - Labels:         " + getLabelString(jenkins));
             out.println("      - Usage:          `" + jenkins.getMode() + "`");
             out.println("      - Slave Version:  " + Launcher.VERSION);
@@ -856,15 +857,15 @@ public class AboutJenkins extends Component {
             out.println();
             for (Node node : jenkins.getNodes()) {
                 out.println("  * " + node.getNodeName() + " (" + getDescriptorName(node) + ")");
-                out.println("      - Description:    _" + Util.fixNull(node.getNodeDescription()).replaceAll("_", "&#95;") + "_");
+                out.println("      - Description:    _" +
+                        Markdown.escapeUnderscore(Util.fixNull(node.getNodeDescription())) + "_");
                 out.println("      - Executors:      " + node.getNumExecutors());
                 FilePath rootPath = node.getRootPath();
                 if (rootPath != null) {
-                    out.println("      - Remote FS root: `" + rootPath.getRemote().replaceAll("`", "&#96;")
-                            + "`");
+                    out.println("      - Remote FS root: `" + Markdown.escapeBacktick(rootPath.getRemote()) + "`");
                 } else if (node instanceof Slave) {
-                    out.println("      - Remote FS root: `" + Slave.class.cast(node).getRemoteFS()
-                            .replaceAll("`", "&#96;") + "`");
+                    out.println("      - Remote FS root: `" +
+                            Markdown.escapeBacktick(Slave.class.cast(node).getRemoteFS()) + "`");
                 }
                 out.println("      - Labels:         " + getLabelString(node));
                 out.println("      - Usage:          `" + node.getMode() + "`");

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
@@ -330,8 +330,10 @@ public class AboutJenkins extends Component {
             result.append(maj).append(" Java\n");
             result.append(min).append(" Home:           `").append(
                     Markdown.escapeBacktick(System.getProperty("java.home"))).append("`\n");
-            result.append(min).append(" Vendor:           ").append(System.getProperty("java.vendor")).append("\n");
-            result.append(min).append(" Version:          ").append(System.getProperty("java.version")).append("\n");
+            result.append(min).append(" Vendor:           ").append(
+                    Markdown.escapeUnderscore(System.getProperty("java.vendor"))).append("\n");
+            result.append(min).append(" Version:          ").append(
+                    Markdown.escapeUnderscore(System.getProperty("java.version"))).append("\n");
             long maxMem = runtime.maxMemory();
             long allocMem = runtime.totalMemory();
             long freeMem = runtime.freeMemory();
@@ -383,27 +385,35 @@ public class AboutJenkins extends Component {
             result.append(min).append(" Version: ").append(System.getProperty("java.vm.specification.version"))
                     .append("\n");
             result.append(maj).append(" JVM Implementation\n");
-            result.append(min).append(" Name:    ").append(System.getProperty("java.vm.name")).append("\n");
-            result.append(min).append(" Vendor:  ").append(System.getProperty("java.vm.vendor")).append("\n");
-            result.append(min).append(" Version: ").append(System.getProperty("java.vm.version")).append("\n");
+            result.append(min).append(" Name:    ").append(
+                    Markdown.escapeUnderscore(System.getProperty("java.vm.name"))).append("\n");
+            result.append(min).append(" Vendor:  ").append(
+                    Markdown.escapeUnderscore(System.getProperty("java.vm.vendor"))).append("\n");
+            result.append(min).append(" Version: ").append(
+                    Markdown.escapeUnderscore(System.getProperty("java.vm.version"))).append("\n");
             result.append(maj).append(" Operating system\n");
-            result.append(min).append(" Name:         ").append(System.getProperty("os.name")).append("\n");
-            result.append(min).append(" Architecture: ").append(System.getProperty("os.arch")).append("\n");
-            result.append(min).append(" Version:      ").append(System.getProperty("os.version")).append("\n");
+            result.append(min).append(" Name:         ").append(
+                    Markdown.escapeUnderscore(System.getProperty("os.name"))).append("\n");
+            result.append(min).append(" Architecture: ").append(
+                    Markdown.escapeUnderscore(System.getProperty("os.arch"))).append("\n");
+            result.append(min).append(" Version:      ").append(
+                    Markdown.escapeUnderscore(System.getProperty("os.version"))).append("\n");
             File lsb_release = new File("/usr/bin/lsb_release");
             if (lsb_release.canExecute()) {
                 try {
                     Process proc = new ProcessBuilder().command(lsb_release.getAbsolutePath(), "--description", "--short").start();
                     String distro = IOUtils.readFirstLine(proc.getInputStream(), "UTF-8");
                     if (proc.waitFor() == 0) {
-                        result.append(min).append(" Distribution: ").append(distro).append("\n");
+                        result.append(min).append(" Distribution: ").append(
+                                Markdown.escapeUnderscore(distro)).append("\n");
                     } else {
                         logger.fine("lsb_release had a nonzero exit status");
                     }
                     proc = new ProcessBuilder().command(lsb_release.getAbsolutePath(), "--version", "--short").start();
                     String modules = IOUtils.readFirstLine(proc.getInputStream(), "UTF-8");
                     if (proc.waitFor() == 0 && modules != null) {
-                        result.append(min).append(" LSB Modules:  `").append(modules).append("`\n");
+                        result.append(min).append(" LSB Modules:  `").append(
+                                Markdown.escapeUnderscore(modules)).append("`\n");
                     } else {
                         logger.fine("lsb_release had a nonzero exit status");
                     }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
@@ -129,7 +129,7 @@ public class AboutJenkins extends Component {
 
     private static String getDescriptorName(@CheckForNull Describable<?> d) {
         if (d == null) {
-            return "(none)";
+            return Markdown.NONE_STRING;
         }
         return "`" + Markdown.escapeBacktick(d.getClass().getName()) + "`";
     }
@@ -821,8 +821,7 @@ public class AboutJenkins extends Component {
             super("nodes.md");
         }
         private String getLabelString(Node n) {
-            String r = n.getLabelString();
-            return r.isEmpty() ? "(none)" : r;
+            return Markdown.prettyNone(n.getLabelString());
         }
         @Override protected void printTo(PrintWriter out) throws IOException {
             final Jenkins jenkins = Jenkins.getInstance();

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
@@ -856,7 +856,8 @@ public class AboutJenkins extends Component {
             out.print(new GetJavaInfo("      -", "          +").call());
             out.println();
             for (Node node : jenkins.getNodes()) {
-                out.println("  * " + node.getNodeName() + " (" + getDescriptorName(node) + ")");
+                out.println("  * `" + Markdown.escapeBacktick(node.getNodeName()) + "` (" +getDescriptorName(node) +
+                        ")");
                 out.println("      - Description:    _" +
                         Markdown.escapeUnderscore(Util.fixNull(node.getNodeDescription())) + "_");
                 out.println("      - Executors:      " + node.getNumExecutors());
@@ -867,7 +868,7 @@ public class AboutJenkins extends Component {
                     out.println("      - Remote FS root: `" +
                             Markdown.escapeBacktick(Slave.class.cast(node).getRemoteFS()) + "`");
                 }
-                out.println("      - Labels:         " + getLabelString(node));
+                out.println("      - Labels:         " + Markdown.escapeUnderscore(getLabelString(node)));
                 out.println("      - Usage:          `" + node.getMode() + "`");
                 if (node instanceof Slave) {
                     Slave slave = (Slave) node;

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
@@ -131,7 +131,7 @@ public class AboutJenkins extends Component {
         if (d == null) {
             return "(none)";
         }
-        return "`" + d.getClass().getName() + "`";
+        return "`" + Markdown.escapeBacktick(d.getClass().getName()) + "`";
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/support/util/Markdown.java
+++ b/src/main/java/com/cloudbees/jenkins/support/util/Markdown.java
@@ -1,6 +1,10 @@
 package com.cloudbees.jenkins.support.util;
 
+import hudson.model.Describable;
+
 public final class Markdown {
+    public static final String NONE_STRING = "(none)";
+
     /** Not instantiable. */
     private Markdown() {
         throw new AssertionError("Not instantiable");
@@ -12,4 +16,6 @@ public final class Markdown {
     public static String escapeBacktick(String raw) {
         return raw.replaceAll("`", "&#96;");
     }
+
+    public static String prettyNone(String raw) { return raw != null && !raw.isEmpty() ? raw : NONE_STRING; }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/util/Markdown.java
+++ b/src/main/java/com/cloudbees/jenkins/support/util/Markdown.java
@@ -1,0 +1,15 @@
+package com.cloudbees.jenkins.support.util;
+
+public final class Markdown {
+    /** Not instantiable. */
+    private Markdown() {
+        throw new AssertionError("Not instantiable");
+    }
+
+    public static String escapeUnderscore(String raw) {
+        return raw.replaceAll("_", "&#95;");
+    }
+    public static String escapeBacktick(String raw) {
+        return raw.replaceAll("`", "&#96;");
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/support/util/MarkdownTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/util/MarkdownTest.java
@@ -1,0 +1,20 @@
+package com.cloudbees.jenkins.support.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MarkdownTest {
+
+    @Test
+    public void escapeUnderscore() {
+        assertEquals("a&#95;b", Markdown.escapeUnderscore("a_b"));
+        assertEquals("a`b", Markdown.escapeUnderscore("a`b"));
+    }
+
+    @Test
+    public void escapeBacktick() {
+        assertEquals("a&#96;b", Markdown.escapeBacktick("a`b"));
+        assertEquals("a_b", Markdown.escapeBacktick("a_b"));
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/support/util/MarkdownTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/util/MarkdownTest.java
@@ -17,4 +17,11 @@ public class MarkdownTest {
         assertEquals("a&#96;b", Markdown.escapeBacktick("a`b"));
         assertEquals("a_b", Markdown.escapeBacktick("a_b"));
     }
+
+    @Test
+    public void prettyNone() {
+        assertEquals(Markdown.NONE_STRING, Markdown.prettyNone(null));
+        assertEquals(Markdown.NONE_STRING, Markdown.prettyNone(""));
+        assertEquals("a", Markdown.prettyNone("a"));
+    }
 }


### PR DESCRIPTION
The goal here is to be able to fix the markdown generation by this plugin.
https://issues.jenkins-ci.org/browse/JENKINS-54922

Currently, it generates:
```
  * computer_reliable_bulletin (`user_junior_process.slaves.DumbSlave`)
      - Description:    _Java 8_
      - Executors:      1
      - Remote FS root: `/home/jenkins`
      - Labels:         label_transparent_court label_religious_blood pipeline view_medieval_corn label_mutual_violation label_related_favourite label_easy_insurance
```

Which, in **MacDown.app** renders as :
  * computer _reliable_ bulletin (`user_junior_process.slaves.DumbSlave`)
      - Description:    _Java 8_
      - Executors:      1
      - Remote FS root: `/home/jenkins`
      - Labels:         label _transparent_ court label _religious_ blood pipeline view _medieval_ corn label _mutual_ violation label _related_ favourite label _easy_ insurance

![image](https://user-images.githubusercontent.com/2119212/49101796-13950a80-f245-11e8-8665-4541f48f0078.png)