### PR TITLE
[JENKINS-50297] WinSW logs not being cleaned up for cloud-provisioned (ephemeral) agents

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLogs.java
@@ -93,7 +93,8 @@ public class SlaveLogs extends Component {
         SmartLogFetcher logFetcher = new SmartLogFetcher("cache", new LogFilenameFilter()); // id is awkward because of backward compatibility
         SmartLogFetcher winswLogFetcher = new SmartLogFetcher("winsw", new WinswLogfileFilter());
 
-        for (final Node node : Jenkins.get().getNodes()) {
+        List<Node> nodes = Jenkins.get().getNodes();
+        for (final Node node : nodes) {
             if (node.toComputer() instanceof SlaveComputer) {
                 container.add(
                         new LogRecordContent("nodes/slave/{0}/jenkins.log", node.getNodeName()) {
@@ -117,6 +118,9 @@ public class SlaveLogs extends Component {
             addSlaveJulLogRecords(container, tasks, node, logFetcher);
             addWinsStdoutStderrLog(tasks, node, winswLogFetcher);
         }
+
+        new SmartLogCleaner("winsw", nodes).execute();
+        new SmartLogCleaner("cache", nodes).execute();
 
         // execute all the expensive computations in parallel to speed up the time
         if (!tasks.isEmpty()) {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SmartLogCleaner.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SmartLogCleaner.java
@@ -18,6 +18,7 @@ import com.cloudbees.jenkins.support.SupportPlugin;
  * <p>
  * Iterate over the cache entries stored by the {@link SmartLogFetcher} and remove those which 
  * belong to agents that are no longer attached.
+ * </p>
  */
 class SmartLogCleaner {
 

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SmartLogCleaner.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SmartLogCleaner.java
@@ -1,0 +1,94 @@
+package com.cloudbees.jenkins.support.impl;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+
+import com.cloudbees.jenkins.support.SupportPlugin;
+
+import hudson.Util;
+import hudson.model.Node;
+
+/**
+ * <p>
+ * Iterate over the cache entries stored by the {@link SmartLogFetcher} and remove those which 
+ * belong to agents that are no longer attached.
+ */
+class SmartLogCleaner {
+
+    private final File rootCacheDir;
+    private final Set<String> cacheKeys;
+
+    /**
+     * @param id
+     *      SmartLogCleaner only supports one directory full of log files.
+     *      So different IDs would have to be specified for different log files from different directories.
+     * @param nodes
+     *      Used to generate the cache keys to match within the target directory.
+     */
+    SmartLogCleaner(final String id, final List<Node> nodes) {
+        this.rootCacheDir = new File(SupportPlugin.getRootDirectory(), id);
+        this.cacheKeys = getActiveCacheKeys(nodes);
+    }
+
+    void execute() {
+        File[] cacheKeyDirs = rootCacheDir.listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(File current, String name) {
+              return new File(current, name).isDirectory();
+            }
+        });
+
+        if (cacheKeyDirs == null || cacheKeyDirs.length == 0) {
+            LOGGER.log(Level.FINE, "cacheKeys directory '{0]' is empty, nothing to clean up", rootCacheDir);
+        } else {
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            try {
+                executor.execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        for (File dir: cacheKeyDirs) {
+                            if (dir.isDirectory() && dir.exists() && cacheKeys.contains(dir.getName())) {
+                                LOGGER.log(Level.FINE, "cacheKey belongs to agent, keeping the directory '{0}'", dir.getName());
+                            } else {
+                                try {
+                                    FileUtils.deleteDirectory(dir);
+                                    LOGGER.log(Level.INFO, "The agent is no longer available, cache entry {0} was deleted", dir.getName());
+                                } catch (IOException e) {
+                                    LOGGER.log(Level.WARNING, "Couldn't remove the cache directory " + dir.getName(), e);
+                                }
+                            }
+                        }
+                    }
+                });
+            } catch (RuntimeException e) {
+                LOGGER.log(Level.WARNING, "The clean up task has ended with errors", e);
+            } finally {
+                executor.shutdown();
+            }
+        }
+    }
+
+    private Set<String> getActiveCacheKeys(final List<Node> nodes) {
+        Set<String> cacheKeys = new HashSet<>(nodes.size());
+        for (Node node : nodes) {
+            // can't use node.getRootPath() cause won't work with disconnected agents.
+            String cacheKey = Util.getDigestOf(node.getNodeName() + ":" + ((hudson.model.Slave)node).getRemoteFS());
+            LOGGER.log(Level.FINEST, "cacheKey {0} is active", cacheKey);
+            cacheKeys.add(StringUtils.right(cacheKey, 8));
+        }
+        return cacheKeys;
+    }
+
+    private static final Logger LOGGER = Logger.getLogger(SmartLogCleaner.class.getName());
+}

--- a/src/test/java/com/cloudbees/jenkins/support/impl/SmartLogCleanerTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/SmartLogCleanerTest.java
@@ -1,0 +1,87 @@
+package com.cloudbees.jenkins.support.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.List;
+import java.util.zip.ZipFile;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import com.cloudbees.jenkins.support.SupportPlugin;
+import com.cloudbees.jenkins.support.api.Component;
+import com.cloudbees.jenkins.support.filter.ContentFilters;
+
+import hudson.ExtensionList;
+import hudson.slaves.DumbSlave;
+
+public class SmartLogCleanerTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
+
+    @Test
+    public void cleanUp() throws Exception {
+
+        File supportDir = new File(j.getInstance().getRootDir(), "support");
+        File cacheDir = new File(supportDir, "winsw");
+
+        DumbSlave slave1 = j.createOnlineSlave();
+        DumbSlave slave2 = j.createOnlineSlave();
+        generateBundle();
+
+        assertNotNull("The cache directory is empty",cacheDir.list());
+
+        // wait for completion of SmartLogFetcher async tasks during the bundle generation
+        for (int i = 0; i <  10; i++) {
+            int cacheDirsCount = cacheDir.list().length;
+            if (cacheDir != null && cacheDir.list() != null && cacheDirsCount == 2) {
+                break;
+            } else {
+                Thread.sleep(1000 * 10);
+            }
+        }
+
+        assertEquals(cacheDir.list().length, 2);
+        j.getInstance().removeNode(slave2);
+
+        new SmartLogCleaner("winsw", j.getInstance().getNodes()).execute();
+
+        // wait for completion of SmartLogFetcher async tasks during the bundle generation
+        for (int i = 0; i <  10; i++) {
+            int cacheDirsCount = cacheDir.list().length;
+            if (cacheDir != null && cacheDir.list() != null && cacheDirsCount == 1) {
+                break;
+            } else {
+                Thread.sleep(1000 * 10);
+            }
+        }
+
+        assertEquals(cacheDir.list().length, 1);
+        j.getInstance().removeNode(slave1);
+
+    }
+
+    private ZipFile generateBundle() throws IOException {
+        List<Component> componentsToCreate = Collections.singletonList(ExtensionList.lookup(Component.class).get(SlaveLogs.class));
+        File bundleFile = temp.newFile();
+        try (OutputStream os = Files.newOutputStream(bundleFile.toPath())) {
+            ContentFilters.get().setEnabled(false);
+            SupportPlugin.writeBundle(os, componentsToCreate);
+            ZipFile zip = new ZipFile(bundleFile);
+            return zip;
+        }
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/support/impl/SmartLogCleanerTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/SmartLogCleanerTest.java
@@ -2,7 +2,6 @@ package com.cloudbees.jenkins.support.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 import java.io.File;
 import java.io.IOException;
@@ -57,7 +56,7 @@ public class SmartLogCleanerTest {
         assertEquals(cacheDir.list().length, 2);
         j.getInstance().removeNode(slave2);
 
-        new SmartLogCleaner("winsw", j.getInstance().getNodes()).execute();
+        generateBundle();
 
         // wait for completion of SmartLogFetcher async tasks during the bundle generation
         for (int i = 0; i <  10; i++) {
@@ -70,7 +69,6 @@ public class SmartLogCleanerTest {
         }
 
         assertEquals(cacheDir.list().length, 1);
-        j.getInstance().removeNode(slave1);
 
     }
 


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-50297

The issue was not only impacting over `winsw` agents logs but in every agent log. 

`SmartLogFetcher` is not removing the cache entries created by agents that are no longer attached to Jenkins. Sometimes these directories can take a big amount of disk space may cause a performance issue in the instance.

In this approach, `SmartLogCleaner` provides a way to clean up the directories which belong to nodes that are not attached anymore to Jenkins.