### PR TITLE
[JENKINS-60009] Add support for Java 9 and later for GCLogs

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
@@ -149,27 +149,27 @@ public class GCLogs extends Component {
 
         String fileLocation;
         
-        if(!isJava8OrBelow()) {
-            String gcLogSwitch = vmArgumentFinder.findVmArgument(GCLOGS_JRE9_SWITCH);
-            if (gcLogSwitch == null) {
-                LOGGER.fine("No GC Logging switch found, cannot collect gc logging files.");
-                fileLocation = null;
-            } else {
-                Matcher fileLocationMatcher = Pattern.compile(GCLOGS_JRE9_LOCATION).matcher(gcLogSwitch);
-                if(fileLocationMatcher.matches()) { 
-                    fileLocation = fileLocationMatcher.group("location");
-                } else {
-                    LOGGER.fine("No GC Logging custom file location found.");
-                    fileLocation = null;
-                }
-            }
-        } else {
+        if(isJava8OrBelow()) {
             String gcLogSwitch = vmArgumentFinder.findVmArgument(GCLOGS_JRE_SWITCH);
             if (gcLogSwitch == null) {
                 LOGGER.fine("No GC Logging switch found, cannot collect gc logging files.");
                 fileLocation = null;
             } else {
                 fileLocation = gcLogSwitch.substring(GCLOGS_JRE_SWITCH.length());
+            }
+        } else {
+            String gcLogSwitch = vmArgumentFinder.findVmArgument(GCLOGS_JRE9_SWITCH);
+            if (gcLogSwitch == null) {
+                LOGGER.fine("No GC Logging switch found, cannot collect gc logging files.");
+                fileLocation = null;
+            } else {
+                Matcher fileLocationMatcher = Pattern.compile(GCLOGS_JRE9_LOCATION).matcher(gcLogSwitch);
+                if(fileLocationMatcher.matches()) {
+                    fileLocation = fileLocationMatcher.group("location");
+                } else {
+                    LOGGER.fine("No GC Logging custom file location found.");
+                    fileLocation = null;
+                }
             }
         }
         return fileLocation;

--- a/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
@@ -33,7 +33,8 @@ public class GCLogs extends Component {
 
     static final String GCLOGS_JRE_SWITCH = "-Xloggc:";
     static final String GCLOGS_JRE9_SWITCH = "-Xlog:gc";
-    static final String GCLOGS_JRE9_LOCATION = ".*:file=(?<location>[^:]*).*";
+    // We need (?:[a-zA-Z]\:\\)? to handle Windows disk drive 
+    static final String GCLOGS_JRE9_LOCATION = ".*:file=[\"]?(?<location>(?:[a-zA-Z]:\\\\)?[^\":]*).*";
     static final String GCLOGS_ROTATION_SWITCH = "-XX:+UseGCLogFileRotation";
 
     private static final String GCLOGS_RETENTION_PROPERTY = GCLogs.class.getName() + ".retention";

--- a/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -31,7 +32,8 @@ import java.util.regex.Pattern;
 public class GCLogs extends Component {
 
     static final String GCLOGS_JRE_SWITCH = "-Xloggc:";
-
+    static final String GCLOGS_JRE9_SWITCH = "-Xlog:gc";
+    static final String GCLOGS_JRE9_LOCATION = ".*:file=(?<location>[^:]*).*";
     static final String GCLOGS_ROTATION_SWITCH = "-XX:+UseGCLogFileRotation";
 
     private static final String GCLOGS_RETENTION_PROPERTY = GCLogs.class.getName() + ".retention";
@@ -82,7 +84,7 @@ public class GCLogs extends Component {
             return;
         }
 
-        if (isGcLogRotationConfigured() || isFileLocationParameterized(gcLogFileLocation)) {
+        if (isFileLocationParameterized(gcLogFileLocation) || isGcLogRotationConfigured()) {
             handleRotatedLogs(gcLogFileLocation, result);
         } else {
             File file = new File(gcLogFileLocation);
@@ -145,16 +147,36 @@ public class GCLogs extends Component {
     @CheckForNull
     private String getGcLogFileLocation() {
 
-        String gcLogSwitch = vmArgumentFinder.findVmArgument(GCLOGS_JRE_SWITCH);
-        if (gcLogSwitch == null) {
-            LOGGER.fine("No GC Logging switch found, cannot collect gc logging files.");
-            return null;
+        String fileLocation;
+        
+        if(!isJava8OrBelow()) {
+            String gcLogSwitch = vmArgumentFinder.findVmArgument(GCLOGS_JRE9_SWITCH);
+            if (gcLogSwitch == null) {
+                LOGGER.fine("No GC Logging switch found, cannot collect gc logging files.");
+                fileLocation = null;
+            } else {
+                Matcher fileLocationMatcher = Pattern.compile(GCLOGS_JRE9_LOCATION).matcher(gcLogSwitch);
+                if(fileLocationMatcher.matches()) { 
+                    fileLocation = fileLocationMatcher.group("location");
+                } else {
+                    LOGGER.fine("No GC Logging custom file location found.");
+                    fileLocation = null;
+                }
+            }
+        } else {
+            String gcLogSwitch = vmArgumentFinder.findVmArgument(GCLOGS_JRE_SWITCH);
+            if (gcLogSwitch == null) {
+                LOGGER.fine("No GC Logging switch found, cannot collect gc logging files.");
+                fileLocation = null;
+            } else {
+                fileLocation = gcLogSwitch.substring(GCLOGS_JRE_SWITCH.length());
+            }
         }
-        return gcLogSwitch.substring(GCLOGS_JRE_SWITCH.length());
+        return fileLocation;
     }
     
     public boolean isFileLocationParameterized(String fileLocation) {
-        return Pattern.compile(".*%[tnp].*").matcher(fileLocation).find();
+        return Pattern.compile(".*%[tp].*").matcher(fileLocation).find();
     }
 
     /**
@@ -169,7 +191,17 @@ public class GCLogs extends Component {
     }
 
     private boolean isGcLogRotationConfigured() {
-        return vmArgumentFinder.findVmArgument(GCLOGS_ROTATION_SWITCH) != null;
+        return isJava8OrBelow() && vmArgumentFinder.findVmArgument(GCLOGS_ROTATION_SWITCH) != null;
+    }
+
+    /**
+     * Return if this instance if running Java 8 or a lower version
+     * (Can be replaced by JavaUtils.isRunningWithJava8OrBelow() since 2.164.1)
+     * @ See https://openjdk.java.net/jeps/223
+     * @return true if running java 8 or an older version
+     */
+    private boolean isJava8OrBelow() {
+        return System.getProperty("java.specification.version").startsWith("1.");
     }
 
     /**

--- a/src/test/java/com/cloudbees/jenkins/support/SupportTestUtils.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportTestUtils.java
@@ -170,4 +170,13 @@ public class SupportTestUtils {
             }
         }
     }
+
+    /**
+     * Return if this instance if running Java 8 or a lower version
+     * (Can be replaced by JavaUtils.isRunningWithJava8OrBelow() since 2.164.1)
+     * @return true if running java 8 or an older version
+     */
+    public static boolean isJava8OrBelow() {
+        return System.getProperty("java.specification.version").startsWith("1.");
+    }
 }

--- a/src/test/java/com/cloudbees/jenkins/support/impl/GCLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/GCLogsTest.java
@@ -59,15 +59,35 @@ public class GCLogsTest {
 
     @Test
     public void rotatedJava9Files() throws Exception {
-        Assume.assumeFalse(SupportTestUtils.isJava8OrBelow());
+        Assume.assumeTrue(!SupportTestUtils.isJava8OrBelow());
         File tempDir = Files.createTempDir();
         for (int count = 0; count < 5; count++) {
             Files.touch(new File(tempDir, "gc.log." + count));
         }
 
         GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
-        when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file="
-                + tempDir.getAbsolutePath() + File.separator + "gc.log.%p:filecount=10,filesize=50m");
+        when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=" 
+            + tempDir.getAbsolutePath() + File.separator + "gc.log.%p" + ":filecount=10,filesize=50m");
+
+        TestContainer container = new TestContainer();
+
+        new GCLogs(finder).addContents(container);
+
+        assertEquals(5, container.getContents().size());
+    }
+
+    @Test
+    public void rotatedJava9FilesWithQuotes() throws Exception {
+        Assume.assumeTrue(!SupportTestUtils.isJava8OrBelow());
+        File tempDir = Files.createTempDir();
+        for (int count = 0; count < 5; count++) {
+            Files.touch(new File(tempDir, "gc.log." + count));
+        }
+
+        GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
+        // In Windows, the file locations must be wrapped with quotes
+        when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\"" 
+                + tempDir.getAbsolutePath() + File.separator + "gc.log.%p\":filecount=10,filesize=50m");
 
         TestContainer container = new TestContainer();
 
@@ -100,7 +120,7 @@ public class GCLogsTest {
 
     @Test
     public void parameterizedJava9Files() throws Exception {
-        Assume.assumeFalse(SupportTestUtils.isJava8OrBelow());
+        Assume.assumeTrue(!SupportTestUtils.isJava8OrBelow());
         File tempDir = Files.createTempDir();
         for (int count = 0; count < 5; count++) {
             Files.touch(new File(tempDir, "gc." + System.currentTimeMillis() + ".1423.log." + count));
@@ -110,8 +130,31 @@ public class GCLogsTest {
         }
 
         GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
-        when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH
-                + "*:file=" + tempDir.getAbsolutePath() + File.separator + "gc.%t.%p.log");
+        when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=" 
+                + tempDir.getAbsolutePath() + File.separator + "gc.%t.%p.log");
+
+        TestContainer container = new TestContainer();
+
+        new GCLogs(finder).addContents(container);
+
+        assertEquals(8, container.getContents().size());
+    }
+
+    @Test
+    public void parameterizedJava9FilesWithQuotes() throws Exception {
+        Assume.assumeTrue(!SupportTestUtils.isJava8OrBelow());
+        File tempDir = Files.createTempDir();
+        for (int count = 0; count < 5; count++) {
+            Files.touch(new File(tempDir, "gc." + System.currentTimeMillis() + ".1423.log." + count));
+        }
+        for (int count = 0; count < 3; count++) {
+            Files.touch(new File(tempDir, "gc." + System.currentTimeMillis() + ".2534.log." + count));
+        }
+
+        GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
+        // In Windows, the file locations must be wrapped with quotes
+        when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\"" 
+                + tempDir.getAbsolutePath() + File.separator + "gc.%t.%p.log\"");
 
         TestContainer container = new TestContainer();
 

--- a/src/test/java/com/cloudbees/jenkins/support/impl/GCLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/GCLogsTest.java
@@ -85,7 +85,7 @@ public class GCLogsTest {
         }
 
         GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
-        // In Windows, the file locations must be wrapped with quotes
+        // The file locations may be wrapped with quotes
         when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\"" 
                 + tempDir.getAbsolutePath() + File.separator + "gc.log.%p\":filecount=10,filesize=50m");
 
@@ -152,7 +152,7 @@ public class GCLogsTest {
         }
 
         GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
-        // In Windows, the file locations must be wrapped with quotes
+        // The file locations may be wrapped with quotes
         when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\"" 
                 + tempDir.getAbsolutePath() + File.separator + "gc.%t.%p.log\"");
 

--- a/src/test/java/com/cloudbees/jenkins/support/impl/GCLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/GCLogsTest.java
@@ -47,7 +47,8 @@ public class GCLogsTest {
 
         GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
         when(finder.findVmArgument(GCLogs.GCLOGS_ROTATION_SWITCH)).thenReturn(GCLogs.GCLOGS_ROTATION_SWITCH);
-        when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH + tempDir.getAbsolutePath()+"/gc.log");
+        when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH 
+                + tempDir.getAbsolutePath() + File.separator + "gc.log");
 
         TestContainer container = new TestContainer();
 
@@ -65,8 +66,8 @@ public class GCLogsTest {
         }
 
         GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
-        when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=" 
-                + tempDir.getAbsolutePath()+ "/gc.log.%p:filecount=10,filesize=50m");
+        when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file="
+                + tempDir.getAbsolutePath() + File.separator + "gc.log.%p:filecount=10,filesize=50m");
 
         TestContainer container = new TestContainer();
 
@@ -87,7 +88,7 @@ public class GCLogsTest {
         }
 
         GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
-        when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH 
+        when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH
                 + new File(tempDir, "gc.%t.%p.log").getAbsolutePath());
 
         TestContainer container = new TestContainer();
@@ -109,8 +110,8 @@ public class GCLogsTest {
         }
 
         GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
-        when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH 
-                + "*:file=" + tempDir.getAbsolutePath()+ "/gc.%t.%p.log");
+        when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH
+                + "*:file=" + tempDir.getAbsolutePath() + File.separator + "gc.%t.%p.log");
 
         TestContainer container = new TestContainer();
 
@@ -168,7 +169,7 @@ public class GCLogsTest {
         Assertions.assertThat(container.getContents())
                 .extracting("file", File.class)
                 .extractingResultOf("getName")
-                .contains("gc3421.log0", "gc3421.log1", "gc3421.log2", "gc3421.log3", "gc3421.log4"); 
+                .contains("gc3421.log0", "gc3421.log1", "gc3421.log2", "gc3421.log3", "gc3421.log4");
     }
 
     private static class TestContainer extends Container {


### PR DESCRIPTION
[JENKINS-60009](https://issues.jenkins-ci.org/projects/JENKINS/issues/JENKINS-60009): The java arguments to enable GC logs are different since Java9. This PR adds support for it, see also https://docs.oracle.com/javase/9/tools/java.htm#GUID-BE93ABDC-999C-4CB5-A88B-1994AAAC74D5__CONVERTGCLOGGINGFLAGSTOXLOG-A5046BD1.

In order to write tests for this, we need to have tests that execute in JDK 8 or older and tests that execute in JDK 9 or later. So I used the `org.junit.Assume` for this.

Note: Since the 2.164.1 LTS, there is a class [jenkins.utils.java.JavaUtils](https://github.com/jenkinsci/jenkins/commit/412da254f2bbac386e9ab736684140cf107a3ffd#diff-f820412d63e84d362e303aeaa8be7729) that can be used to check if the runtime version is older than 8 or not. But I did not want to raise the version in the pom as this could prevent people that are running older version of core to upgrade the support core plugin. I wonder what are your thoughts about it ?