### PR TITLE
[JENKINS-61796] JCasC test and configuration section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### Version 2.68 (TBD)
+-   [JENKINS-61796](https://issues.jenkins-ci.org/browse/JENKINS-61796) - Add JCasC compatibility. See [CasC configuration](README.md#casc) to get more details.
+
 ### Version 2.65 (2019 Dec 4)
 
 -   [JENKINS-59455](https://issues.jenkins-ci.org/browse/JENKINS-59455) - Fix the checking of env vars using an existing env var instead of path

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ you do not wish to disclose the names of custom proprietary plugins.
 
 ## <a name="casc"></a>Configuration as Code
 
-As of 2.68 support-core is compatible with [Jenkins Configuration as Code](https://github.com/jenkinsci/configuration-as-code-plugin) (CasC).
+As of 2.68 version, support-core is compatible with [Jenkins Configuration as Code](https://github.com/jenkinsci/configuration-as-code-plugin) (CasC).
 
 The configuration looks like:
 
@@ -155,4 +155,5 @@ unclassified:
   contentFilters:
     enabled: false
 ```
-This version fixes the configuration fields to be more intuitive.
+This version fixes the configuration fields to be more intuitive. Please update your yaml file if
+you update support-core to version 2.68 or later.

--- a/README.md
+++ b/README.md
@@ -134,3 +134,25 @@ These reports are in the
 files `plugins/active.txt`, `plugins/disabled.txt`, `plugins/failed.txt`,
 and `docker/Dockerfile`. These files should all be manually reviewed if
 you do not wish to disclose the names of custom proprietary plugins.
+
+## <a name="casc"></a>Configuration as Code
+
+As of 2.68 support-core is compatible with [Jenkins Configuration as Code](https://github.com/jenkinsci/configuration-as-code-plugin) (CasC).
+
+The configuration looks like:
+
+```
+security:
+  anonymizeSupportBundle:
+    enabled: true
+```
+It enables (_true_) or disables (_false_) the anonymization of the bundle.
+
+Previous versions of this plugin could be configured by CasC as well, but the configuration was so:
+
+```
+unclassified:
+  contentFilters:
+    enabled: false
+```
+This version fixes the configuration fields to be more intuitive.

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.138.4</jenkins.version>
     <java.level>8</java.level>
+    <configuration-as-code.version>1.36</configuration-as-code.version>
   </properties>
 
   <repositories>
@@ -129,6 +130,14 @@
       <artifactId>wordnet-random-name</artifactId>
       <version>1.3</version>
     </dependency>
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <version>${configuration-as-code.version}</version>
+      <!-- Optional instead of scope=test to add the category when exporting the configuration -->
+      <optional>true</optional>
+    </dependency>
+    
     <!-- test dependencies -->
     <dependency>
       <groupId>org.assertj</groupId>
@@ -177,6 +186,12 @@
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-support</artifactId>
       <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
+      <version>${configuration-as-code.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,10 @@
       <!-- Optional instead of scope=test to add the category when exporting the configuration -->
       <optional>true</optional>
     </dependency>
-    
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>structs</artifactId>
+    </dependency>
     <!-- test dependencies -->
     <dependency>
       <groupId>org.assertj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
+      <version>1.20</version>
     </dependency>
     <!-- test dependencies -->
     <dependency>

--- a/src/main/java/com/cloudbees/jenkins/support/filter/ContentFilters.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/ContentFilters.java
@@ -26,6 +26,8 @@ package com.cloudbees.jenkins.support.filter;
 
 import hudson.Extension;
 import jenkins.model.GlobalConfiguration;
+import jenkins.model.GlobalConfigurationCategory;
+import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -40,6 +42,7 @@ import javax.annotation.Nonnull;
  */
 @Extension
 @Restricted(NoExternalUse.class)
+@Symbol("anonymizeSupportBundle")
 public class ContentFilters extends GlobalConfiguration {
 
     public static ContentFilters get() {
@@ -68,4 +71,12 @@ public class ContentFilters extends GlobalConfiguration {
         return Messages.ContentFilters_DisplayName();
     }
 
+    /**
+     * 
+     * @return the global configuration category for CasC where this config lands
+     */
+    @Override
+    public @Nonnull GlobalConfigurationCategory getCategory() {
+        return GlobalConfigurationCategory.get(GlobalConfigurationCategory.Security.class);
+    }
 }

--- a/src/test/java/com/cloudbees/jenkins/support/CasCTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/CasCTest.java
@@ -1,0 +1,19 @@
+package com.cloudbees.jenkins.support;
+
+import com.cloudbees.jenkins.support.filter.ContentFilters;
+import io.jenkins.plugins.casc.misc.RoundTripAbstractTest;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import static org.junit.Assert.assertTrue;
+
+public class CasCTest extends RoundTripAbstractTest {
+    @Override
+    protected void assertConfiguredAsExpected(RestartableJenkinsRule restartableJenkinsRule, java.lang.String s) {
+        assertTrue("JCasC should have configured support core to anonymize contents, but it didn't", ContentFilters.get().isEnabled());
+    }
+
+    @Override
+    protected java.lang.String stringInLogExpected() {
+        return ".enabled = true";
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/support/filter/ContentMappingsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/filter/ContentMappingsTest.java
@@ -160,6 +160,9 @@ public class ContentMappingsTest {
     public void jenkinsVersionIncludedAsStopWord() {
         rr.then(r -> {
             Jenkins.VERSION = "1.2.3.4";
+            // With JCasC the ContentMappings is created before Jenkins.VERSION is called, so the previous instruction
+            // doesn't take effect in the mappings. We have to force the mappings to reload after the version is set.
+            ContentMappings.get().clear();
             ContentMappings mappings = ContentMappings.get();
 
             // Jenkins version added to stop words

--- a/src/test/resources/com/cloudbees/jenkins/support/configuration-as-code.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/support/configuration-as-code.yaml
@@ -1,0 +1,3 @@
+security:
+  anonymizeSupportBundle:
+    enabled: true


### PR DESCRIPTION
See: https://issues.jenkins-ci.org/browse/JENKINS-61796

Add a test for JCasC configuration and set the section of the plugin under the security group, to match the group where it will land when https://github.com/jenkinsci/support-core-plugin/pull/211 is merged

![image](https://user-images.githubusercontent.com/22069922/78338753-a2c9d500-7593-11ea-93e4-4c04a2d4d1ad.png)

The new place on UI:
![image](https://user-images.githubusercontent.com/22069922/78341609-45845280-7598-11ea-9102-f2630f31ff02.png)
