### PR TITLE
Test improvement - Consistent naming of JenkinsRule variable

### DIFF
--- a/src/test/java/com/cloudbees/jenkins/support/BundleNamePrefixTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/BundleNamePrefixTest.java
@@ -17,7 +17,7 @@ public class BundleNamePrefixTest {
     private static final String CURRENT_YEAR = new SimpleDateFormat("YYYY").format(new Date());
 
     @Rule
-    public JenkinsRule rule = new JenkinsRule();
+    public JenkinsRule j = new JenkinsRule();
 
     @Test
     public void checkOriginalBehaviour() throws Exception {

--- a/src/test/java/com/cloudbees/jenkins/support/CheckFilterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/CheckFilterTest.java
@@ -77,12 +77,12 @@ public class CheckFilterTest {
     public TemporaryFolder temp = new TemporaryFolder();
 
     @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
+    public JenkinsRule j = new JenkinsRule();
 
     @Test
     public void checkFilterTest() throws Exception {
         // Create the files to check
-        FileChecker checker = new FileChecker(jenkins.jenkins);
+        FileChecker checker = new FileChecker(j.jenkins);
         // Create the objects needed for some contents to be included
         QueueTaskFuture<FreeStyleBuild> build = createObjectsWithNames();
 
@@ -133,14 +133,14 @@ public class CheckFilterTest {
         User.getOrCreateByIdOrFullName("encoding");
 
         // For ConfigFileComponent --> config.xml
-        jenkins.jenkins.getView("all").rename(VIEW_ALL_NEW_NAME);
-        jenkins.jenkins.save();
+        j.jenkins.getView("all").rename(VIEW_ALL_NEW_NAME);
+        j.jenkins.save();
 
         // Create the slave slave0 for some components and wait until it's online
-        jenkins.waitOnline(jenkins.createOnlineSlave());
-        
+        j.waitOnline(j.createOnlineSlave());
+
         // Create a job to have something pending in the queue for the BuilQueue component
-        FreeStyleProject project = jenkins.createFreeStyleProject(JOB_NAME);
+        FreeStyleProject project = j.createFreeStyleProject(JOB_NAME);
         project.setAssignedLabel(new LabelAtom("foo")); //it's mandatory
 
         //project.getBuildersList().add(new SimpleBuilder());

--- a/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
@@ -65,7 +65,7 @@ import static org.junit.Assert.fail;
  */
 public class SupportActionTest {
     @Rule
-    public JenkinsRule rule = new JenkinsRule();
+    public JenkinsRule j = new JenkinsRule();
 
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();
@@ -81,7 +81,7 @@ public class SupportActionTest {
 
     @Before
     public void setUp() {
-        rule.jenkins.getInjector().injectMembers(this);
+        j.jenkins.getInjector().injectMembers(this);
     }
 
     @Test
@@ -142,24 +142,24 @@ public class SupportActionTest {
      * @throws IOException when any exception creating the url to call
      */
     private WebResponse deleteBundle(String bundle, String user) throws IOException {
-        rule.jenkins.setCrumbIssuer(null);
+        j.jenkins.setCrumbIssuer(null);
 
-        rule.jenkins.setSecurityRealm(rule.createDummySecurityRealm());
-        rule.jenkins.setAuthorizationStrategy(
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(
                 new MockAuthorizationStrategy()
                         .grant(Jenkins.ADMINISTER).everywhere().to("admin")
                         .grant(Jenkins.READ).everywhere().to("user")
         );
-        WebClient wc = rule.createWebClient()
+        WebClient wc = j.createWebClient()
                 .withBasicCredentials(user)
                 .withThrowExceptionOnFailingStatusCode(false);
 
-        WebRequest request = new WebRequest(new URL(rule.getURL()+ root.getUrlName() + "/deleteBundles?json={%22bundles%22:[{%22selected%22:+true,%22name%22:+%22" + bundle + "%22}]}"), HttpMethod.POST);
+        WebRequest request = new WebRequest(new URL(j.getURL() + root.getUrlName() + "/deleteBundles?json={%22bundles%22:[{%22selected%22:+true,%22name%22:+%22" + bundle + "%22}]}"), HttpMethod.POST);
         return wc.getPage(request).getWebResponse();
     }
     
     private ZipFile downloadBundle(String s) throws IOException, SAXException {
-        JenkinsRule.JSONWebResponse jsonWebResponse = rule.postJSON(root.getUrlName() + s, "");
+        JenkinsRule.JSONWebResponse jsonWebResponse = j.postJSON(root.getUrlName() + s, "");
         File zipFile = File.createTempFile("test", "zip");
         IOUtils.copy(jsonWebResponse.getContentAsStream(), Files.newOutputStream(zipFile.toPath()));
         return new ZipFile(zipFile);
@@ -204,8 +204,8 @@ public class SupportActionTest {
      */
     @Test
     public void takeSnapshotAndMakeSureSomethingHappens() throws Exception {
-        rule.createSlave("slave1","test",null).getComputer().connect(false).get();
-        rule.createSlave("slave2","test",null).getComputer().connect(false).get();
+        j.createSlave("slave1","test",null).getComputer().connect(false).get();
+        j.createSlave("slave2","test",null).getComputer().connect(false).get();
 
         RingBufferLogHandler checker = new RingBufferLogHandler();
         Logger logger = Logger.getLogger(SupportPlugin.class.getPackage().getName());
@@ -213,7 +213,7 @@ public class SupportActionTest {
         logger.addHandler(checker);
 
         try {
-            WebClient wc = rule.createWebClient();
+            WebClient wc = j.createWebClient();
             HtmlPage p = wc.goTo(root.getUrlName());
 
             HtmlForm form = p.getFormByName("bundle-contents");
@@ -269,7 +269,7 @@ public class SupportActionTest {
 
     @Test
     public void anonymizationSmokes() throws Exception {
-        Slave node = rule.createSlave(Label.get("super_secret_node"));
+        Slave node = j.createSlave(Label.get("super_secret_node"));
         File bundleFile = temp.newFile();
         List<Component> componentsToCreate = Collections.singletonList(ExtensionList.lookup(Component.class).get(AboutJenkins.class));
         try (OutputStream os = Files.newOutputStream(bundleFile.toPath())) {
@@ -301,7 +301,7 @@ public class SupportActionTest {
     @Test
     public void corruptZipTestBySlash() throws Exception {
         final String OBJECT_NAME = "slave";
-        Slave node = rule.createSlave(OBJECT_NAME, "/", null);
+        Slave node = j.createSlave(OBJECT_NAME, "/", null);
 
         // Set the components to generate
         List<Component> componentsToCreate = Collections.singletonList(ExtensionList.lookup(Component.class).get(AboutJenkins.class));
@@ -320,7 +320,7 @@ public class SupportActionTest {
     @Test
     public void corruptZipTestByDot() throws Exception {
         final String OBJECT_NAME = "slave";
-        Slave node = rule.createSlave(OBJECT_NAME, ".", null);
+        Slave node = j.createSlave(OBJECT_NAME, ".", null);
         // Set the components to generate
         List<Component> componentsToCreate = Collections.singletonList(ExtensionList.lookup(Component.class).get(AboutJenkins.class));
 
@@ -339,7 +339,7 @@ public class SupportActionTest {
     public void corruptZipTestByWordsInFileName() throws Exception {
         final String OBJECT_NAME = "slave";
         // Create a slave with very bad words
-        Slave node = rule.createSlave(OBJECT_NAME, "active plugins checksums md5 items about nodes manifest errors", null);
+        j.createSlave(OBJECT_NAME, "active plugins checksums md5 items about nodes manifest errors", null);
 
         /* This words are in the stopWords, so they won't never be replaced
         "jenkins", "node", "master", "computer", "item", "label", "view", "all", "unknown", "user", "anonymous",

--- a/src/test/java/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponentTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponentTest.java
@@ -24,7 +24,7 @@ import org.jvnet.hudson.test.LoggerRule;
 public class OtherConfigFilesComponentTest {
 
     @Rule
-    public JenkinsRule r = new JenkinsRule();
+    public JenkinsRule j = new JenkinsRule();
 
     @Rule
     public LoggerRule logging = new LoggerRule().recordPackage(OtherConfigFilesComponent.class, Level.WARNING).capture(100);
@@ -102,7 +102,7 @@ public class OtherConfigFilesComponentTest {
 
     @Test
     public void missingFile() throws Exception {
-        File file = new File(r.jenkins.root, "x.xml");
+        File file = new File(j.jenkins.root, "x.xml");
         FileUtils.writeStringToFile(file, xml);
         Map<String, Content> contents = new HashMap<>();
         new OtherConfigFilesComponent().addContents(new Container() {

--- a/src/test/java/com/cloudbees/jenkins/support/configfiles/SecretHandlerTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/configfiles/SecretHandlerTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertThat;
 public class SecretHandlerTest {
 
     @Rule
-    public JenkinsRule r = new JenkinsRule();
+    public JenkinsRule j = new JenkinsRule();
 
     private String xml;
 

--- a/src/test/java/com/cloudbees/jenkins/support/filter/InetAddressContentFilterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/filter/InetAddressContentFilterTest.java
@@ -42,7 +42,7 @@ public class InetAddressContentFilterTest {
     private static String originalVersion;
 
     @ClassRule
-    public static JenkinsRule jenkins = new JenkinsRule();
+    public static JenkinsRule j = new JenkinsRule();
 
     @Before
     public void resetMappings() {

--- a/src/test/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilterTest.java
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SensitiveContentFilterTest {
 
     @ClassRule
-    public static JenkinsRule jenkins = new JenkinsRule();
+    public static JenkinsRule j = new JenkinsRule();
 
     @Issue("JENKINS-21670")
     @Test
@@ -47,8 +47,8 @@ public class SensitiveContentFilterTest {
         SensitiveContentFilter filter = SensitiveContentFilter.get();
         // using foo, bar, jar and war could raise flaky test failures. It happened to me when
         // bar was changed by label_barrier :-O So we use stranger words to avoid this test to be flaky
-        jenkins.createSlave("foostrange", "barstrange", null);
-        jenkins.createSlave("jarstrange", "warstrange", null);
+        j.createSlave("foostrange", "barstrange", null);
+        j.createSlave("jarstrange", "warstrange", null);
         filter.reload();
 
         String foo = filter.filter("foostrange");
@@ -68,7 +68,7 @@ public class SensitiveContentFilterTest {
     @Test
     public void anonymizeItems() throws IOException {
         SensitiveContentFilter filter = SensitiveContentFilter.get();
-        FreeStyleProject project = jenkins.createFreeStyleProject();
+        FreeStyleProject project = j.createFreeStyleProject();
         filter.reload();
         String name = project.getName();
 
@@ -81,7 +81,7 @@ public class SensitiveContentFilterTest {
     @Test
     public void anonymizeViews() throws IOException {
         SensitiveContentFilter filter = SensitiveContentFilter.get();
-        jenkins.getInstance().addView(new ListView("foobar"));
+        j.getInstance().addView(new ListView("foobar"));
         filter.reload();
 
         String foobar = filter.filter("foobar");
@@ -107,7 +107,7 @@ public class SensitiveContentFilterTest {
         final String os = "Linux";
         final String label = "fake";
         SensitiveContentFilter filter = SensitiveContentFilter.get();
-        jenkins.createSlave("foo", String.format("%s %s", os, label), null);
+        j.createSlave("foo", String.format("%s %s", os, label), null);
         filter.reload();
         assertThat(filter.filter(os)).isEqualTo(os);
         assertThat(filter.filter(label)).startsWith("label_").isNotEqualTo(label);

--- a/src/test/java/com/cloudbees/jenkins/support/impl/AgentProtocolsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/AgentProtocolsTest.java
@@ -14,7 +14,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 public class AgentProtocolsTest {
 
     @Rule
-    public JenkinsRule r = new JenkinsRule();
+    public JenkinsRule j = new JenkinsRule();
 
     @Test
     public void testAgentProtocolsContents() {

--- a/src/test/java/com/cloudbees/jenkins/support/impl/NetworkInterfacesTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/NetworkInterfacesTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertThat;
 
 public class NetworkInterfacesTest {
     @Rule
-    public JenkinsRule r = new JenkinsRule();
+    public JenkinsRule j = new JenkinsRule();
 
     @Test
     public void testGetNetworkInterface() throws Exception {

--- a/src/test/java/com/cloudbees/jenkins/support/impl/ReverseProxyTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/ReverseProxyTest.java
@@ -29,7 +29,7 @@ public class ReverseProxyTest {
   private static final String HEADER_VALUE = "value";
 
   @Rule
-  public JenkinsRule r = new JenkinsRule();
+  public JenkinsRule j = new JenkinsRule();
 
   @Mock
   private StaplerRequest staplerRequest;

--- a/src/test/java/com/cloudbees/jenkins/support/impl/SlaveCommandStatisticsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/SlaveCommandStatisticsTest.java
@@ -48,15 +48,15 @@ import org.jvnet.hudson.test.TestBuilder;
 public class SlaveCommandStatisticsTest {
 
     @Rule
-    public JenkinsRule r = new JenkinsRule();
+    public JenkinsRule j = new JenkinsRule();
 
     @Rule
     public LoggerRule logging = new LoggerRule().record(SlaveComputer.class, Level.FINEST);
 
     @Test
     public void smokes() throws Exception {
-        DumbSlave s = r.createSlave();
-        FreeStyleProject p = r.createFreeStyleProject();
+        DumbSlave s = j.createSlave();
+        FreeStyleProject p = j.createFreeStyleProject();
         p.setAssignedNode(s);
         p.getBuildersList().add(new TestBuilder() {
             @Override
@@ -65,7 +65,8 @@ public class SlaveCommandStatisticsTest {
                 return true;
             }
         });
-        r.buildAndAssertSuccess(p);
+        j.buildAndAssertSuccess(p);
+
         String dump = SupportTestUtils.invokeComponentToString(ExtensionList.lookupSingleton(SlaveCommandStatistics.class));
         System.out.println(dump);
         assertThat(dump, containsString(SampleCallable.class.getName()));
@@ -84,37 +85,37 @@ public class SlaveCommandStatisticsTest {
 
         SlaveCommandStatistics.MAX_STATS_SIZE = 0;
         assertThat(scs.getStatistics().size(), equalTo(0));
-        DumbSlave s0 = r.createOnlineSlave();
+        DumbSlave s0 = j.createOnlineSlave();
         assertThat(scs.getStatistics().size(), equalTo(1));
-        r.jenkins.removeNode(s0);
+        j.jenkins.removeNode(s0);
         assertThat(scs.getStatistics().size(), equalTo(0));
 
         SlaveCommandStatistics.MAX_STATS_SIZE = 1;
-        DumbSlave s1 = r.createOnlineSlave();
-        DumbSlave s2 = r.createOnlineSlave();
-        DumbSlave s3 = r.createOnlineSlave();
+        DumbSlave s1 = j.createOnlineSlave();
+        DumbSlave s2 = j.createOnlineSlave();
+        DumbSlave s3 = j.createOnlineSlave();
         assertThat(scs.getStatistics().size(), equalTo(3));
-        r.jenkins.removeNode(s1);
+        j.jenkins.removeNode(s1);
         assertThat(scs.getStatistics().size(), equalTo(3));
-        r.jenkins.removeNode(s2);
+        j.jenkins.removeNode(s2);
         assertThat(scs.getStatistics().size(), equalTo(2));
-        r.jenkins.removeNode(s3);
+        j.jenkins.removeNode(s3);
         assertThat(scs.getStatistics().size(), equalTo(1));
         assertThat("Latest preserved", scs.getStatistics().keySet(), contains(s3.getNodeName()));
 
         SlaveCommandStatistics.MAX_STATS_SIZE = 3;
-        s0 = r.createOnlineSlave();
-        s1 = r.createOnlineSlave();
-        s2 = r.createOnlineSlave();
-        s3 = r.createOnlineSlave();
+        s0 = j.createOnlineSlave();
+        s1 = j.createOnlineSlave();
+        s2 = j.createOnlineSlave();
+        s3 = j.createOnlineSlave();
         assertThat(scs.getStatistics().size(), equalTo(4));
-        r.jenkins.removeNode(s0);
+        j.jenkins.removeNode(s0);
         assertThat(scs.getStatistics().size(), equalTo(4));
-        r.jenkins.removeNode(s1);
+        j.jenkins.removeNode(s1);
         assertThat(scs.getStatistics().size(), equalTo(4));
-        r.jenkins.removeNode(s2);
+        j.jenkins.removeNode(s2);
         assertThat(scs.getStatistics().size(), equalTo(4));
-        r.jenkins.removeNode(s3);
+        j.jenkins.removeNode(s3);
         assertThat(scs.getStatistics().size(), equalTo(3));
         assertThat("Latest preserved", scs.getStatistics().keySet(), containsInAnyOrder(
                 s3.getNodeName(), s2.getNodeName(), s1.getNodeName()

--- a/src/test/java/com/cloudbees/jenkins/support/slowrequest/InflightRequestTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/slowrequest/InflightRequestTest.java
@@ -23,13 +23,15 @@ import static org.junit.Assert.assertNotNull;
  * @author schristou88
  */
 public class InflightRequestTest {
-    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
     @Test
     @Issue("JENKINS-24671")
     public void verifyUsernameInflightRequest() throws Exception {
-        r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
-        JenkinsRule.WebClient webClient = r.createWebClient().login("bob", "bob");
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        JenkinsRule.WebClient webClient = j.createWebClient().login("bob", "bob");
         MockSlowURLCall.seconds = 5;
         webClient.goTo("mockSlowURLCall/submit");
         InflightRequest request = MockSlowURLCall.request;
@@ -41,7 +43,7 @@ public class InflightRequestTest {
     @Test
     @Issue("JENKINS-24671")
     public void verifyRefererHeaderFromInflightRequest() throws Exception {
-        JenkinsRule.WebClient webClient = r.createWebClient();
+        JenkinsRule.WebClient webClient = j.createWebClient();
 
         URL refererUrl = new URL(webClient.getContextPath() + "mockSlowURLCall/submitReferer");
 


### PR DESCRIPTION
I have see many different variants like `j`, `r`, `rule`, `jenkins` and `jenkinsRule` among different Jenkins related repositories. `j` seems to be the most common one. Therefore adapting the tests here that used a different variant so far.