### PR TITLE
[JENKINS-55014] Preload PrintWriter and Throwable

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/JenkinsLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/JenkinsLogs.java
@@ -22,6 +22,7 @@ import jenkins.model.Jenkins;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -242,6 +243,8 @@ public class JenkinsLogs extends Component {
                 SupportLogFormatter.class,
                 LogFlusher.class,
                 CopyOnWriteList.class,
+                PrintWriter.class,
+                Throwable.class,
             });
         }
 


### PR DESCRIPTION
[JENKINS-55014](https://issues.jenkins-ci.org/browse/JENKINS-55014)

In order to try to prevent a deadlock when the support bundle is generated at startup, try to preload `PrintWriter` and `Throwable` classes.

Idea from @dwnusbaum.

cc @oleg-nenashev 