### PR TITLE
[JENKINS-57602] Check null strings to avoid a message in the log

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/util/Markdown.java
+++ b/src/main/java/com/cloudbees/jenkins/support/util/Markdown.java
@@ -1,6 +1,6 @@
 package com.cloudbees.jenkins.support.util;
 
-import hudson.model.Describable;
+import javax.annotation.CheckForNull;
 
 public final class Markdown {
     public static final String NONE_STRING = "(none)";
@@ -10,11 +10,11 @@ public final class Markdown {
         throw new AssertionError("Not instantiable");
     }
 
-    public static String escapeUnderscore(String raw) {
-        return raw.replaceAll("_", "&#95;");
+    public static String escapeUnderscore(@CheckForNull String raw) {
+        return (raw == null) ? null : raw.replaceAll("_", "&#95;");
     }
-    public static String escapeBacktick(String raw) {
-        return raw.replaceAll("`", "&#96;");
+    public static String escapeBacktick(@CheckForNull String raw) {
+        return (raw == null) ? null : raw.replaceAll("`", "&#96;");
     }
 
     public static String prettyNone(String raw) { return raw != null && !raw.isEmpty() ? raw : NONE_STRING; }


### PR DESCRIPTION
See [JENKINS-57602](https://issues.jenkins-ci.org/browse/JENKINS-57602)

It doesn't deserve more effort, it's usual to have problems while gathering the data.

Avoid an NPE message in the logs.
And a not used import.

Changelog:
* Avoid an extra message in the log