### PR TITLE
Avoid capturing an automatic bundle immediately after startup

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -816,6 +816,11 @@ public class SupportPlugin extends Plugin {
         }
 
         @Override
+        public long getInitialDelay() {
+            return TimeUnit.MINUTES.toMillis(5);
+        }
+
+        @Override
         protected synchronized void doRun() throws Exception {
             if (Main.isUnitTest) {
                 return;

--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -817,7 +817,7 @@ public class SupportPlugin extends Plugin {
 
         @Override
         public long getInitialDelay() {
-            return TimeUnit.MINUTES.toMillis(5);
+            return TimeUnit.MINUTES.toMillis(3);
         }
 
         @Override


### PR DESCRIPTION
I have noticed that managed masters in CloudBees Core can be unexpectedly slow to start, and thread dumps often implicate automatic support bundle capture. It seems this happens within ~7s of Jenkins starting up, during which time lots of stuff is still being initialized, so attempting to browse the web UI can be quite slow as Jelly compilation competes with background support file writing often of hundreds of Kib of content. Better to defer this for a few minutes until Jenkins is comfortably up and running.

Workaround: `-Dcom.cloudbees.jenkins.support.SupportPlugin.AUTO_BUNDLE_PERIOD_HOURS=0`