### PR TITLE
[JENKINS-55493] Upgrade parent pom and solve JTH html API usage 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.19</version>
+    <version>3.32</version>
     <relativePath />
   </parent>
 

--- a/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
@@ -102,7 +102,7 @@ public class SupportActionTest {
             HtmlPage p = wc.goTo(root.getUrlName());
 
             HtmlForm form = p.getFormByName("bundle-contents");
-            HtmlButton submit = (HtmlButton) form.getHtmlElementsByTagName("button").get(0);
+            HtmlButton submit = (HtmlButton) form.getElementsByTagName("button").get(0);
             Page zip = submit.click();
             File zipFile = File.createTempFile("test", "zip");
             IOUtils.copy(zip.getWebResponse().getContentAsStream(), Files.newOutputStream(zipFile.toPath()));


### PR DESCRIPTION
[JENKINS-55493](https://issues.jenkins-ci.org/browse/JENKINS-55493)

This is required to validate the plugin with PCT against Java 11 support. It will require to upgrade `metrics` plugin version requirement to include the fix from https://github.com/jenkinsci/metrics-plugin/pull/42 once released but that can be done in a follow-up PR.

@jenkinsci/java11-support 