### PR TITLE
[JENKINS-58980] Only include latest GC logs

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
@@ -35,13 +35,13 @@ public class GCLogs extends Component {
 
     static final String GCLOGS_ROTATION_SWITCH = "-XX:+UseGCLogFileRotation";
 
-    private static final String GCLOGS_RETENTION_PROPERTY = GCLogs.class.getCanonicalName() + ".retention";
+    private static final String GCLOGS_RETENTION_PROPERTY = GCLogs.class.getName() + ".retention";
 
     /**
      * How many days of garbage collector log files should be included in the bundle. 
      * By default {@code 5} days. Any value less or equals to {@code 0} disables the retention.
      */
-    private static final Integer GCLOGS_RETENTION_DAYS = Math.max(0, Integer.getInteger(GCLOGS_RETENTION_PROPERTY, 5));
+    private static final Integer GCLOGS_RETENTION_DAYS = Integer.getInteger(GCLOGS_RETENTION_PROPERTY, 5);
 
     private static final String GCLOGS_BUNDLE_ROOT = "/nodes/master/logs/gc/";
 

--- a/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
@@ -39,9 +39,9 @@ public class GCLogs extends Component {
 
     /**
      * How many days of garbage collector log files should be included in the bundle. 
-     * By default {@code 3} days. Any value less or equals to {@code 0} disables the retention.
+     * By default {@code 5} days. Any value less or equals to {@code 0} disables the retention.
      */
-    private static final Integer GCLOGS_RETENTION_DAYS = Math.max(0, Integer.getInteger(GCLOGS_RETENTION_PROPERTY, 2));
+    private static final Integer GCLOGS_RETENTION_DAYS = Math.max(0, Integer.getInteger(GCLOGS_RETENTION_PROPERTY, 5));
 
     private static final String GCLOGS_BUNDLE_ROOT = "/nodes/master/logs/gc/";
 

--- a/src/test/java/com/cloudbees/jenkins/support/impl/GCLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/GCLogsTest.java
@@ -4,6 +4,7 @@ import com.cloudbees.jenkins.support.api.Container;
 import com.cloudbees.jenkins.support.api.Content;
 import com.google.common.io.Files;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
@@ -77,6 +78,10 @@ public class GCLogsTest {
         new GCLogs(finder).addContents(container);
 
         assertEquals(5, container.getContents().size());
+        Assertions.assertThat(container.getContents())
+                .extracting("file", File.class)
+                .extractingResultOf("getName")
+                .contains("gc3421.log0", "gc3421.log1", "gc3421.log2", "gc3421.log3", "gc3421.log4"); 
     }
 
     private static class TestContainer extends Container {

--- a/src/test/java/com/cloudbees/jenkins/support/impl/GCLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/GCLogsTest.java
@@ -62,7 +62,7 @@ public class GCLogsTest {
         for (int count = 0; count < 10; count++) {
             File gcLogFile = new File(tempDir, "gc5625.log" + count);
             Files.touch(gcLogFile);
-            gcLogFile.setLastModified(currentTime - TimeUnit.DAYS.toMillis(2));
+            gcLogFile.setLastModified(currentTime - TimeUnit.DAYS.toMillis(5));
         }
         for (int count = 0; count < 5; count++) {
             Files.touch(new File(tempDir, "gc3421.log" + count));

--- a/src/test/java/com/cloudbees/jenkins/support/impl/GCLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/GCLogsTest.java
@@ -5,10 +5,12 @@ import com.cloudbees.jenkins.support.api.Content;
 import com.google.common.io.Files;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -50,6 +52,31 @@ public class GCLogsTest {
         new GCLogs(finder).addContents(container);
 
         assertEquals(15, container.getContents().size());
+    }
+
+    @Test
+    @Issue("JENKINS-58980")
+    public void latestFiles() throws Exception {
+        File tempDir = Files.createTempDir();
+        long currentTime = System.currentTimeMillis();
+        for (int count = 0; count < 10; count++) {
+            File gcLogFile = new File(tempDir, "gc5625.log" + count);
+            Files.touch(gcLogFile);
+            gcLogFile.setLastModified(currentTime - TimeUnit.DAYS.toMillis(2));
+        }
+        for (int count = 0; count < 5; count++) {
+            Files.touch(new File(tempDir, "gc3421.log" + count));
+        }
+
+        GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
+        when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH + new File(tempDir, "gc%p.log").getAbsolutePath());
+        when(finder.findVmArgument(GCLogs.GCLOGS_ROTATION_SWITCH)).thenReturn(GCLogs.GCLOGS_ROTATION_SWITCH);
+
+        TestContainer container = new TestContainer();
+
+        new GCLogs(finder).addContents(container);
+
+        assertEquals(5, container.getContents().size());
     }
 
     private static class TestContainer extends Container {


### PR DESCRIPTION
[JENKINS-58980](https://issues.jenkins-ci.org/browse/JENKINS-58980): Limit the number of GC logs to include in the support bundle, keeping only the latest ones.

* By default, discard GC logs files older than 2 days (last modified date)
* Ability to change / disable this behavior via a system property `com.cloudbees.jenkins.support.impl.GCLogs.retention` accepting a value in days