### PR TITLE
[JENKINS-61659] Allow to generate custom support bundle through api

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
@@ -186,11 +186,11 @@ public class SupportAction implements RootAction, StaplerProxy {
     }
 
     /**
-     * Generates a support bundle with default components.
+     * Generates a support bundle with selected components from the UI.
      * @param req The stapler request
      * @param rsp The stapler response
      * @throws ServletException
-     * @throws IOException
+     * @throws IOException If an input or output exception occurs
      */
     @RequirePOST
     public void doDownload(StaplerRequest req, StaplerResponse rsp) throws ServletException, IOException {
@@ -198,11 +198,11 @@ public class SupportAction implements RootAction, StaplerProxy {
     }
 
     /**
-     * Generates a supoprt bundle with default components, adding and excluding components based on form input.
-     * @param req
-     * @param rsp
+     * Generates a support bundle with selected components from the UI.
+     * @param req The stapler request
+     * @param rsp The stapler response
      * @throws ServletException
-     * @throws IOException
+     * @throws IOException If an input or output exception occurs
      */
     @RequirePOST
     public void doGenerateAllBundles(StaplerRequest req, StaplerResponse rsp) throws ServletException, IOException {
@@ -232,8 +232,8 @@ public class SupportAction implements RootAction, StaplerProxy {
     /**
      * Generates a support bundle with only requested components.
      * @param components component names separated by comma.
-     * @param rsp
-     * @throws IOException
+     * @param rsp The stapler response
+     * @throws IOException If an input or output exception occurs
      */
     @RequirePOST
     public void doGenerateBundle(@QueryParameter("components") String components, StaplerResponse rsp) throws IOException {

--- a/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
@@ -243,7 +243,12 @@ public class SupportAction implements RootAction, StaplerProxy {
         }
         List<String> componentNames = Arrays.asList(components.split(","));
         logger.fine("Selecting components...");
-        prepareBundle(rsp, getComponents().stream().filter(c -> componentNames.contains(c.getId())).collect(Collectors.toList()));
+        List<Component> selectedComponents = getComponents().stream().filter(c -> componentNames.contains(c.getId())).collect(Collectors.toList());
+        if (selectedComponents.isEmpty()) {
+            rsp.sendError(HttpServletResponse.SC_BAD_REQUEST, "selected component list is empty");
+            return;
+        }
+        prepareBundle(rsp, selectedComponents);
      }
 
     private void prepareBundle(StaplerResponse rsp, List<Component> components) throws IOException {

--- a/src/main/java/com/cloudbees/jenkins/support/api/Component.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/Component.java
@@ -31,6 +31,8 @@ import hudson.security.ACL;
 import hudson.security.Permission;
 import jenkins.model.Jenkins;
 import org.acegisecurity.Authentication;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
 
 import java.util.Collections;
 import java.util.Set;
@@ -44,6 +46,7 @@ import java.util.Set;
  *
  * @author Stephen Connolly
  */
+@ExportedBean
 public abstract class Component implements ExtensionPoint {
     
     /**
@@ -85,6 +88,7 @@ public abstract class Component implements ExtensionPoint {
      *
      * @return {@code true} if the current authentication can include this component in a bundle.
      */
+    @Exported
     public boolean isEnabled() {
         ACL acl = Jenkins.getInstance().getAuthorizationStrategy().getRootACL();
         if (acl != null) {
@@ -99,6 +103,7 @@ public abstract class Component implements ExtensionPoint {
         return true;
     }
 
+    @Exported
     public boolean isSelectedByDefault() {
         return true;
     }
@@ -115,6 +120,7 @@ public abstract class Component implements ExtensionPoint {
     }
 
     @NonNull
+    @Exported
     public abstract String getDisplayName();
 
     /**
@@ -128,6 +134,7 @@ public abstract class Component implements ExtensionPoint {
      *
      * @return by default, the {@link Class#getSimpleName} of the component implementation.
      */
+    @Exported
     @NonNull public String getId() {
         return getClass().getSimpleName();
     }


### PR DESCRIPTION
See [JENKINS-61659](https://issues.jenkins-ci.org/browse/JENKINS-61659)

* Expose components through api
* New endpoint generating a support bundle only with included components