### PR TITLE
Test improvement - Remove non-required Javadoc on test methods

### DIFF
--- a/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
@@ -94,10 +94,8 @@ public class SupportActionTest {
         downloadBundle("/generateAllBundles?json={\"components\":1}");
     }
 
-    /**
-     * Trying to remove not existing bundles will do nothing, just a message in the log. 
-     * @throws IOException 
-     * @throws SAXException
+    /*
+     * Trying to remove not existing bundles will do nothing, just a message in the log.
      */
     @Test
     public void deleteNotExistingBundleWillFail() throws IOException, SAXException {
@@ -107,9 +105,8 @@ public class SupportActionTest {
         assertTrue(logger.getMessages().stream().anyMatch(m -> m.startsWith(String.format("The bundle to delete %s does not exist", bundle))));
     }
 
-    /**
+    /*
      * Trying to remove an existing bundle (a zip or log file in JH/support directory) will success.
-     * @throws IOException
      */
     @Test
     public void deleteExistingBundleWillSucceed() throws IOException {
@@ -194,9 +191,8 @@ public class SupportActionTest {
     }
 
 
-    /**
+    /*
      * Integration test that simulates the user action of clicking the button to generate the bundle.
-     *
      * <p>
      * If any warning is reported to j.u.l logger, treat that as a sign of failure, because
      * support-core plugin works darn hard to try to generate something in the presence of failing
@@ -294,9 +290,8 @@ public class SupportActionTest {
         }
     }
 
-    /**
+    /*
      * Check if the zip loses the folders due to anonymize '/' because there is an object with such a name. For example, a label.
-     * @throws Exception If exception happened during the test
      */
     @Test
     public void corruptZipTestBySlash() throws Exception {
@@ -312,10 +307,9 @@ public class SupportActionTest {
         bundlesMatch(zip, anonymizedZip, OBJECT_NAME, ContentMappings.get().getMappings().get(OBJECT_NAME));
     }
 
-    /**
+    /*
      * Check if the file names in the zip are corrupt due to anonymize '.' because there is an object with such a name.
      * For example, a label.
-     * @throws Exception If exception happened during the test
      */
     @Test
     public void corruptZipTestByDot() throws Exception {
@@ -330,10 +324,9 @@ public class SupportActionTest {
         bundlesMatch(zip, anonymizedZip,  OBJECT_NAME, ContentMappings.get().getMappings().get(OBJECT_NAME));
     }
 
-    /**
+    /*
      * Check if the file names in the zip are corrupt due to anonymize words in the file names because there is an object
      * with such a name. For example, a label.
-     * @throws Exception If exception happened during the test
      */
     @Test
     public void corruptZipTestByWordsInFileName() throws Exception {

--- a/src/test/java/com/cloudbees/jenkins/support/actions/SupportAbstractItemActionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/actions/SupportAbstractItemActionTest.java
@@ -28,7 +28,7 @@ public class SupportAbstractItemActionTest {
     @Rule
     public JenkinsRule j = new JenkinsRule();
 
-    /**
+    /*
      * Integration test that simulates the user action of clicking the button to generate the bundle from a Folder.
      */
     @Test
@@ -50,7 +50,7 @@ public class SupportAbstractItemActionTest {
         assertNull("'**/jobs/**' should be excluded by default", z.getEntry(itemEntryPrefix + "/jobs/subFolder/jobs/testFreestyle/config.xml"));
     }
 
-    /**
+    /*
      * Integration test that simulates the user action of clicking the button to generate the bundl from a Freesttle job.
      */
     @Test
@@ -76,7 +76,7 @@ public class SupportAbstractItemActionTest {
         assertNotNull(z.getEntry(itemEntryPrefix + "/builds/1/log"));
     }
 
-    /**
+    /*
      * Integration test that simulates the user action of clicking the button to generate the bundle from a Folder.
      */
     @Test

--- a/src/test/java/com/cloudbees/jenkins/support/actions/SupportComputerActionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/actions/SupportComputerActionTest.java
@@ -22,7 +22,7 @@ public class SupportComputerActionTest {
     @Rule
     public JenkinsRule j = new JenkinsRule();
 
-    /**
+    /*
      * Integration test that simulates the user action of clicking the button to generate the bundle.
      */
     @Test

--- a/src/test/java/com/cloudbees/jenkins/support/actions/SupportRunActionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/actions/SupportRunActionTest.java
@@ -23,7 +23,7 @@ public class SupportRunActionTest {
     @Rule
     public JenkinsRule j = new JenkinsRule();
 
-    /**
+    /*
      * Integration test that simulates the user action of clicking the button to generate the bundle.
      */
     @Test

--- a/src/test/java/com/cloudbees/jenkins/support/impl/AbstractItemComponentTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/AbstractItemComponentTest.java
@@ -25,7 +25,7 @@ public class AbstractItemComponentTest {
     @Rule
     public JenkinsRule j = new JenkinsRule();
 
-    /**
+    /*
      * Test adding item directory content with defaults for a folder.
      */
     @Test
@@ -48,7 +48,7 @@ public class AbstractItemComponentTest {
         assertThat(output.get(prefix + "/config.xml"), Matchers.containsString("<org.jvnet.hudson.test.MockFolder>"));
     }
 
-    /**
+    /*
      * Test adding item directory content with includes patterns for a folder.
      */
     @Test
@@ -72,7 +72,7 @@ public class AbstractItemComponentTest {
         assertFalse(output.containsKey(prefix + "/jobs/subFolder/jobs/" + JOB_NAME + "/1/log"));
     }
 
-    /**
+    /*
      * Test adding item directory content with excludes patterns for a folder.
      */
     @Test
@@ -96,7 +96,7 @@ public class AbstractItemComponentTest {
         assertFalse(output.containsKey(prefix + "/jobs/subFolder/jobs/" + JOB_NAME + "/1/log"));
     }
 
-    /**
+    /*
      * Test adding item directory content with excludes patterns for a freestyle job.
      */
     @Test
@@ -120,7 +120,7 @@ public class AbstractItemComponentTest {
         assertFalse(output.containsKey(prefix + "/jobs/subFolder/jobs/" + JOB_NAME + "/1/log"));
     }
 
-    /**
+    /*
      * Test adding item directory content with defaults for a freestyle job.
      */
     @Test
@@ -140,7 +140,7 @@ public class AbstractItemComponentTest {
         assertThat(output.get(prefix + "/config.xml"), Matchers.containsString("<project>"));
     }
 
-    /**
+    /*
      * Test adding item directory content with defaults for a pipeline.
      */
     @Test
@@ -167,7 +167,7 @@ public class AbstractItemComponentTest {
         assertThat(output.get(prefix + "/nextBuildNumber"), Matchers.containsString("2"));
     }
 
-    /**
+    /*
      * Test adding item directory content with excludes patterns.
      */
     @Test
@@ -193,7 +193,7 @@ public class AbstractItemComponentTest {
         assertFalse(output.containsKey(prefix + "/builds/1/workflow/2.xml"));
     }
 
-    /**
+    /*
      * Test adding item directory content with includes patterns.
      */
     @Test
@@ -217,7 +217,7 @@ public class AbstractItemComponentTest {
         assertFalse(output.containsKey(prefix + "/builds/1/workflow/2.xml"));
     }
 
-    /**
+    /*
      * Test adding item directory content with includes patterns.
      */
     @Test
@@ -241,7 +241,7 @@ public class AbstractItemComponentTest {
         assertFalse(output.containsKey(prefix + "/builds/1/workflow/2.xml"));
     }
 
-    /**
+    /*
      * Test adding item directory content with includes / excludes patterns.
      */
     @Test

--- a/src/test/java/com/cloudbees/jenkins/support/impl/NodeRemoteDirectoryComponentTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/NodeRemoteDirectoryComponentTest.java
@@ -20,7 +20,7 @@ public class NodeRemoteDirectoryComponentTest {
     @Rule
     public JenkinsRule j = new JenkinsRule();
 
-    /**
+    /*
      * Test adding agent remote directory content with the defaults.
      */
     @Test
@@ -33,7 +33,7 @@ public class NodeRemoteDirectoryComponentTest {
         assertTrue(output.keySet().stream().anyMatch(key -> key.matches(prefix + "/support/.*.log")));
     }
 
-    /**
+    /*
      * Test adding agent remote directory content with excludes pattern(s).
      */
     @Test
@@ -49,7 +49,7 @@ public class NodeRemoteDirectoryComponentTest {
         assertFalse(output.keySet().stream().anyMatch(key -> key.matches(prefix + ".*/.*.log")));
     }
 
-    /**
+    /*
      * Test adding agent remote directory content with includes pattern(s).
      */
     @Test
@@ -65,7 +65,7 @@ public class NodeRemoteDirectoryComponentTest {
         assertTrue(output.keySet().stream().anyMatch(key -> key.matches(prefix + "/support/.*.log")));
     }
 
-    /**
+    /*
      * Test adding agent remote directory content with includes pattern(s).
      */
     @Test


### PR DESCRIPTION
The usage in test methods here often did not meet some Javadoc requirements, therefore generating a lot of warnings when running `mvn javadoc:test-javadoc`.