### PR TITLE
[JENKINS-55866] Fix replacement with empty strings

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/util/WordReplacer.java
+++ b/src/main/java/com/cloudbees/jenkins/support/util/WordReplacer.java
@@ -60,7 +60,7 @@ public class WordReplacer {
 
         // the same number of word to replace and replaces to use
         if (words.length != replaces.length) {
-            throw new IllegalArgumentException(String.format("Words (%d) and replaces (%d) lenghts should be equals", words.length, replaces.length));
+            throw new IllegalArgumentException(String.format("Words (%d) and replaces (%d) lengths should be equals", words.length, replaces.length));
         }
 
         for(int i = 0; i < words.length; i++) {
@@ -120,6 +120,14 @@ public class WordReplacer {
         // The string to find (lower case if ignoreCase)
         String workWord;
 
+        if (input == null || word == null || input.length() == 0 || word.length() == 0) {
+            return;
+        }
+
+        if (replace == null) {
+            replace = "";
+        }
+
         // Use the lowercase versions to compare, but replace in the original input
         if (ignoreCase) {
             workInput = new StringBuilder(input.toString().toLowerCase(Locale.ENGLISH));
@@ -161,11 +169,14 @@ public class WordReplacer {
                 }
             }
 
-            // replace this word but in the original input (without changing the case)
-            input.replace(pos, pos + workWord.length(), replace);
+            if (pos >= 0 && pos < input.length()) {
+                // replace this word but in the original input (without changing the case)
+                input.replace(pos, pos + workWord.length(), replace);
+                workInput.replace(pos, pos + workWord.length(), replace);
+            }
 
             // move to the next character after the replace word
             pos = pos + replace.length();
-        } while (pos > -1);
+        } while (pos > -1 && pos < workInput.length());
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilterTest.java
@@ -45,21 +45,23 @@ public class SensitiveContentFilterTest {
     @Test
     public void anonymizeSlavesAndLabels() throws Exception {
         SensitiveContentFilter filter = SensitiveContentFilter.get();
-        jenkins.createSlave("foo", "bar", null);
-        jenkins.createSlave("jar", "war", null);
+        // using foo, bar, jar and war could raise flaky test failures. It happened to me when
+        // bar was changed by label_barrier :-O So we use stranger words to avoid this test to be flaky
+        jenkins.createSlave("foostrange", "barstrange", null);
+        jenkins.createSlave("jarstrange", "warstrange", null);
         filter.reload();
 
-        String foo = filter.filter("foo");
-        assertThat(foo).startsWith("computer_").doesNotContain("foo");
+        String foo = filter.filter("foostrange");
+        assertThat(foo).startsWith("computer_").doesNotContain("foostrange");
 
-        String bar = filter.filter("bar");
-        assertThat(bar).startsWith("label_").doesNotContain("bar");
+        String bar = filter.filter("barstrange");
+        assertThat(bar).startsWith("label_").doesNotContain("barstrange");
 
-        String jar = filter.filter("jar");
-        assertThat(jar).startsWith("computer_").doesNotContain("jar");
+        String jar = filter.filter("jarstrange");
+        assertThat(jar).startsWith("computer_").doesNotContain("jarstrange");
 
-        String war = filter.filter("war");
-        assertThat(war).startsWith("label_").doesNotContain("war");
+        String war = filter.filter("warstrange");
+        assertThat(war).startsWith("label_").doesNotContain("warstrange");
     }
 
     @Issue("JENKINS-21670")

--- a/src/test/java/com/cloudbees/jenkins/support/util/WordReplacerTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/util/WordReplacerTest.java
@@ -153,6 +153,20 @@ public class WordReplacerTest {
         Assert.assertEquals("1 1 b,B.c:C abc ABC ignored", inputSB.toString());
     }
 
+    @Test
+    public void indexOutOfBoundsExceptionTest() {
+        String input = "input one input";
+        String[] words = new String[]{   "input",   "one"};
+        String[] replaces = new String[]{"", ""};
+
+        String result = "  ";
+
+        String replaced = WordReplacer.replaceWords(input, words, replaces);
+
+        Assert.assertEquals(result, replaced);
+    }
+
+
     private List<String> generateFakeListString(int lines) {
         Assert.assertTrue(lines < 1001);
         return Stream.generate(() -> FilteredOutputStreamTest.FAKE_TEXT).limit(lines).collect(Collectors.toList());

--- a/src/test/java/com/cloudbees/jenkins/support/util/WordReplacerTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/util/WordReplacerTest.java
@@ -154,12 +154,12 @@ public class WordReplacerTest {
     }
 
     @Test
-    public void indexOutOfBoundsExceptionTest() {
+    public void replacementByShorterWordTest() {
         String input = "input one input";
         String[] words = new String[]{   "input",   "one"};
-        String[] replaces = new String[]{"", ""};
+        String[] replaces = new String[]{"i", "o"};
 
-        String result = "  ";
+        String result = "i o i";
 
         String replaced = WordReplacer.replaceWords(input, words, replaces);
 


### PR DESCRIPTION
See [JENKINS-55866](https://issues.jenkins-ci.org/browse/JENKINS-55866)

Previous PR was: https://github.com/jenkinsci/support-core-plugin/pull/163

This is a follow up ticket to fix the replacements with empty strings, a test and avoid flaky test that happened to me during testing.

@reviewbybees Specially: @varyvol @fcojfernandez @jvz 