### PR TITLE
JENKINS-56190 - Only include the proc files that has to be included.

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/JVMProcessSystemMetricsContents.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/JVMProcessSystemMetricsContents.java
@@ -2,9 +2,12 @@ package com.cloudbees.jenkins.support.impl;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import hudson.model.Node;
+import jenkins.model.Jenkins;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -17,6 +20,11 @@ public abstract class JVMProcessSystemMetricsContents extends ProcFilesRetriever
         @NonNull
         public String getDisplayName() {
             return "Master JVM process system metrics (Linux only)";
+        }
+
+        @Override
+        protected List<Node> getNodes() {
+            return Collections.singletonList(Jenkins.get());
         }
     }
 
@@ -31,6 +39,11 @@ public abstract class JVMProcessSystemMetricsContents extends ProcFilesRetriever
         @Override
         public boolean isSelectedByDefault() {
             return false;
+        }
+
+        @Override
+        protected List<Node> getNodes() {
+            return Jenkins.get().getNodes();
         }
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/impl/ProcFilesRetriever.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/ProcFilesRetriever.java
@@ -14,6 +14,7 @@ import jenkins.model.Jenkins;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
@@ -45,6 +46,8 @@ public abstract class ProcFilesRetriever extends Component {
      */
     abstract public Map<String, String> getFilesToRetrieve();
 
+    abstract protected List<Node> getNodes();
+
     @NonNull
     @Override
     public Set<Permission> getRequiredPermissions() {
@@ -53,10 +56,7 @@ public abstract class ProcFilesRetriever extends Component {
 
     @Override
     public void addContents(@NonNull Container container) {
-        Jenkins j = Jenkins.getInstance();
-        addUnixContents(container, j);
-
-        for (Node node : j.getNodes()) {
+        for (Node node : getNodes()) {
             addUnixContents(container, node);
         }
     }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/ProcFilesRetriever.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/ProcFilesRetriever.java
@@ -13,6 +13,7 @@ import hudson.security.Permission;
 import jenkins.model.Jenkins;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +47,14 @@ public abstract class ProcFilesRetriever extends Component {
      */
     abstract public Map<String, String> getFilesToRetrieve();
 
-    abstract protected List<Node> getNodes();
+    protected List<Node> getNodes() {
+        final Jenkins jenkins = Jenkins.get();
+        final List<Node> agents = jenkins.getNodes();
+        List<Node> allNodes = new ArrayList<>(agents.size() + 1);
+        allNodes.add(jenkins);
+        allNodes.addAll(agents);
+        return allNodes;
+    }
 
     @NonNull
     @Override

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SystemConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SystemConfiguration.java
@@ -37,10 +37,13 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
 
 /**
@@ -55,6 +58,11 @@ public abstract class SystemConfiguration extends ProcFilesRetriever {
         public String getDisplayName() {
             return "Master system configuration (Linux only)";
         }
+
+        @Override
+        protected List<Node> getNodes() {
+            return Collections.singletonList(Jenkins.get());
+        }
     }
 
     @Extension
@@ -68,6 +76,11 @@ public abstract class SystemConfiguration extends ProcFilesRetriever {
         @Override
         public boolean isSelectedByDefault() {
             return false;
+        }
+
+        @Override
+        protected List<Node> getNodes() {
+            return Jenkins.get().getNodes();
         }
     }
 


### PR DESCRIPTION
"Master JVM porcess system metrics" and "Agent system configuration"
components were only split in label. So all the files were included
twice. The node list to extract proc info from is abstracted. The
components are update to provide only the nodes from which data must
be collected.