### PR TITLE
Name of the category for this management link

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/filter/ContentMappings.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/ContentMappings.java
@@ -246,4 +246,12 @@ public class ContentMappings extends ManagementLink implements Saveable, Iterabl
     public @Nonnull String getUrlName() {
         return "anonymizedMappings";
     }
+    
+    /**
+     * Name of the category for this management link.
+     * TBD: Use getCategory when core requirement is greater or equal to 2.226 
+     */
+    public @Nonnull String getCategoryName() {
+        return "SECURITY";
+    }    
 }


### PR DESCRIPTION
Used only by Jenkins core 2.226+

Ref:
* https://jenkins.io/changelog/#v2.226
* jenkinsci/jenkins#4546

I hesitated between SECURITY and TROUBLESHOOTING categories but I think that the security concern of this feature is more important