### PR TITLE
[JENKINS-59714] Remove the pinned/unpinned information

### DIFF
--- a/src/test/java/com/cloudbees/jenkins/support/impl/AboutJenkinsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/AboutJenkinsTest.java
@@ -6,7 +6,6 @@ package com.cloudbees.jenkins.support.impl;
 import com.cloudbees.jenkins.support.SupportTestUtils;
 import com.cloudbees.jenkins.support.api.Component;
 import hudson.ExtensionList;
-import hudson.PluginWrapper;
 import jenkins.model.identity.IdentityRootAction;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/com/cloudbees/jenkins/support/impl/AboutJenkinsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/AboutJenkinsTest.java
@@ -6,6 +6,7 @@ package com.cloudbees.jenkins.support.impl;
 import com.cloudbees.jenkins.support.SupportTestUtils;
 import com.cloudbees.jenkins.support.api.Component;
 import hudson.ExtensionList;
+import hudson.PluginWrapper;
 import jenkins.model.identity.IdentityRootAction;
 import org.junit.Rule;
 import org.junit.Test;


### PR DESCRIPTION
* The pinned/unpinned feature is not used in Jenkins 2.x
* Core always returns unpinned
* It makes the active.txt incompatible with downstream tools.