### PR TITLE
[JENKINS-55843] Folders missed due to anonymization in the bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.138</jenkins.version>
+    <jenkins.version>2.107</jenkins.version>
     <java.level>8</java.level>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.107</jenkins.version>
+    <jenkins.version>2.138</jenkins.version>
     <java.level>8</java.level>
   </properties>
 

--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -33,8 +33,8 @@ import com.cloudbees.jenkins.support.api.SupportProviderDescriptor;
 import com.cloudbees.jenkins.support.filter.ContentFilter;
 import com.cloudbees.jenkins.support.filter.ContentFilters;
 import com.cloudbees.jenkins.support.filter.ContentMappings;
-import com.cloudbees.jenkins.support.filter.PrefilteredContent;
 import com.cloudbees.jenkins.support.filter.FilteredOutputStream;
+import com.cloudbees.jenkins.support.filter.PrefilteredContent;
 import com.cloudbees.jenkins.support.impl.ThreadDumps;
 import com.cloudbees.jenkins.support.util.IgnoreCloseOutputStream;
 import com.cloudbees.jenkins.support.util.OutputStreamSelector;
@@ -88,17 +88,24 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.TreeSet;
+import java.util.WeakHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Function;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
-import java.util.stream.Stream;
 
 /**
  * Main entry point for the support plugin.

--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -342,7 +342,7 @@ public class SupportPlugin extends Plugin {
      * Filter the name of a content depending on the tokens in the name that need to be replaced.
      * @param maybeFilter an Optional with a {@link ContentFilter} or not
      * @param name the name of the content to be filtered
-     * @param tokens tokens in the name to be filtered. If null, the whole name is filtered
+     * @param tokens tokens in the name to be filtered. If null, no filter takes place to avoid corruption
      * @return the name filtered
      */
     private static String getNameFiltered(Optional<ContentFilter> maybeFilter, String name, String[] tokens) {

--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -360,7 +360,7 @@ public class SupportPlugin extends Plugin {
             //filteredName = maybeFilter.map(filter -> filter.filter(name)).orElse(name);
             filteredName = name;
         }
-        System.out.format("%s is replaced by %s%n", name, filteredName);
+
         return filteredName;
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -298,7 +298,7 @@ public class SupportPlugin extends Plugin {
                     if (content == null) {
                         continue;
                     }
-                    final String name = getNameFiltered(maybeFilter, content.getName(), content.getTokens());
+                    final String name = getNameFiltered(maybeFilter, content.getName(), content.getFilterableParameters());
                     final ZipArchiveEntry entry = new ZipArchiveEntry(name);
                     entry.setTime(content.getTime());
                     try {
@@ -346,21 +346,21 @@ public class SupportPlugin extends Plugin {
     }
 
     /**
-     * Filter the name of a content depending on the tokens in the name that need to be replaced.
+     * Filter the name of a content depending on the filterableParameters in the name that need to be replaced.
      * @param maybeFilter an Optional with a {@link ContentFilter} or not
      * @param name the name of the content to be filtered
-     * @param tokens tokens in the name to be filtered. If null, no filter takes place to avoid corruption
+     * @param filterableParameters filterableParameters in the name to be filtered. If null, no filter takes place to avoid corruption
      * @return the name filtered
      */
-    private static String getNameFiltered(Optional<ContentFilter> maybeFilter, String name, String[] tokens) {
+    private static String getNameFiltered(Optional<ContentFilter> maybeFilter, String name, String[] filterableParameters) {
         String filteredName;
 
-        if (tokens != null) {
+        if (filterableParameters != null) {
             // Filter each token or return the token depending on whether the filter is active or not
-            String[] replacedTokens = Arrays.stream(tokens).map(token -> maybeFilter.map(filter -> filter.filter(token)).orElse(token)).toArray(String[]::new);
+            String[] replacedParameters = Arrays.stream(filterableParameters).map(filterableParameter -> maybeFilter.map(filter -> filter.filter(filterableParameter)).orElse(filterableParameter)).toArray(String[]::new);
 
             // Replace each placeholder {0}, {1} in the name, with the replaced token
-            filteredName = MessageFormat.format(name, replacedTokens);
+            filteredName = MessageFormat.format(name, replacedParameters);
         } else {
             // Previous behavior was filter all the name, but it could end up in having a corrupted bundle. So we expect
             // implementors to use the appropriate constructor of Content.

--- a/src/main/java/com/cloudbees/jenkins/support/api/CommandOutputContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/CommandOutputContent.java
@@ -5,6 +5,7 @@ import com.cloudbees.jenkins.support.SupportLogFormatter;
 import hudson.model.Node;
 import hudson.remoting.VirtualChannel;
 import jenkins.model.Jenkins;
+import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
@@ -14,7 +15,6 @@ import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
-import jenkins.security.MasterToSlaveCallable;
 
 /**
  * Content of a command output. You can only instantiate this content with
@@ -28,8 +28,8 @@ public class CommandOutputContent extends StringContent {
         super(name, value);
     }
 
-    private CommandOutputContent(String name, String[] tokens, String value) {
-        super(name, tokens, value);
+    private CommandOutputContent(String name, String[] filterableParameters, String value) {
+        super(name, filterableParameters, value);
     }
 
     public static class CommandLauncher extends MasterToSlaveCallable<String, RuntimeException> {
@@ -61,7 +61,7 @@ public class CommandOutputContent extends StringContent {
         return runOnNode(node, name, null, command);
     }
 
-    public static CommandOutputContent runOnNode(Node node, String name, String[] tokens, String... command) {
+    public static CommandOutputContent runOnNode(Node node, String name, String[] filterableParameters, String... command) {
         String content = "Exception occurred while retrieving command content";
 
         VirtualChannel chan = node.getChannel();
@@ -83,14 +83,14 @@ public class CommandOutputContent extends StringContent {
             }
         }
 
-        return new CommandOutputContent(name, tokens, content);
+        return new CommandOutputContent(name, filterableParameters, content);
     }
 
     public static CommandOutputContent runOnNodeAndCache(WeakHashMap<Node, String> cache, Node node, String name, String... command) {
         return runOnNodeAndCache(cache, node, name, null, command);
     }
 
-    public static CommandOutputContent runOnNodeAndCache(WeakHashMap<Node, String> cache, Node node, String name, String[] tokens, String... command) {
+    public static CommandOutputContent runOnNodeAndCache(WeakHashMap<Node, String> cache, Node node, String name, String[] filterableParameters, String... command) {
         String content = "Exception occurred while retrieving command content";
 
         try {
@@ -103,6 +103,6 @@ public class CommandOutputContent extends StringContent {
             LOGGER.log(lr);
         }
 
-        return new CommandOutputContent(name, tokens, content);
+        return new CommandOutputContent(name, filterableParameters, content);
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/api/CommandOutputContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/CommandOutputContent.java
@@ -28,6 +28,10 @@ public class CommandOutputContent extends StringContent {
         super(name, value);
     }
 
+    private CommandOutputContent(String name, String[] tokens, String value) {
+        super(name, tokens, value);
+    }
+
     public static class CommandLauncher extends MasterToSlaveCallable<String, RuntimeException> {
         final String[] command;
 
@@ -54,6 +58,10 @@ public class CommandOutputContent extends StringContent {
     }
 
     public static CommandOutputContent runOnNode(Node node, String name, String... command) {
+        return runOnNode(node, name, null, command);
+    }
+
+    public static CommandOutputContent runOnNode(Node node, String name, String[] tokens, String... command) {
         String content = "Exception occurred while retrieving command content";
 
         VirtualChannel chan = node.getChannel();
@@ -75,10 +83,14 @@ public class CommandOutputContent extends StringContent {
             }
         }
 
-        return new CommandOutputContent(name, content);
+        return new CommandOutputContent(name, tokens, content);
     }
 
     public static CommandOutputContent runOnNodeAndCache(WeakHashMap<Node, String> cache, Node node, String name, String... command) {
+        return runOnNodeAndCache(cache, node, name, null, command);
+    }
+
+    public static CommandOutputContent runOnNodeAndCache(WeakHashMap<Node, String> cache, Node node, String name, String[] tokens, String... command) {
         String content = "Exception occurred while retrieving command content";
 
         try {
@@ -91,6 +103,6 @@ public class CommandOutputContent extends StringContent {
             LOGGER.log(lr);
         }
 
-        return new CommandOutputContent(name, content);
+        return new CommandOutputContent(name, tokens, content);
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/api/Content.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/Content.java
@@ -62,9 +62,9 @@ public abstract class Content {
      * {code}new Content("nodes/{0}/file-descriptors.txt", "node") will filter the {0} part of the name with all the
      * declared {@link ContentFilter}.
      * This new constructor avoid having incorrectly filtered elements in the support bundle. For example, when having
-     * a job called <i>nodes</i>. The <i>nodes</i> element in the file name of a  file in the bundle shouldn't be filtered.
+     * a job called <i>nodes</i>. The <i>nodes</i> element in the file name of a file in the bundle shouldn't be filtered.
      *
-     * The name is filtered using the {@link java.text.MessageFormat#format(String, Object...)} method.
+     * The name is rendered using the {@link java.text.MessageFormat#format(String, Object...)} method after the filter.
      *
      * @param name name of the content
      * @param tokens strings to be filtered in the name

--- a/src/main/java/com/cloudbees/jenkins/support/api/Content.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/Content.java
@@ -24,8 +24,12 @@
 
 package com.cloudbees.jenkins.support.api;
 
+import com.cloudbees.jenkins.support.filter.ContentFilter;
+
+import javax.annotation.CheckForNull;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Arrays;
 
 /**
  * Represents some content in a support bundle.
@@ -36,12 +40,47 @@ public abstract class Content {
 
     private final String name;
 
+    /**
+     * Parts of the name to be filtered
+     */
+    private String[] tokens;
+
+
+    /**
+     * Create a Content with this name. The name is not filtered so this constructor should be used exclusively when
+     * the name is not prone to have sensitive information. If the name of this content is someway dinamically generated
+     * and prone to have sensitive information, use the {@link #Content(String, String...)} constructor.
+     * @param name name of the content.
+     */
     protected Content(String name) {
+        this(name, null);
+    }
+
+    /**
+     * Set a name to this content with some filterable parts. The name could have elements with the form {0}, {1} that
+     * will be filtered properly using the tokens. Example: Creating a content with
+     * {code}new Content("nodes/{0}/file-descriptors.txt", "node") will filter the {0} part of the name with all the
+     * declared {@link ContentFilter}.
+     * This new constructor avoid having incorrectly filtered elements in the support bundle. For example, when having
+     * a job called <i>nodes</i>. The <i>nodes</i> element in the file name of a  file in the bundle shouldn't be filtered.
+     *
+     * The name is filtered using the {@link java.text.MessageFormat#format(String, Object...)} method.
+     *
+     * @param name name of the content
+     * @param tokens strings to be filtered in the name
+     */
+    protected Content(String name, String... tokens) {
         this.name = name;
+        this.tokens = tokens;
     }
 
     public String getName() {
         return name;
+    }
+
+    @CheckForNull
+    public String[] getTokens() {
+        return (tokens == null) ? null : Arrays.copyOf(tokens, tokens.length);
     }
 
     public abstract void writeTo(OutputStream os) throws IOException;

--- a/src/main/java/com/cloudbees/jenkins/support/api/Content.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/Content.java
@@ -43,7 +43,7 @@ public abstract class Content {
     /**
      * Parts of the name to be filtered
      */
-    private String[] tokens;
+    private String[] filterableParameters;
 
 
     /**
@@ -58,7 +58,7 @@ public abstract class Content {
 
     /**
      * Set a name to this content with some filterable parts. The name could have elements with the form {0}, {1} that
-     * will be filtered properly using the tokens. Example: Creating a content with
+     * will be filtered properly using the filterableParameters. Example: Creating a content with
      * {code}new Content("nodes/{0}/file-descriptors.txt", "node") will filter the {0} part of the name with all the
      * declared {@link ContentFilter}.
      * This new constructor avoid having incorrectly filtered elements in the support bundle. For example, when having
@@ -67,11 +67,11 @@ public abstract class Content {
      * The name is rendered using the {@link java.text.MessageFormat#format(String, Object...)} method after the filter.
      *
      * @param name name of the content
-     * @param tokens strings to be filtered in the name
+     * @param filterableParameters strings to be filtered in the name
      */
-    protected Content(String name, String... tokens) {
+    protected Content(String name, String... filterableParameters) {
         this.name = name;
-        this.tokens = tokens;
+        this.filterableParameters = filterableParameters;
     }
 
     public String getName() {
@@ -79,8 +79,8 @@ public abstract class Content {
     }
 
     @CheckForNull
-    public String[] getTokens() {
-        return (tokens == null) ? null : Arrays.copyOf(tokens, tokens.length);
+    public String[] getFilterableParameters() {
+        return (filterableParameters == null) ? null : Arrays.copyOf(filterableParameters, filterableParameters.length);
     }
 
     public abstract void writeTo(OutputStream os) throws IOException;

--- a/src/main/java/com/cloudbees/jenkins/support/api/FileContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/FileContent.java
@@ -68,12 +68,12 @@ public class FileContent extends PrefilteredContent {
         this.isBinary = isBinary();
     }
 
-    public FileContent(String name, String[] tokens, File file) {
-        this(name, tokens, file, -1);
+    public FileContent(String name, String[] filterableParameters, File file) {
+        this(name, filterableParameters, file, -1);
     }
 
-    public FileContent(String name, String[] tokens, File file, long maxSize) {
-        super(name, tokens);
+    public FileContent(String name, String[] filterableParameters, File file, long maxSize) {
+        super(name, filterableParameters);
         this.file = file;
         this.maxSize = maxSize;
         this.isBinary = isBinary();

--- a/src/main/java/com/cloudbees/jenkins/support/api/FileContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/FileContent.java
@@ -68,6 +68,17 @@ public class FileContent extends PrefilteredContent {
         this.isBinary = isBinary();
     }
 
+    public FileContent(String name, String[] tokens, File file) {
+        this(name, tokens, file, -1);
+    }
+
+    public FileContent(String name, String[] tokens, File file, long maxSize) {
+        super(name, tokens);
+        this.file = file;
+        this.maxSize = maxSize;
+        this.isBinary = isBinary();
+    }
+
     @Override
     public void writeTo(OutputStream os) throws IOException {
         try {

--- a/src/main/java/com/cloudbees/jenkins/support/api/FilePathContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/FilePathContent.java
@@ -52,6 +52,11 @@ public class FilePathContent extends Content {
         this.file = file;
     }
 
+    public FilePathContent(String name, String[] tokens, FilePath file) {
+        super(name, tokens);
+        this.file = file;
+    }
+
     @Override
     public void writeTo(OutputStream os) throws IOException {
         try {

--- a/src/main/java/com/cloudbees/jenkins/support/api/FilePathContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/FilePathContent.java
@@ -52,8 +52,8 @@ public class FilePathContent extends Content {
         this.file = file;
     }
 
-    public FilePathContent(String name, String[] tokens, FilePath file) {
-        super(name, tokens);
+    public FilePathContent(String name, String[] filterableParameters, FilePath file) {
+        super(name, filterableParameters);
         this.file = file;
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/api/GenerateOnDemandContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/GenerateOnDemandContent.java
@@ -37,8 +37,8 @@ public abstract class GenerateOnDemandContent extends Content {
         super(name);
     }
 
-    public GenerateOnDemandContent(String name, String... tokens) {
-        super(name, tokens);
+    public GenerateOnDemandContent(String name, String... filterableParameters) {
+        super(name, filterableParameters);
     }
     public abstract void writeTo(OutputStream os) throws IOException;
 

--- a/src/main/java/com/cloudbees/jenkins/support/api/GenerateOnDemandContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/GenerateOnDemandContent.java
@@ -37,6 +37,9 @@ public abstract class GenerateOnDemandContent extends Content {
         super(name);
     }
 
+    public GenerateOnDemandContent(String name, String... tokens) {
+        super(name, tokens);
+    }
     public abstract void writeTo(OutputStream os) throws IOException;
 
 }

--- a/src/main/java/com/cloudbees/jenkins/support/api/PrintedContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/PrintedContent.java
@@ -45,8 +45,8 @@ public abstract class PrintedContent extends GenerateOnDemandContent {
         super(name);
     }
 
-    public PrintedContent(String name, String... tokens) {
-        super(name, tokens);
+    public PrintedContent(String name, String... filterableParameters) {
+        super(name, filterableParameters);
     }
 
     @Override

--- a/src/main/java/com/cloudbees/jenkins/support/api/PrintedContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/PrintedContent.java
@@ -45,6 +45,10 @@ public abstract class PrintedContent extends GenerateOnDemandContent {
         super(name);
     }
 
+    public PrintedContent(String name, String... tokens) {
+        super(name, tokens);
+    }
+
     @Override
     public final void writeTo(OutputStream os) throws IOException {
         final PrintWriter writer = getWriter(os);

--- a/src/main/java/com/cloudbees/jenkins/support/api/StringContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/StringContent.java
@@ -44,8 +44,8 @@ public class StringContent extends PrefilteredContent {
         this.value = value;
     }
 
-    public StringContent(String name, String[] filterableNameTokens, String value) {
-        super(name, filterableNameTokens);
+    public StringContent(String name, String[] filterableParameters, String value) {
+        super(name, filterableParameters);
         this.value = value;
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/api/StringContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/StringContent.java
@@ -44,6 +44,11 @@ public class StringContent extends PrefilteredContent {
         this.value = value;
     }
 
+    public StringContent(String name, String[] filterableNameTokens, String value) {
+        super(name, filterableNameTokens);
+        this.value = value;
+    }
+
     @Override
     public void writeTo(OutputStream os) throws IOException {
         writeTo(os, null);

--- a/src/main/java/com/cloudbees/jenkins/support/api/TemporaryFileContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/TemporaryFileContent.java
@@ -44,6 +44,11 @@ public class TemporaryFileContent extends FileContent {
         f = file;
     }
 
+    public TemporaryFileContent(String name, String[] tokens, File file) {
+        super(name, tokens, file);
+        f = file;
+    }
+
     @Override
     public void writeTo(OutputStream os) throws IOException {
         try {

--- a/src/main/java/com/cloudbees/jenkins/support/api/TemporaryFileContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/TemporaryFileContent.java
@@ -44,8 +44,8 @@ public class TemporaryFileContent extends FileContent {
         f = file;
     }
 
-    public TemporaryFileContent(String name, String[] tokens, File file) {
-        super(name, tokens, file);
+    public TemporaryFileContent(String name, String[] filterableParameters, File file) {
+        super(name, filterableParameters, file);
         f = file;
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/api/TruncatedContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/TruncatedContent.java
@@ -50,12 +50,12 @@ public abstract class TruncatedContent extends Content {
     this.maxSize = maxSize;
   }
 
-  public TruncatedContent(String name, String... tokens) {
-    this(name, tokens, FileListCapComponent.MAX_FILE_SIZE);
+  public TruncatedContent(String name, String... filterableParameters) {
+    this(name, filterableParameters, FileListCapComponent.MAX_FILE_SIZE);
   }
 
-  public TruncatedContent(String name, String[] tokens, int maxSize) {
-    super(name, tokens);
+  public TruncatedContent(String name, String[] filterableParameters, int maxSize) {
+    super(name, filterableParameters);
     this.maxSize = maxSize;
   }
 

--- a/src/main/java/com/cloudbees/jenkins/support/api/TruncatedContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/TruncatedContent.java
@@ -50,6 +50,15 @@ public abstract class TruncatedContent extends Content {
     this.maxSize = maxSize;
   }
 
+  public TruncatedContent(String name, String... tokens) {
+    this(name, tokens, FileListCapComponent.MAX_FILE_SIZE);
+  }
+
+  public TruncatedContent(String name, String[] tokens, int maxSize) {
+    super(name, tokens);
+    this.maxSize = maxSize;
+  }
+
   @Override
   public void writeTo(OutputStream os) throws IOException {
     PrintWriter out = new PrintWriter(new BufferedWriter(new OutputStreamWriter(new TruncatedOutputStream(os, maxSize), "UTF-8")));

--- a/src/main/java/com/cloudbees/jenkins/support/configfiles/AgentsConfigFile.java
+++ b/src/main/java/com/cloudbees/jenkins/support/configfiles/AgentsConfigFile.java
@@ -69,7 +69,7 @@ public class AgentsConfigFile extends Component {
         }
         for(File agentDir : agentDirs) {
             File config = new File(agentDir, "config.xml");
-            container.add(new XmlRedactedSecretFileContent("nodes/slave/" + agentDir.getName() + "/config.xml", config));
+            container.add(new XmlRedactedSecretFileContent("nodes/slave/{0}/config.xml", new String[]{agentDir.getName()}, config));
         }
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/configfiles/ConfigFileComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/configfiles/ConfigFileComponent.java
@@ -37,8 +37,8 @@ public class ConfigFileComponent extends Component {
         File configFile = new File(jenkins.getRootDir(), "config.xml");
         if (configFile.exists()) {
             container.add(
-                    new XmlRedactedSecretFileContent("jenkins-root-configuration-files/" + configFile.getName(),
-                                                     configFile));
+                    new XmlRedactedSecretFileContent("jenkins-root-configuration-files/{0}",
+                            new String[] {configFile.getName()}, configFile));
         } else {
             //this should never happen..
             LOGGER.log(Level.WARNING, "Jenkins global config file does not exist.");

--- a/src/main/java/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponent.java
@@ -76,7 +76,7 @@ public class OtherConfigFilesComponent extends Component {
             if (files != null) {
                 for (File configFile : files) {
                     if (configFile.exists()) {
-                        container.add(new XmlRedactedSecretFileContent("jenkins-root-configuration-files/" + configFile.getName(), configFile));
+                        container.add(new XmlRedactedSecretFileContent("jenkins-root-configuration-files/{0}", new String[] {configFile.getName()}, configFile));
                     }
                 }
             } else {

--- a/src/main/java/com/cloudbees/jenkins/support/configfiles/XmlRedactedSecretFileContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/configfiles/XmlRedactedSecretFileContent.java
@@ -15,6 +15,10 @@ class XmlRedactedSecretFileContent extends FileContent {
         super(name, file);
     }
 
+    public XmlRedactedSecretFileContent(String name, String[] tokens, File file) {
+        super(name, tokens, file);
+    }
+
     @Override
     protected InputStream getInputStream() throws IOException {
         try {

--- a/src/main/java/com/cloudbees/jenkins/support/configfiles/XmlRedactedSecretFileContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/configfiles/XmlRedactedSecretFileContent.java
@@ -15,8 +15,8 @@ class XmlRedactedSecretFileContent extends FileContent {
         super(name, file);
     }
 
-    public XmlRedactedSecretFileContent(String name, String[] tokens, File file) {
-        super(name, tokens, file);
+    public XmlRedactedSecretFileContent(String name, String[] filterableParameters, File file) {
+        super(name, filterableParameters, file);
     }
 
     @Override

--- a/src/main/java/com/cloudbees/jenkins/support/filter/ContentMapping.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/ContentMapping.java
@@ -74,7 +74,6 @@ public class ContentMapping implements ContentFilter {
                 .distinct()
                 .map(Pattern::quote)
                 .collect(joining("|", "\\b(", ")\\b"));
-        System.out.println("To look for regex: [" + regex + "]");
         return Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/filter/ContentMapping.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/ContentMapping.java
@@ -74,6 +74,7 @@ public class ContentMapping implements ContentFilter {
                 .distinct()
                 .map(Pattern::quote)
                 .collect(joining("|", "\\b(", ")\\b"));
+        System.out.println("To look for regex: [" + regex + "]");
         return Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/filter/ContentMappings.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/ContentMappings.java
@@ -35,7 +35,15 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.Spliterator;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.function.Consumer;
 import java.util.function.Function;

--- a/src/main/java/com/cloudbees/jenkins/support/filter/ContentMappings.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/ContentMappings.java
@@ -124,7 +124,6 @@ public class ContentMappings extends ManagementLink implements Saveable, Iterabl
             singleChars.add(Character.toString((char) i));
         }
 
-        System.out.println(singleChars);
         return singleChars;
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/filter/ContentMappings.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/ContentMappings.java
@@ -35,15 +35,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.Spliterator;
+import java.util.*;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -98,6 +90,9 @@ public class ContentMappings extends ManagementLink implements Saveable, Iterabl
         // JENKINS-54688
         stopWords.addAll(getAllowedOSName());
 
+        // Add single character words
+        stopWords.addAll(getAllAsciiCharacters());
+
         mappings = proxy.mappings == null
                 ? new ConcurrentSkipListMap<>(COMPARATOR)
                 : proxy.mappings.stream()
@@ -110,9 +105,27 @@ public class ContentMappings extends ManagementLink implements Saveable, Iterabl
                 "jenkins", "node", "master", "computer",
                 "item", "label", "view", "all", "unknown",
                 "user", "anonymous", "authenticated",
-                "everyone", "system", "admin",
-                Jenkins.VERSION
+                "everyone", "system", "admin", Jenkins.VERSION
         ));
+    }
+
+    /**
+     * To avoid corrupt the content of the files in the bundle just in case we have an object name as 'a' or '.', we
+     * avoid replacing one single characteres (ascii codes actually). A one single character in other languages could
+     * have a meaning, so we remain replacing them. Example: 日 (Sun)
+     * @return Set of characters in ascii code chart
+     */
+    private static Set<String> getAllAsciiCharacters() {
+        final int SPACE = ' '; //20
+        final int TILDE = '~'; //126
+        Set<String> singleChars = new HashSet<>(TILDE - SPACE + 1);
+
+        for (int i = SPACE; i <= TILDE; i++) {
+            singleChars.add(Character.toString((char) i));
+        }
+
+        System.out.println(singleChars);
+        return singleChars;
     }
 
     private static Set<String> getAllowedOSName() {

--- a/src/main/java/com/cloudbees/jenkins/support/filter/PrefilteredContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/PrefilteredContent.java
@@ -38,8 +38,8 @@ public abstract class PrefilteredContent extends Content {
         super(name);
     }
 
-    protected PrefilteredContent(String name, String... tokens) {
-        super(name, tokens);
+    protected PrefilteredContent(String name, String... filterableParameters) {
+        super(name, filterableParameters);
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/support/filter/PrefilteredContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/PrefilteredContent.java
@@ -38,6 +38,10 @@ public abstract class PrefilteredContent extends Content {
         super(name);
     }
 
+    protected PrefilteredContent(String name, String... tokens) {
+        super(name, tokens);
+    }
+
     /**
      * Write the component in the bundle filtering the content
      * @param os OutputStream where write the content

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
@@ -557,7 +557,7 @@ public class AboutJenkins extends Component {
                 out.println("  * Mode:    WAR");
             }
             final JenkinsLocationConfiguration jlc = JenkinsLocationConfiguration.get();
-            out.println("  * Url:     " + (jlc != null ? jlc.getUrl() : "No JenkinsLocationConfiguration available"));
+            out.println("  * Url:     " + jlc.getUrl());
             try {
                 final ServletContext servletContext = Stapler.getCurrent().getServletContext();
                 out.println("  * Servlet container");
@@ -998,7 +998,7 @@ public class AboutJenkins extends Component {
     private class NodeChecksumsContent extends PrintedContent {
         private final Node node;
         NodeChecksumsContent(Node node) {
-            super("nodes/slave/" + node.getNodeName() + "/checksums.md5");
+            super("nodes/slave/{0}/checksums.md5", node.getNodeName());
             this.node = node;
         }
         @Override protected void printTo(PrintWriter out) throws IOException {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
@@ -557,7 +557,7 @@ public class AboutJenkins extends Component {
                 out.println("  * Mode:    WAR");
             }
             final JenkinsLocationConfiguration jlc = JenkinsLocationConfiguration.get();
-            out.println("  * Url:     " + jlc.getUrl());
+            out.println("  * Url:     " + (jlc != null ? jlc.getUrl() : "No JenkinsLocationConfiguration available"));
             try {
                 final ServletContext servletContext = Stapler.getCurrent().getServletContext();
                 out.println("  * Servlet container");

--- a/src/main/java/com/cloudbees/jenkins/support/impl/DumpExportTable.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/DumpExportTable.java
@@ -49,7 +49,7 @@ public class DumpExportTable extends Component {
   public void addContents(@NonNull Container result) {
     for (final Node node : Jenkins.getInstance().getNodes()) {
       result.add(
-        new TruncatedContent("nodes/slave/" + node.getNodeName() + "/exportTable.txt") {
+        new TruncatedContent("nodes/slave/{0}/exportTable.txt", node.getNodeName()) {
           @Override
           protected void printTo(PrintWriter out) throws IOException {
             try {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/EnvironmentVariables.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/EnvironmentVariables.java
@@ -66,7 +66,7 @@ public class EnvironmentVariables extends Component {
         );
         for (final Node node : Jenkins.getInstance().getNodes()) {
             result.add(
-                    new PrintedContent("nodes/slave/" + node.getNodeName() + "/environment.txt") {
+                    new PrintedContent("nodes/slave/{0}/environment.txt", node.getNodeName()) {
                         @Override
                         protected void printTo(PrintWriter out) throws IOException {
                             try {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/FileDescriptorLimit.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/FileDescriptorLimit.java
@@ -83,7 +83,7 @@ public class FileDescriptorLimit extends Component {
                 name = "slave/" + node.getNodeName();
             }
             container.add(
-                    new Content("nodes/" + name + "/file-descriptors.txt") {
+                    new Content("nodes/{0}/file-descriptors.txt", name) {
                         @Override
                         public void writeTo(OutputStream os) throws IOException {
                             PrintWriter out = new PrintWriter(new BufferedWriter(new OutputStreamWriter(os, "utf-8")));

--- a/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
@@ -133,7 +133,7 @@ public class GCLogs extends Component {
         LOGGER.finest("Found " + gcLogs.length + " matching files in " + parentDirectory.getAbsolutePath());
         for (File gcLog : gcLogs) {
             LOGGER.finest("Adding '" + gcLog.getName() + "' file");
-            result.add(new FileContent(GCLOGS_BUNDLE_ROOT + gcLog.getName(), gcLog));
+            result.add(new FileContent(GCLOGS_BUNDLE_ROOT + "{0}", new String[]{gcLog.getName()}, gcLog));
         }
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/impl/JenkinsLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/JenkinsLogs.java
@@ -80,14 +80,14 @@ public class JenkinsLogs extends Component {
     private void addLogRecorders(Container result) {
         for (Map.Entry<String, LogRecorder> entry : logRecorders.entrySet()) {
             String name = entry.getKey();
-            String entryName = "nodes/master/logs/custom/" + name + ".log";
+            String entryName = "nodes/master/logs/custom/{0}.log"; // name to be filtered in the bundle
             File storedFile = new File(customLogs, name + ".log");
             if (storedFile.isFile()) {
-                result.add(new FileContent(entryName, storedFile));
+                result.add(new FileContent(entryName, new String[]{name}, storedFile));
             } else {
                 // Was not stored for some reason; fine, just load the memory buffer.
                 final LogRecorder recorder = entry.getValue();
-                result.add(new LogRecordContent(entryName) {
+                result.add(new LogRecordContent(entryName, new String[]{name}) {
                     @Override
                     public Iterable<LogRecord> getLogRecords() {
                         return recorder.getLogRecords();
@@ -108,14 +108,14 @@ public class JenkinsLogs extends Component {
         File[] files = jenkins.getRootDir().listFiles(ROTATED_LOGFILE_FILTER);
         if (files != null) {
             for (File f : files) {
-                result.add(new FileContent("other-logs/" + f.getName(), f));
+                result.add(new FileContent("other-logs/{0}", new String[]{f.getName()}, f));
             }
         }
         File logs = getLogsRoot();
         files = logs.listFiles(ROTATED_LOGFILE_FILTER);
         if (files != null) {
             for (File f : files) {
-                result.add(new FileContent("other-logs/" + f.getName(), f));
+                result.add(new FileContent("other-logs/{0}", new String[]{f.getName()}, f));
             }
         }
 
@@ -123,7 +123,7 @@ public class JenkinsLogs extends Component {
         files = taskLogs.listFiles(ROTATED_LOGFILE_FILTER);
         if (files != null) {
             for (File f : files) {
-                result.add(new FileContent("other-logs/" + f.getName(), f));
+                result.add(new FileContent("other-logs/{0}", new String[]{f.getName()}, f));
             }
         }
     }
@@ -189,7 +189,7 @@ public class JenkinsLogs extends Component {
 
         // log records written to the disk
         for (File file : julLogFiles){
-            result.add(new FileContent("nodes/master/logs/" + file.getName(), file));
+            result.add(new FileContent("nodes/master/logs/{0}", new String[]{file.getName()}, file));
         }
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/impl/LoadStats.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/LoadStats.java
@@ -129,8 +129,8 @@ public class LoadStats extends Component {
             this.image = image;
         }
 
-        public ImageContent(String name, String[] tokens, BufferedImage image) {
-            super(name, tokens);
+        public ImageContent(String name, String[] filterableParameters, BufferedImage image) {
+            super(name, filterableParameters);
             this.image = image;
         }
 
@@ -168,8 +168,8 @@ public class LoadStats extends Component {
         private final long time;
         private final long clock;
 
-        public CsvContent(String name, String[] tokens, LoadStatistics stats, MultiStageTimeSeries.TimeScale scale) {
-            super(name, tokens);
+        public CsvContent(String name, String[] filterableParameters, LoadStatistics stats, MultiStageTimeSeries.TimeScale scale) {
+            super(name, filterableParameters);
 
             time = System.currentTimeMillis();
             clock = scale.tick;
@@ -246,8 +246,8 @@ public class LoadStats extends Component {
             super(name);
         }
 
-        public GnuPlotScript(String name, String... tokens) {
-            super(name, tokens);
+        public GnuPlotScript(String name, String... filterableParameters) {
+            super(name, filterableParameters);
         }
 
         @Override

--- a/src/main/java/com/cloudbees/jenkins/support/impl/LogRecordContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/LogRecordContent.java
@@ -26,6 +26,10 @@ public abstract class LogRecordContent extends PrefilteredContent {
         super(name);
     }
 
+    public LogRecordContent(String name, String... tokens) {
+        super(name, tokens);
+    }
+
     /**
      * Iterates {@link LogRecord}s to be printed as this content.
      *

--- a/src/main/java/com/cloudbees/jenkins/support/impl/LogRecordContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/LogRecordContent.java
@@ -26,8 +26,8 @@ public abstract class LogRecordContent extends PrefilteredContent {
         super(name);
     }
 
-    public LogRecordContent(String name, String... tokens) {
-        super(name, tokens);
+    public LogRecordContent(String name, String... filterableParameters) {
+        super(name, filterableParameters);
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/support/impl/MetricsContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/MetricsContent.java
@@ -32,8 +32,8 @@ public class MetricsContent extends Content {
         objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
     }
 
-    public MetricsContent(String name, String[] tokens,  MetricRegistry metricsRegistry) {
-        super(name, tokens);
+    public MetricsContent(String name, String[] filterableParameters,  MetricRegistry metricsRegistry) {
+        super(name, filterableParameters);
 
         this.registry = metricsRegistry;
         objectMapper = new ObjectMapper();

--- a/src/main/java/com/cloudbees/jenkins/support/impl/MetricsContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/MetricsContent.java
@@ -24,6 +24,17 @@ public class MetricsContent extends Content {
 
     public MetricsContent(String name, MetricRegistry metricsRegistry) {
         super(name);
+
+        this.registry = metricsRegistry;
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new MetricsModule(TimeUnit.MINUTES, TimeUnit.SECONDS, true));
+        objectMapper.registerModule(new HealthCheckModule());
+        objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+    }
+
+    public MetricsContent(String name, String[] tokens,  MetricRegistry metricsRegistry) {
+        super(name, tokens);
+
         this.registry = metricsRegistry;
         objectMapper = new ObjectMapper();
         objectMapper.registerModule(new MetricsModule(TimeUnit.MINUTES, TimeUnit.SECONDS, true));

--- a/src/main/java/com/cloudbees/jenkins/support/impl/NetworkInterfaces.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/NetworkInterfaces.java
@@ -77,7 +77,7 @@ public class NetworkInterfaces extends Component {
 
         for (final Node node : Jenkins.getInstance().getNodes()) {
             result.add(
-                    new Content("nodes/slave/" + node.getNodeName() + "/networkInterface.md") {
+                    new Content("nodes/slave/{0}/networkInterface.md", node.getNodeName()) {
                         @Override
                         public void writeTo(OutputStream os) throws IOException {
                             os.write(getNetworkInterface(node).getBytes("UTF-8"));

--- a/src/main/java/com/cloudbees/jenkins/support/impl/ProcFilesRetriever.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/ProcFilesRetriever.java
@@ -82,7 +82,7 @@ public abstract class ProcFilesRetriever extends Component {
         }
 
         for (Map.Entry<String, String> procDescriptor : getFilesToRetrieve().entrySet()) {
-            container.add(new FilePathContent("nodes/" + name + "/proc/" + procDescriptor.getValue(),
+            container.add(new FilePathContent("nodes/{0}/proc/{1}", new String[]{name, procDescriptor.getValue()},
                     new FilePath(c.getChannel(), procDescriptor.getKey())));
         }
 

--- a/src/main/java/com/cloudbees/jenkins/support/impl/RootCAs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/RootCAs.java
@@ -97,7 +97,7 @@ public class RootCAs extends Component {
       name = "slave/" + node.getNodeName();
     }
     container.add(
-            new Content("nodes/" + name + "/RootCA.txt") {
+            new Content("nodes/{0}/RootCA.txt", name) {
               @Override
               public void writeTo(OutputStream os) throws IOException {
                 PrintWriter out = new PrintWriter(new BufferedWriter(new OutputStreamWriter(os, "utf-8")));

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SlaveCommandStatistics.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SlaveCommandStatistics.java
@@ -69,7 +69,7 @@ public final class SlaveCommandStatistics extends Component {
 
     @Override
     public void addContents(Container container) {
-        statistics.forEach((name, stats) -> container.add(new PrintedContent("nodes/slave/" + name + "/command-stats.md") {
+        statistics.forEach((name, stats) -> container.add(new PrintedContent("nodes/slave/{0}/command-stats.md", name) {
             @Override
             protected void printTo(PrintWriter out) throws IOException {
                 stats.print(out);

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLaunchLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLaunchLogs.java
@@ -162,7 +162,7 @@ public class SlaveLaunchLogs extends Component{
             File[] files = s.dir.listFiles(ROTATED_LOGFILE_FILTER);
             if (files!=null)
                 for (File f : files) {
-                    result.add(new FileContent("nodes/slave/" + s.getName() + "/launchLogs/"+f.getName() , f, FileListCapComponent.MAX_FILE_SIZE));
+                    result.add(new FileContent("nodes/slave/{0}/launchLogs/{1}", new String[]{s.getName(), f.getName()} , f, FileListCapComponent.MAX_FILE_SIZE));
                 }
         }
     }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLogs.java
@@ -96,7 +96,7 @@ public class SlaveLogs extends Component {
         for (final Node node : Jenkins.get().getNodes()) {
             if (node.toComputer() instanceof SlaveComputer) {
                 container.add(
-                        new LogRecordContent("nodes/slave/" + node.getNodeName() + "/jenkins.log") {
+                        new LogRecordContent("nodes/slave/{0}/jenkins.log", node.getNodeName()) {
                             @Override
                             public Iterable<LogRecord> getLogRecords() throws IOException {
                                 Computer computer = node.toComputer();
@@ -169,7 +169,7 @@ public class SlaveLogs extends Component {
                         final Map<String, File> logFiles = logFetcher.forNode(node).getLogFiles(supportPath);
                         for (Map.Entry<String, File> entry : logFiles.entrySet()) {
                             result.add(new FileContent(
-                                    "nodes/slave/" + node.getNodeName() + "/logs/" + entry.getKey(),
+                                    "nodes/slave/{0}/logs/{1}", new String[]{node.getNodeName(), entry.getKey()},
                                     entry.getValue())
                             );
                         }
@@ -184,7 +184,7 @@ public class SlaveLogs extends Component {
         // but added nonetheless just in case.
         //
         // should be ignorable.
-        result.add(new LogRecordContent("nodes/slave/" + node.getNodeName() + "/logs/all_memory_buffer.log") {
+        result.add(new LogRecordContent("nodes/slave/{0}/logs/all_memory_buffer.log", node.getNodeName()) {
             @Override
             public Iterable<LogRecord> getLogRecords() throws IOException {
                 try {
@@ -209,7 +209,7 @@ public class SlaveLogs extends Component {
                     final Map<String, File> logFiles = logFetcher.forNode(node).getLogFiles(rootPath);
                     for (Map.Entry<String, File> entry : logFiles.entrySet()) {
                         result.add(new FileContent(
-                                "nodes/slave/" + node.getNodeName() + "/logs/winsw/" + entry.getKey(),
+                                "nodes/slave/{0}/logs/winsw/{1}", new String[] {node.getNodeName(), entry.getKey()},
                                 entry.getValue(), FileListCapComponent.MAX_FILE_SIZE)
                         );
                     }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SystemConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SystemConfiguration.java
@@ -99,10 +99,10 @@ public abstract class SystemConfiguration extends ProcFilesRetriever {
     @Override
     protected void afterAddUnixContents(@NonNull Container container, final @NonNull Node node, String name) {
         container.add(
-                CommandOutputContent.runOnNodeAndCache(sysCtlCache, node, "nodes/" + name + "/sysctl.txt", "/bin/sh", "-c", "sysctl -a"));
-        container.add(CommandOutputContent.runOnNode(node, "nodes/" + name + "/dmesg.txt", "/bin/sh", "-c", "(dmesg --ctime 2>/dev/null||dmesg) |tail -1000"));
-        container.add(CommandOutputContent.runOnNodeAndCache(userIdCache, node, "nodes/" + name + "/userid.txt", "/bin/sh", "-c", "id -a"));
-        container.add(new StringContent("nodes/" + name + "/dmi.txt", getDmiInfo(node)));
+                CommandOutputContent.runOnNodeAndCache(sysCtlCache, node, "nodes/{0}/sysctl.txt", new String[]{name},  "/bin/sh", "-c", "sysctl -a"));
+        container.add(CommandOutputContent.runOnNode(node, "nodes/{0}/dmesg.txt", new String[]{name}, "/bin/sh", "-c", "(dmesg --ctime 2>/dev/null||dmesg) |tail -1000"));
+        container.add(CommandOutputContent.runOnNodeAndCache(userIdCache, node, "nodes/{0}/userid.txt", new String[]{name}, "/bin/sh", "-c", "id -a"));
+        container.add(new StringContent("nodes/{0}/dmi.txt", new String[]{name}, getDmiInfo(node)));
     }
 
     public String getDmiInfo(Node node) {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SystemProperties.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SystemProperties.java
@@ -72,7 +72,7 @@ public class SystemProperties extends Component {
         );
         for (final Node node : Jenkins.getInstance().getNodes()) {
             result.add(
-                    new Content("nodes/slave/" + node.getNodeName() + "/system.properties") {
+                    new Content("nodes/slave/{0}/system.properties", node.getNodeName()) {
                         @Override
                         public void writeTo(OutputStream os) {
                             try {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/ThreadDumps.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/ThreadDumps.java
@@ -105,7 +105,7 @@ public class ThreadDumps extends Component {
                 SupportLogFormatter.printStackTrace(e, out);
                 out.close();
                 result.add(
-                        new StringContent("nodes/slave/" + node.getNodeName() + "/thread-dump.txt", sw.toString()));
+                        new StringContent("nodes/slave/{0}/thread-dump.txt", new String[]{node.getNodeName()}, sw.toString()));
                 continue;
             }
             if (threadDump == null) {
@@ -114,10 +114,10 @@ public class ThreadDumps extends Component {
                 buf.append("======\n");
                 buf.append("\n");
                 buf.append("N/A: No connection to node.\n");
-                result.add(new StringContent("nodes/slave/" + node.getNodeName() + "/thread-dump.txt", buf.toString()));
+                result.add(new StringContent("nodes/slave/{0}/thread-dump.txt", new String[]{node.getNodeName()}, buf.toString()));
             } else {
                 result.add(
-                        new Content("nodes/slave/" + node.getNodeName() + "/thread-dump.txt") {
+                        new Content("nodes/slave/{0}/thread-dump.txt", node.getNodeName()) {
                             @Override
                             public void writeTo(OutputStream os) throws IOException {
                                 PrintWriter out =

--- a/src/main/java/com/cloudbees/jenkins/support/timer/FileListCapComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/timer/FileListCapComponent.java
@@ -37,7 +37,7 @@ public abstract class FileListCapComponent extends Component {
             final Collection<File> files = FileUtils.listFiles(
                     fileListCap.getFolder(), new String[] {"txt"}, false);
             for (File f : files) {
-                container.add(new FileContent(fileListCap.getFolder().getName() + "/" + f.getName(), f, MAX_FILE_SIZE));
+                container.add(new FileContent("{0}/{1}", new String[]{fileListCap.getFolder().getName(), f.getName()}, f, MAX_FILE_SIZE));
             }
         }
     }

--- a/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
@@ -1,6 +1,7 @@
 package com.cloudbees.jenkins.support;
 
 import com.cloudbees.jenkins.support.api.Component;
+import com.cloudbees.jenkins.support.configfiles.OtherConfigFilesComponent;
 import com.cloudbees.jenkins.support.filter.ContentFilters;
 import com.cloudbees.jenkins.support.filter.ContentMappings;
 import com.cloudbees.jenkins.support.impl.AboutJenkins;
@@ -13,6 +14,7 @@ import hudson.ExtensionList;
 import hudson.model.Label;
 import hudson.model.Slave;
 import hudson.util.RingBufferLogHandler;
+import jenkins.model.Jenkins;
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Rule;
@@ -238,9 +240,6 @@ public class SupportActionTest {
         ZipFile anonymizedZip = generateBundle(componentsToCreate, true);
 
         bundlesMatch(zip, anonymizedZip, OBJECT_NAME, ContentMappings.get().getMappings().get(OBJECT_NAME));
-
-        //assertThat("Node name should be present when anonymization is disabled",
-        //      nodeComponentText, containsString(node.getNodeName()));
     }
 
     /**
@@ -255,7 +254,7 @@ public class SupportActionTest {
         // Debugging
         //entries.stream().forEach(entry -> System.out.println(entry));
         //System.out.println("nodes.md: \n"+ getContentZipEntry(zip,"nodes.md"));
-q
+
         List<String> anonymizedEntries = getFileNamesFromBundle(anonymizedZip);
 
         //The name of the node created becomes replaced, so we change it to how the anonymization process has left it

--- a/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
@@ -255,8 +255,10 @@ public class SupportActionTest {
         // Debugging
         //entries.stream().forEach(entry -> System.out.println(entry));
         //System.out.println("nodes.md: \n"+ getContentZipEntry(zip,"nodes.md"));
-
+q
         List<String> anonymizedEntries = getFileNamesFromBundle(anonymizedZip);
+
+        //The name of the node created becomes replaced, so we change it to how the anonymization process has left it
         List<String> anonymizedEntriesRestored = anonymizedEntries.stream().map(entry -> entry.replaceAll(anonymizedObjectName, objectName)).collect(Collectors.toList());
 
         // More debugging

--- a/src/test/java/com/cloudbees/jenkins/support/filter/ContentMappingsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/filter/ContentMappingsTest.java
@@ -25,28 +25,28 @@ package com.cloudbees.jenkins.support.filter;
 
 import hudson.model.FreeStyleProject;
 import jenkins.model.Jenkins;
-import org.apache.commons.io.IOUtils;
 import org.assertj.core.api.Assertions;
-import org.junit.*;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 import org.jvnet.hudson.test.recipes.LocalData;
 
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.file.Files;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.stream.StreamSupport;
-import java.util.zip.ZipFile;
 
 import static java.util.stream.Collectors.toList;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class ContentMappingsTest {
 

--- a/src/test/java/com/cloudbees/jenkins/support/filter/ContentMappingsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/filter/ContentMappingsTest.java
@@ -172,22 +172,4 @@ public class ContentMappingsTest {
             assertTrue(stopWords.contains(originalVersion));
         });
     }
-
-    /*
-    @Test
-    public void filteredNamesGeneratingBundle() {
-        JenkinsRule.JSONWebResponse jsonWebResponse = rule.postJSON(root.getUrlName() + s, "");
-        IOUtils.copy(jsonWebResponse.getContentAsStream(), Files.newOutputStream(zipFile.toPath()));
-        ZipFile z = new ZipFile(zipFile);
-        zj.
-
-        File zipFile = File.createTempFile("test", "zip");
-        ((File) zipFile).deleteOnExit();
-        FileOutputStream fileOutputStream = new FileOutputStream(tempLogFile);
-
-        ClearCaseChangeLogSet.saveToChangeLog(fileOutputStream, history);
-        fileOutputStream.close();
-
-        comprobar que el zip tiene las entradas bien
-    }*/
 }

--- a/src/test/java/com/cloudbees/jenkins/support/filter/ContentMappingsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/filter/ContentMappingsTest.java
@@ -25,17 +25,24 @@ package com.cloudbees.jenkins.support.filter;
 
 import hudson.model.FreeStyleProject;
 import jenkins.model.Jenkins;
+import org.apache.commons.io.IOUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.*;
 import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 import org.jvnet.hudson.test.recipes.LocalData;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.stream.StreamSupport;
+import java.util.zip.ZipFile;
 
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.*;
@@ -165,4 +172,22 @@ public class ContentMappingsTest {
             assertTrue(stopWords.contains(originalVersion));
         });
     }
+
+    /*
+    @Test
+    public void filteredNamesGeneratingBundle() {
+        JenkinsRule.JSONWebResponse jsonWebResponse = rule.postJSON(root.getUrlName() + s, "");
+        IOUtils.copy(jsonWebResponse.getContentAsStream(), Files.newOutputStream(zipFile.toPath()));
+        ZipFile z = new ZipFile(zipFile);
+        zj.
+
+        File zipFile = File.createTempFile("test", "zip");
+        ((File) zipFile).deleteOnExit();
+        FileOutputStream fileOutputStream = new FileOutputStream(tempLogFile);
+
+        ClearCaseChangeLogSet.saveToChangeLog(fileOutputStream, history);
+        fileOutputStream.close();
+
+        comprobar que el zip tiene las entradas bien
+    }*/
 }


### PR DESCRIPTION
See [[JENKINS-55843] Folders missed due to anonymization in the bundle](https://issues.jenkins-ci.org/browse/JENKINS-55843) 

When a bundle is anonymized and there are objects with tricky names, the zip could become corrupt.

For example, when you create labels like '/', the folders in the zip are not created and instead files acre created. Other tricky object naes are:  '.', ':', '\', or even 'a/b'.

Instead of:
jenkins-root-configuration-files **/** build-failure-analyzer.xml 
you get:
jenkins-root-configuration-files **user_steep_lung** build-failure-analyzer.xml

The first commit add three tests to probe the failure.

**ADVISORY**: As of this PR *Content* class has a specific constructor to filter the name of the files in the bundle. Any implementor needs to use this constructor to leave it clear what needs to be filtered (dynamic names most likely) and  what doesn't. It's a change in the current behavior where the complete name is filtered and due to that, the file/folder names in the zip may become currupt. I took this approach because it's the safest one and It's not likely to be many extra implementors so far.

The other approach is to keep the former constructor filtering all the file name and take the risk to have corrupt bundles. It's just a change on a line: https://github.com/jenkinsci/support-core-plugin/pull/161/files#diff-79928e08589e1f90af352ccce49d8eb0R360

@reviewbybees @jvz @varyvol 