### PR TITLE
LogFlusher should run before shutting down Jenkins

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/JenkinsLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/JenkinsLogs.java
@@ -11,6 +11,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressWarnings;
 import hudson.Extension;
 import hudson.WebAppMain;
+import hudson.init.Terminator;
 import hudson.logging.LogRecorder;
 import hudson.model.PeriodicWork;
 import hudson.security.Permission;
@@ -290,6 +291,10 @@ public class JenkinsLogs extends Component {
         }
 
         @Override protected void doRun() throws Exception {
+            flush();
+        }
+
+        @Terminator public static void flush() {
             Handler[] handlers;
             synchronized (LogFlusher.class) {
                 handlers = unflushedHandlers.toArray(new Handler[unflushedHandlers.size()]);


### PR DESCRIPTION
While investigating some activity in the last few seconds before the Jenkins JVM exits, I noticed that some log messages were getting lost. This patch seems to fix it.