### PR TITLE
[JENKINS-59696] Fix ContentFilters dynamic loading issue

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -400,7 +400,7 @@ public class SupportPlugin extends Plugin {
      */
     public static Optional<ContentFilter> getContentFilter() {
         ContentFilters filters = ContentFilters.get();
-        if (filters.isEnabled()) {
+        if (filters != null  && filters.isEnabled()) {
             ContentFilter filter = ContentFilter.ALL;
             return Optional.of(filter);
         }

--- a/src/main/java/com/cloudbees/jenkins/support/filter/ContentFilters.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/ContentFilters.java
@@ -25,7 +25,6 @@
 package com.cloudbees.jenkins.support.filter;
 
 import hudson.Extension;
-import hudson.ExtensionList;
 import jenkins.model.GlobalConfiguration;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -44,7 +43,7 @@ import javax.annotation.Nonnull;
 public class ContentFilters extends GlobalConfiguration {
 
     public static ContentFilters get() {
-        return ExtensionList.lookupSingleton(ContentFilters.class);
+        return GlobalConfiguration.all().get(ContentFilters.class);
     }
 
     private boolean enabled;

--- a/src/main/java/com/cloudbees/jenkins/support/timer/DeadlockTrackChecker.java
+++ b/src/main/java/com/cloudbees/jenkins/support/timer/DeadlockTrackChecker.java
@@ -55,10 +55,10 @@ public class DeadlockTrackChecker extends PeriodicWork {
                 builder.println("==============");
                 ThreadInfo[] deadLockThreads = mbean.getThreadInfo(deadLocks, Integer.MAX_VALUE);
 
-                Optional<ContentFilter> contentFilter = SupportPlugin.getContentFilter();
+                ContentFilter contentFilter = SupportPlugin.getContentFilter().orElse(null);
                 for (ThreadInfo threadInfo : deadLockThreads) {
                     try {
-                        ThreadDumps.printThreadInfo(builder, threadInfo, mbean, contentFilter.orElse(null));
+                        ThreadDumps.printThreadInfo(builder, threadInfo, mbean, contentFilter);
                     } catch (LinkageError e) {
                         builder.println(threadInfo);
                     }

--- a/src/main/java/com/cloudbees/jenkins/support/timer/DeadlockTrackChecker.java
+++ b/src/main/java/com/cloudbees/jenkins/support/timer/DeadlockTrackChecker.java
@@ -1,7 +1,6 @@
 package com.cloudbees.jenkins.support.timer;
 
 import com.cloudbees.jenkins.support.SupportPlugin;
-import com.cloudbees.jenkins.support.filter.ContentFilter;
 import com.cloudbees.jenkins.support.impl.ThreadDumps;
 import hudson.Extension;
 import hudson.model.PeriodicWork;
@@ -22,12 +21,10 @@ import java.util.concurrent.TimeUnit;
  */
 @Extension
 public class DeadlockTrackChecker extends PeriodicWork {
-    final ContentFilter filter;
 
     final SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd-HHmmss");
     {
         format.setTimeZone(TimeZone.getTimeZone("UTC"));
-        filter = SupportPlugin.getContentFilter().orElse(null);
     }
     final FileListCap logs = new FileListCap(new File(Jenkins.getInstance().getRootDir(),"deadlocks"), 50);
 
@@ -58,7 +55,8 @@ public class DeadlockTrackChecker extends PeriodicWork {
 
                 for (ThreadInfo threadInfo : deadLockThreads) {
                     try {
-                        ThreadDumps.printThreadInfo(builder, threadInfo, mbean, filter);
+                        ThreadDumps.printThreadInfo(builder, threadInfo, mbean, 
+                                SupportPlugin.getContentFilter().orElse(null));
                     } catch (LinkageError e) {
                         builder.println(threadInfo);
                     }

--- a/src/main/java/com/cloudbees/jenkins/support/timer/DeadlockTrackChecker.java
+++ b/src/main/java/com/cloudbees/jenkins/support/timer/DeadlockTrackChecker.java
@@ -1,6 +1,7 @@
 package com.cloudbees.jenkins.support.timer;
 
 import com.cloudbees.jenkins.support.SupportPlugin;
+import com.cloudbees.jenkins.support.filter.ContentFilter;
 import com.cloudbees.jenkins.support.impl.ThreadDumps;
 import hudson.Extension;
 import hudson.model.PeriodicWork;
@@ -13,6 +14,7 @@ import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Optional;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
@@ -53,10 +55,10 @@ public class DeadlockTrackChecker extends PeriodicWork {
                 builder.println("==============");
                 ThreadInfo[] deadLockThreads = mbean.getThreadInfo(deadLocks, Integer.MAX_VALUE);
 
+                Optional<ContentFilter> contentFilter = SupportPlugin.getContentFilter();
                 for (ThreadInfo threadInfo : deadLockThreads) {
                     try {
-                        ThreadDumps.printThreadInfo(builder, threadInfo, mbean, 
-                                SupportPlugin.getContentFilter().orElse(null));
+                        ThreadDumps.printThreadInfo(builder, threadInfo, mbean, contentFilter.orElse(null));
                     } catch (LinkageError e) {
                         builder.println(threadInfo);
                     }


### PR DESCRIPTION
[JENKINS-59696](https://issues.jenkins-ci.org/browse/JENKINS-59696): This should fix the dynamic loading issues we encounter. The main fix is what has been done in the `DeadlockTrackChecker`. 
Note: Based on my findings, the use of `GlobalConfiguration.all().get(ContentFilters.class)` instead of `ExtensionList.lookupSingleton(ContentFilters.class)` seems to be general workaround to prevent loading the extension twice.

@MRamonLeon @jglick 