### PR TITLE
Fix the checking of env vars using an existing env var instead of path

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/filter/FilteredConstants.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/FilteredConstants.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
 
 final class FilteredConstants {
 
-    static final Pattern EOL = Pattern.compile("\r?\n");
+    static final Pattern EOL = Pattern.compile("\r?\n|" + '\0');
     static final int DEFAULT_DECODER_CAPACITY = 1024;
 
     private FilteredConstants() {

--- a/src/main/java/com/cloudbees/jenkins/support/util/StreamUtils.java
+++ b/src/main/java/com/cloudbees/jenkins/support/util/StreamUtils.java
@@ -72,6 +72,6 @@ public final class StreamUtils {
 
     private static boolean isNonWhitespaceControlCharacter(byte b) {
         char c = (char) (b & 0xff);
-        return Character.isISOControl(c) && c != '\t' && c != '\n' && c != '\r';
+        return Character.isISOControl(c) && c != '\t' && c != '\n' && c != '\r' && c != '\0';
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/support/CheckFilterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/CheckFilterTest.java
@@ -136,9 +136,9 @@ public class CheckFilterTest {
         jenkins.jenkins.getView("all").rename(VIEW_ALL_NEW_NAME);
         jenkins.jenkins.save();
 
-        // Create the slave slave0 for some components
-        jenkins.createOnlineSlave();
-
+        // Create the slave slave0 for some components and wait until it's online
+        jenkins.waitOnline(jenkins.createOnlineSlave());
+        
         // Create a job to have something pending in the queue for the BuilQueue component
         FreeStyleProject project = jenkins.createFreeStyleProject(JOB_NAME);
         project.setAssignedLabel(new LabelAtom("foo")); //it's mandatory

--- a/src/test/java/com/cloudbees/jenkins/support/CheckFilterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/CheckFilterTest.java
@@ -117,7 +117,7 @@ public class CheckFilterTest {
     private QueueTaskFuture<FreeStyleBuild> createObjectsWithNames() throws Exception {
         // For an environment variable
         if (ENV_VAR != null) {
-            User.getOrCreateByIdOrFullName("path");
+            User.getOrCreateByIdOrFullName(ENV_VAR);
         }
 
         // For JVMProcessSytemMetricsContents

--- a/src/test/java/com/cloudbees/jenkins/support/util/OutputStreamSelectorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/util/OutputStreamSelectorTest.java
@@ -163,10 +163,10 @@ public class OutputStreamSelectorTest {
         for (int i = 0; i < 1024; i++) {
             selector.write(0);
         }
-        verify(binaryOut, never()).flush();
+        verify(textOut, never()).flush();
         selector.flush();
-        verify(binaryOut).flush();
-        verifyNoMoreInteractions(textOut);
+        verify(textOut).flush();
+        verifyNoMoreInteractions(binaryOut);
     }
 
     @Test

--- a/src/test/java/com/cloudbees/jenkins/support/util/StreamUtilsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/util/StreamUtilsTest.java
@@ -1,0 +1,13 @@
+package com.cloudbees.jenkins.support.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StreamUtilsTest {
+
+    @Test
+    public void nullCharacterShouldNotMarkFileAsBinary() {
+        String withNullCharacter = "a" + '\0' + "b";
+        Assert.assertFalse(StreamUtils.isNonWhitespaceControlCharacter(withNullCharacter.getBytes()));
+    }
+}


### PR DESCRIPTION
[JENKINS-59455](https://issues.jenkins-ci.org/browse/JENKINS-59455)

- Use the first available env variable, and not path, to be sure it's available.
- Wait for the created agent to be online.
- Consider '\0' (NUL character) as a character that appears to mark the end of a line, and so it must not make files containing it to be considered as binary files.