### PR TITLE
[JENKINS-47449] Update version of metrics plugin to cleanup dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>metrics</artifactId>
-      <version>3.0.0</version>
+      <version>3.1.2.6</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
[JENKINS-47449](https://issues.jenkins-ci.org/browse/JENKINS-47449): Bump the version of the metrics plugin to remove transitive dependency on `com.google.code.findbugs:jsr305`

cc  @jtnord 