### PR TITLE
[JENKINS-58393] Catch exception thrown by getTime()

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -312,8 +312,8 @@ public class SupportPlugin extends Plugin {
                     }
                     final String name = getNameFiltered(maybeFilter, content.getName(), content.getFilterableParameters());
                     final ZipArchiveEntry entry = new ZipArchiveEntry(name);
-                    entry.setTime(content.getTime());
                     try {
+                        entry.setTime(content.getTime());
                         binaryOut.putArchiveEntry(entry);
                         binaryOut.flush();
                         OutputStream out = content.shouldBeFiltered() ? filteredOut : unfilteredOut;

--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -285,7 +285,7 @@ public class SupportPlugin extends Plugin {
         PrintWriter errorWriter = new PrintWriter(errors);
 
         try {
-            try (BulkChange change = new BulkChange(ContentMappings.get()); 
+            try (BulkChange change = new BulkChange(ContentMappings.get());
                  ZipArchiveOutputStream binaryOut = new ZipArchiveOutputStream(new BufferedOutputStream(outputStream, 16384))) {
                 // Get the filter to be used
                 Optional<ContentFilter> maybeFilter = getContentFilter();

--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -285,7 +285,7 @@ public class SupportPlugin extends Plugin {
         PrintWriter errorWriter = new PrintWriter(errors);
 
         try {
-            try (BulkChange change = new BulkChange(ContentMappings.get());
+            try (BulkChange change = new BulkChange(ContentMappings.get()); 
                  ZipArchiveOutputStream binaryOut = new ZipArchiveOutputStream(new BufferedOutputStream(outputStream, 16384))) {
                 // Get the filter to be used
                 Optional<ContentFilter> maybeFilter = getContentFilter();
@@ -312,8 +312,20 @@ public class SupportPlugin extends Plugin {
                     }
                     final String name = getNameFiltered(maybeFilter, content.getName(), content.getFilterableParameters());
                     final ZipArchiveEntry entry = new ZipArchiveEntry(name);
+                    
                     try {
                         entry.setTime(content.getTime());
+                    } catch (IOException ioe) {
+                        String msg = "Could not set the mtime for ''" + name + "'' in the support bundle";
+                        logger.log(Level.WARNING, msg, ioe);
+                        errorWriter.println(msg);
+                        errorWriter.println("-----------------------------------------------------------------------");
+                        errorWriter.println();
+                        Functions.printStackTrace(ioe, errorWriter);
+                        errorWriter.println();
+                    }
+                    
+                    try {
                         binaryOut.putArchiveEntry(entry);
                         binaryOut.flush();
                         OutputStream out = content.shouldBeFiltered() ? filteredOut : unfilteredOut;

--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -310,22 +310,12 @@ public class SupportPlugin extends Plugin {
                     if (content == null) {
                         continue;
                     }
+                    
                     final String name = getNameFiltered(maybeFilter, content.getName(), content.getFilterableParameters());
-                    final ZipArchiveEntry entry = new ZipArchiveEntry(name);
                     
                     try {
+                        final ZipArchiveEntry entry = new ZipArchiveEntry(name);
                         entry.setTime(content.getTime());
-                    } catch (IOException ioe) {
-                        String msg = "Could not set the mtime for ''" + name + "'' in the support bundle";
-                        logger.log(Level.WARNING, msg, ioe);
-                        errorWriter.println(msg);
-                        errorWriter.println("-----------------------------------------------------------------------");
-                        errorWriter.println();
-                        Functions.printStackTrace(ioe, errorWriter);
-                        errorWriter.println();
-                    }
-                    
-                    try {
                         binaryOut.putArchiveEntry(entry);
                         binaryOut.flush();
                         OutputStream out = content.shouldBeFiltered() ? filteredOut : unfilteredOut;
@@ -335,6 +325,9 @@ public class SupportPlugin extends Plugin {
                             content.writeTo(out);
                         }
                         out.flush();
+                        maybeFilteredOut.ifPresent(FilteredOutputStream::reset);
+                        selector.reset();
+                        binaryOut.closeArchiveEntry();
                     } catch (Throwable e) {
                         String msg = "Could not attach ''" + name + "'' to support bundle";
                         logger.log(Level.WARNING, msg, e);
@@ -343,10 +336,6 @@ public class SupportPlugin extends Plugin {
                         errorWriter.println();
                         Functions.printStackTrace(e, errorWriter);
                         errorWriter.println();
-                    } finally {
-                        maybeFilteredOut.ifPresent(FilteredOutputStream::reset);
-                        selector.reset();
-                        binaryOut.closeArchiveEntry();
                     }
                 }
                 errorWriter.close();

--- a/src/main/java/com/cloudbees/jenkins/support/api/FileContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/FileContent.java
@@ -79,7 +79,7 @@ public class FileContent extends PrefilteredContent {
     }
 
     @Override
-    public long getTime() throws IOException {
+    public long getTime() {
         return baseFileContent.getTime();
     }
 

--- a/src/test/java/com/cloudbees/jenkins/support/SupportPluginTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportPluginTest.java
@@ -3,7 +3,11 @@ package com.cloudbees.jenkins.support;
 import com.cloudbees.jenkins.support.api.Component;
 import com.cloudbees.jenkins.support.api.Container;
 import com.cloudbees.jenkins.support.api.Content;
+import com.cloudbees.jenkins.support.impl.AboutJenkins;
+import com.cloudbees.jenkins.support.impl.BuildQueue;
+import com.cloudbees.jenkins.support.impl.SystemProperties;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.ExtensionList;
 import hudson.security.Permission;
 import jenkins.model.Jenkins;
 import org.junit.Assert;
@@ -17,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -33,7 +38,7 @@ public class SupportPluginTest {
     @Test
     @Issue("JENKINS-58393")
     public void testGenerateBundleExceptionHandler() throws Exception {
-        List<Component> componentsToCreate = Collections.singletonList(new Component() {
+        List<Component> componentsToCreate = Arrays.asList(new Component() {
             @NonNull
             @Override
             public Set<Permission> getRequiredPermissions() {
@@ -60,7 +65,11 @@ public class SupportPluginTest {
                     }
                 });
             }
-        });
+        },
+                ExtensionList.lookup(Component.class).get(AboutJenkins.class),
+                ExtensionList.lookup(Component.class).get(BuildQueue.class),
+                ExtensionList.lookup(Component.class).get(SystemProperties.class)
+        );
 
         File bundleFile = temp.newFile();
         
@@ -69,8 +78,12 @@ public class SupportPluginTest {
         }
         
         ZipFile zip = new ZipFile(bundleFile);
-        Assert.assertNotNull(zip.getEntry("test/testGenerateBundleExceptionHandler.md"));
+        Assert.assertNull(zip.getEntry("test/testGenerateBundleExceptionHandler.md"));
         Assert.assertNotNull(zip.getEntry("manifest.md"));
         Assert.assertNotNull(zip.getEntry("manifest/errors.txt"));
+        Assert.assertNotNull(zip.getEntry("buildqueue.md"));
+        Assert.assertNotNull(zip.getEntry("nodes/master/system.properties"));
+        Assert.assertNotNull(zip.getEntry("about.md"));
+        Assert.assertNotNull(zip.getEntry("nodes.md"));
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/support/SupportPluginTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportPluginTest.java
@@ -1,0 +1,76 @@
+package com.cloudbees.jenkins.support;
+
+import com.cloudbees.jenkins.support.api.Component;
+import com.cloudbees.jenkins.support.api.Container;
+import com.cloudbees.jenkins.support.api.Content;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.security.Permission;
+import jenkins.model.Jenkins;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.zip.ZipFile;
+
+public class SupportPluginTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+    
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
+
+    @Test
+    @Issue("JENKINS-58393")
+    public void testGenerateBundleExceptionHandler() throws Exception {
+        List<Component> componentsToCreate = Collections.singletonList(new Component() {
+            @NonNull
+            @Override
+            public Set<Permission> getRequiredPermissions() {
+                return Collections.singleton(Jenkins.ADMINISTER);
+            }
+
+            @NonNull
+            @Override
+            public String getDisplayName() {
+                return "JENKINS-58393 Test";
+            }
+
+            @Override
+            public void addContents(@NonNull Container container) {
+                container.add(new Content("test/testGenerateBundleExceptionHandler.md") {
+                    @Override
+                    public void writeTo(OutputStream os) throws IOException {
+                        os.write("test".getBytes("UTF-8"));
+                    }
+
+                    @Override
+                    public long getTime() throws IOException {
+                        throw new IOException("JENKINS-58393: Exception should not fail the generation");
+                    }
+                });
+            }
+        });
+
+        File bundleFile = temp.newFile();
+        
+        try (OutputStream os = Files.newOutputStream(bundleFile.toPath())) {
+            SupportPlugin.writeBundle(os, componentsToCreate);
+        }
+        
+        ZipFile zip = new ZipFile(bundleFile);
+        Assert.assertNotNull(zip.getEntry("test/testGenerateBundleExceptionHandler.md"));
+        Assert.assertNotNull(zip.getEntry("manifest.md"));
+        Assert.assertNotNull(zip.getEntry("manifest/errors.txt"));
+    }
+}


### PR DESCRIPTION
[JENKINS-58393](https://issues.jenkins-ci.org/browse/JENKINS-58393): An exception may be thrown when doing a `getTime()` but is not caught in the loop on contents.