### PR TITLE
More gracefully handle a configuration file deleted while the bundle is being written

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/api/BaseFileContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/BaseFileContent.java
@@ -83,7 +83,7 @@ class BaseFileContent {
                     is.close();
                 }
             }
-        } catch (FileNotFoundException e) {
+        } catch (FileNotFoundException e) { // TODO FilePathContent.isFileNotFound?
             OutputStreamWriter osw = new OutputStreamWriter(os, ENCODING);
             try {
                 PrintWriter pw = new PrintWriter(osw, true);
@@ -124,7 +124,7 @@ class BaseFileContent {
                     }
                 }
             }
-        } catch (FileNotFoundException | NoSuchFileException e ) {
+        } catch (FileNotFoundException | NoSuchFileException e ) { // TODO FilePathContent.isFileNotFound?
             OutputStreamWriter osw = new OutputStreamWriter(os, ENCODING);
             try {
                 PrintWriter pw = new PrintWriter(osw, true);

--- a/src/main/java/com/cloudbees/jenkins/support/api/FileContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/FileContent.java
@@ -26,15 +26,15 @@ package com.cloudbees.jenkins.support.api;
 
 import com.cloudbees.jenkins.support.filter.ContentFilter;
 import com.cloudbees.jenkins.support.filter.PrefilteredContent;
-
+import hudson.Functions;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.function.Supplier;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Content that is stored as a file on disk. The content is filtered with the {@link ContentFilter} defined in the
@@ -46,7 +46,6 @@ public class FileContent extends PrefilteredContent {
     protected BaseFileContent baseFileContent;
     // to keep compatibility
     protected final File file;
-    private final Logger LOGGER = Logger.getLogger(this.getClass().getName());
 
     public FileContent(String name, File file) {
         this(name, file, -1);
@@ -97,8 +96,7 @@ public class FileContent extends PrefilteredContent {
             try {
                 return getInputStream();
             } catch (IOException e) {
-                LOGGER.log(Level.WARNING, "Error opening file " + file, e);
-                return null;
+                return new ByteArrayInputStream(Functions.printThrowable(e).getBytes(StandardCharsets.UTF_8));
             }
         };
         return  new BaseFileContent(file, supplier, maxSize);


### PR DESCRIPTION
At least once, I observed a pair of exceptions from the system log of CloudBees Core while it was starting up. I believe this was due to `queue.xml` being deleted at some random time during the bundle write.

```
… com.cloudbees.jenkins.support.api.FileContent lambda$createBaseFileContent$0
WARNING: Error opening file /var/jenkins_home/queue.xml
java.io.FileNotFoundException: File '/var/jenkins_home/queue.xml' does not exist
	at org.apache.commons.io.FileUtils.openInputStream(FileUtils.java:297)
	at org.apache.commons.io.FileUtils.readFileToString(FileUtils.java:1805)
	at org.apache.commons.io.FileUtils.readFileToString(FileUtils.java:1838)
	at com.cloudbees.jenkins.support.configfiles.SecretHandler.findSecrets(SecretHandler.java:96)
	at com.cloudbees.jenkins.support.configfiles.XmlRedactedSecretFileContent.getInputStream(XmlRedactedSecretFileContent.java:25)
	at com.cloudbees.jenkins.support.api.FileContent.lambda$createBaseFileContent$0(FileContent.java:98)
	at com.cloudbees.jenkins.support.api.BaseFileContent.writeTo(BaseFileContent.java:76)
	at com.cloudbees.jenkins.support.api.FileContent.writeTo(FileContent.java:73)
	at com.cloudbees.jenkins.support.SupportPlugin.writeBundle(SupportPlugin.java:327)
	at com.cloudbees.jenkins.support.SupportPlugin.writeBundle(SupportPlugin.java:279)
	at com.cloudbees.jenkins.support.SupportPlugin$PeriodicWorkImpl.lambda$doRun$0(SupportPlugin.java:851)
	at java.lang.Thread.run(Thread.java:748)
… com.cloudbees.jenkins.support.SupportPlugin writeBundle
WARNING: Could not attach ''jenkins-root-configuration-files/queue.xml'' to support bundle
java.lang.NullPointerException
	at org.apache.commons.io.IOUtils.copyLarge(IOUtils.java:2314)
	at org.apache.commons.io.IOUtils.copy(IOUtils.java:2270)
	at org.apache.commons.io.IOUtils.copyLarge(IOUtils.java:2291)
	at org.apache.commons.io.IOUtils.copy(IOUtils.java:2246)
	at com.cloudbees.jenkins.support.api.BaseFileContent.writeTo(BaseFileContent.java:78)
	at com.cloudbees.jenkins.support.api.FileContent.writeTo(FileContent.java:73)
	at com.cloudbees.jenkins.support.SupportPlugin.writeBundle(SupportPlugin.java:327)
	at com.cloudbees.jenkins.support.SupportPlugin.writeBundle(SupportPlugin.java:279)
	at com.cloudbees.jenkins.support.SupportPlugin$PeriodicWorkImpl.lambda$doRun$0(SupportPlugin.java:851)
	at java.lang.Thread.run(Thread.java:748)
```

This PR just moves the stack trace into the bundle content itself (I suppose it could just skip the file altogether, but this was easiest), and stays quiet on the system log.