### PR TITLE
[JENKINS-62526] Split JenkinsLogs

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/CustomLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/CustomLogs.java
@@ -1,0 +1,217 @@
+package com.cloudbees.jenkins.support.impl;
+
+import com.cloudbees.jenkins.support.api.Component;
+import com.cloudbees.jenkins.support.api.Container;
+import com.cloudbees.jenkins.support.api.FileContent;
+import com.cloudbees.jenkins.support.api.SupportContext;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.Extension;
+import hudson.init.Terminator;
+import hudson.logging.LogRecorder;
+import hudson.model.PeriodicWork;
+import hudson.security.Permission;
+import hudson.util.CopyOnWriteList;
+import hudson.util.io.RewindableFileOutputStream;
+import hudson.util.io.RewindableRotatingFileOutputStream;
+import io.jenkins.lib.support_log_formatter.SupportLogFormatter;
+import jenkins.model.Jenkins;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.logging.StreamHandler;
+
+/**
+ * Custom Log recorders files from the master.
+ */
+@Extension(ordinal = 100.0)
+public class CustomLogs extends Component {
+
+    private static final int MAX_ROTATE_LOGS = Integer.getInteger(CustomLogs.class.getName() + ".MAX_ROTATE_LOGS", 9);
+    private final Map<String,LogRecorder> logRecorders = Jenkins.get().getLog().logRecorders;
+    private final File customLogs = new File(getLogsRoot(), "custom");
+
+    @NonNull
+    @Override
+    public Set<Permission> getRequiredPermissions() {
+        return Collections.singleton(Jenkins.ADMINISTER);
+    }
+
+    @NonNull
+    @Override
+    public String getDisplayName() {
+        return "Master Custom Log Recorders";
+    }
+
+    @Override
+    public void start(@NonNull SupportContext context) {
+        Logger.getLogger("").addHandler(new CustomHandler());
+    }
+
+    @Override
+    public void addContents(@NonNull Container result) {
+        addLogRecorders(result);
+    }
+
+    /**
+     * Dumps the content of {@link LogRecorder}, which is the groups of loggers configured
+     * by the user. The contents are also ring buffer and only remembers recent 256 or so entries.
+     */
+    private void addLogRecorders(Container result) {
+        for (Map.Entry<String, LogRecorder> entry : logRecorders.entrySet()) {
+            String name = entry.getKey();
+            String entryName = "nodes/master/logs/custom/{0}.log"; // name to be filtered in the bundle
+            File storedFile = new File(customLogs, name + ".log");
+            if (storedFile.isFile()) {
+                result.add(new FileContent(entryName, new String[]{name}, storedFile));
+            } else {
+                // Was not stored for some reason; fine, just load the memory buffer.
+                final LogRecorder recorder = entry.getValue();
+                result.add(new LogRecordContent(entryName, new String[]{name}) {
+                    @Override
+                    public Iterable<LogRecord> getLogRecords() {
+                        return recorder.getLogRecords();
+                    }
+                });
+            }
+        }
+    }
+
+    /**
+     * Returns the root directory for logs (historically always found under <code>$JENKINS_HOME/logs</code>.
+     * Configurable since Jenkins 2.114.
+     *
+     * @see hudson.triggers.SafeTimerTask#LOGS_ROOT_PATH_PROPERTY
+     * @return the root directory for logs.
+     */
+    private File getLogsRoot() {
+        final String overriddenLogsRoot = System.getProperty("hudson.triggers.SafeTimerTask.logsTargetDir");
+        if (overriddenLogsRoot == null) {
+            return new File(Jenkins.get().getRootDir(), "logs");
+        } else {
+            return new File(overriddenLogsRoot);
+        }
+    }
+
+    @SuppressFBWarnings(value="SIC_INNER_SHOULD_BE_STATIC_NEEDS_THIS", justification="customLogs is not static, so this is a bug in FB")
+    private final class LogFile {
+        private final RewindableRotatingFileOutputStream stream;
+        private final Handler handler;
+        private int count;
+        @SuppressFBWarnings(value="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE", justification="if mkdirs fails, will just get a stack trace later")
+        LogFile(String name) throws IOException {
+            customLogs.mkdirs();
+            stream = new RewindableRotatingFileOutputStream(new File(customLogs, name + ".log"), MAX_ROTATE_LOGS);
+            // TODO there is no way to avoid rotating when first opened; if .rewind is skipped, the file is just truncated
+            stream.rewind();
+            handler = new StreamHandler(stream, new SupportLogFormatter());
+            handler.setLevel(Level.ALL);
+            count = 0;
+        }
+        void publish(LogRecord record) throws IOException {
+            boolean rewind = false;
+            synchronized (this) {
+                if (count++ > 9999) { // make sure it does not get enormous during a single session
+                    count = 0;
+                    rewind = true;
+                }
+            }
+            if (rewind) {
+                stream.rewind();
+            }
+            handler.publish(record);
+            LogFlusher.scheduleFlush(handler);
+        }
+    }
+
+    private final class CustomHandler extends Handler {
+
+        private final Map<String,LogFile> logFiles = new HashMap<String,LogFile>();
+
+        /** JENKINS-27669: try to preload classes that will be needed by {@link #publish} */
+        CustomHandler() {
+            Arrays.hashCode(new Class<?>[] {
+                    Map.Entry.class,
+                    LogRecorder.class,
+                    LogRecorder.Target.class,
+                    LogFile.class,
+                    RewindableFileOutputStream.class,
+                    RewindableRotatingFileOutputStream.class,
+                    StreamHandler.class,
+                    SupportLogFormatter.class,
+                    LogFlusher.class,
+                    CopyOnWriteList.class,
+                    PrintWriter.class,
+                    Throwable.class,
+            });
+        }
+
+        @Override public void publish(LogRecord record) {
+            for (Map.Entry<String,LogRecorder> entry : logRecorders.entrySet()) {
+                for (LogRecorder.Target target : entry.getValue().targets) {
+                    if (target.includes(record)) {
+                        try {
+                            String name = entry.getKey();
+                            LogFile logFile;
+                            synchronized (logFiles) {
+                                logFile = logFiles.get(name);
+                                if (logFile == null) {
+                                    logFile = new LogFile(name);
+                                    logFiles.put(name, logFile);
+                                }
+                            }
+                            logFile.publish(record);
+                        } catch (IOException x) {
+                            x.printStackTrace(); // TODO probably unsafe to log this
+                        }
+                    }
+                }
+            }
+        }
+
+        @Override public void flush() {}
+
+        @Override public void close() throws SecurityException {}
+
+    }
+
+    @Extension public static final class LogFlusher extends PeriodicWork {
+
+        private static final Set<Handler> unflushedHandlers = new HashSet<Handler>();
+
+        static synchronized void scheduleFlush(Handler h) {
+            unflushedHandlers.add(h);
+        }
+
+        @Override public long getRecurrencePeriod() {
+            return 3000; // 3s
+        }
+
+        @Override protected void doRun() throws Exception {
+            flush();
+        }
+
+        @Terminator public static void flush() {
+            Handler[] handlers;
+            synchronized (LogFlusher.class) {
+                handlers = unflushedHandlers.toArray(new Handler[unflushedHandlers.size()]);
+                unflushedHandlers.clear();
+            }
+            for (Handler h : handlers) {
+                h.flush();
+            }
+        }
+
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/support/impl/JenkinsLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/JenkinsLogs.java
@@ -1,42 +1,24 @@
 package com.cloudbees.jenkins.support.impl;
 
-import io.jenkins.lib.support_log_formatter.SupportLogFormatter;
 import com.cloudbees.jenkins.support.SupportPlugin;
 import com.cloudbees.jenkins.support.api.Component;
 import com.cloudbees.jenkins.support.api.Container;
 import com.cloudbees.jenkins.support.api.FileContent;
-import com.cloudbees.jenkins.support.api.SupportContext;
 import com.google.common.collect.Lists;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.WebAppMain;
-import hudson.init.Terminator;
-import hudson.logging.LogRecorder;
-import hudson.model.PeriodicWork;
 import hudson.security.Permission;
-import hudson.util.CopyOnWriteList;
-import hudson.util.io.RewindableFileOutputStream;
-import hudson.util.io.RewindableRotatingFileOutputStream;
 import jenkins.model.Jenkins;
 
 import java.io.File;
 import java.io.FileFilter;
-import java.io.IOException;
-import java.io.PrintWriter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
-import java.util.logging.Formatter;
-import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
-import java.util.logging.StreamHandler;
 import java.util.regex.Pattern;
 
 /**
@@ -46,9 +28,6 @@ import java.util.regex.Pattern;
 public class JenkinsLogs extends Component {
 
     private static final Logger LOGGER = Logger.getLogger(JenkinsLogs.class.getName());
-    private static final int MAX_ROTATE_LOGS = Integer.getInteger(JenkinsLogs.class.getName() + ".MAX_ROTATE_LOGS", 9);
-    private final Map<String,LogRecorder> logRecorders = Jenkins.getInstance().getLog().logRecorders;
-    private final File customLogs = new File(getLogsRoot(), "custom");
 
     @NonNull
     @Override
@@ -63,87 +42,9 @@ public class JenkinsLogs extends Component {
     }
 
     @Override
-    public void start(@NonNull SupportContext context) {
-        Logger.getLogger("").addHandler(new CustomHandler());
-    }
-
-    @Override
     public void addContents(@NonNull Container result) {
         addMasterJulRingBuffer(result);
         addMasterJulLogRecords(result);
-        addOtherMasterLogs(result);
-        addLogRecorders(result);
-    }
-
-    /**
-     * Dumps the content of {@link LogRecorder}, which is the groups of loggers configured
-     * by the user. The contents are also ring buffer and only remembers recent 256 or so entries.
-     */
-    private void addLogRecorders(Container result) {
-        for (Map.Entry<String, LogRecorder> entry : logRecorders.entrySet()) {
-            String name = entry.getKey();
-            String entryName = "nodes/master/logs/custom/{0}.log"; // name to be filtered in the bundle
-            File storedFile = new File(customLogs, name + ".log");
-            if (storedFile.isFile()) {
-                result.add(new FileContent(entryName, new String[]{name}, storedFile));
-            } else {
-                // Was not stored for some reason; fine, just load the memory buffer.
-                final LogRecorder recorder = entry.getValue();
-                result.add(new LogRecordContent(entryName, new String[]{name}) {
-                    @Override
-                    public Iterable<LogRecord> getLogRecords() {
-                        return recorder.getLogRecords();
-                    }
-                });
-            }
-        }
-    }
-
-    /**
-     * Grabs any files that look like log files directly under {@code $JENKINS_HOME}, just in case
-     * any of them are useful.
-     * Does not add anything if Jenkins instance is unavailable.
-     * Some plugins write log files here.
-     */
-    private void addOtherMasterLogs(Container result) {
-        final Jenkins jenkins = Jenkins.getInstance();
-        File[] files = jenkins.getRootDir().listFiles(ROTATED_LOGFILE_FILTER);
-        if (files != null) {
-            for (File f : files) {
-                result.add(new FileContent("other-logs/{0}", new String[]{f.getName()}, f));
-            }
-        }
-        File logs = getLogsRoot();
-        files = logs.listFiles(ROTATED_LOGFILE_FILTER);
-        if (files != null) {
-            for (File f : files) {
-                result.add(new FileContent("other-logs/{0}", new String[]{f.getName()}, f));
-            }
-        }
-
-        File taskLogs = new File(logs, "tasks");
-        files = taskLogs.listFiles(ROTATED_LOGFILE_FILTER);
-        if (files != null) {
-            for (File f : files) {
-                result.add(new FileContent("other-logs/{0}", new String[]{f.getName()}, f));
-            }
-        }
-    }
-
-    /**
-     * Returns the root directory for logs (historically always found under <code>$JENKINS_HOME/logs</code>.
-     * Configurable since Jenkins 2.114.
-     *
-     * @see hudson.triggers.SafeTimerTask#LOGS_ROOT_PATH_PROPERTY
-     * @return the root directory for logs.
-     */
-    private File getLogsRoot() {
-        final String overriddenLogsRoot = System.getProperty("hudson.triggers.SafeTimerTask.logsTargetDir");
-        if (overriddenLogsRoot == null) {
-            return new File(Jenkins.get().getRootDir(), "logs");
-        } else {
-            return new File(overriddenLogsRoot);
-        }
     }
 
     /**
@@ -195,118 +96,6 @@ public class JenkinsLogs extends Component {
         }
     }
 
-
-    @SuppressFBWarnings(value="SIC_INNER_SHOULD_BE_STATIC_NEEDS_THIS", justification="customLogs is not static, so this is a bug in FB")
-    private final class LogFile {
-        private final RewindableRotatingFileOutputStream stream;
-        private final Handler handler;
-        private int count;
-        @SuppressFBWarnings(value="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE", justification="if mkdirs fails, will just get a stack trace later")
-        LogFile(String name) throws IOException {
-            customLogs.mkdirs();
-            stream = new RewindableRotatingFileOutputStream(new File(customLogs, name + ".log"), MAX_ROTATE_LOGS);
-            // TODO there is no way to avoid rotating when first opened; if .rewind is skipped, the file is just truncated
-            stream.rewind();
-            handler = new StreamHandler(stream, new SupportLogFormatter());
-            handler.setLevel(Level.ALL);
-            count = 0;
-        }
-        void publish(LogRecord record) throws IOException {
-            boolean rewind = false;
-            synchronized (this) {
-                if (count++ > 9999) { // make sure it does not get enormous during a single session
-                    count = 0;
-                    rewind = true;
-                }
-            }
-            if (rewind) {
-                stream.rewind();
-            }
-            handler.publish(record);
-            LogFlusher.scheduleFlush(handler);
-        }
-    }
-
-    private final class CustomHandler extends Handler {
-
-        private final Map<String,LogFile> logFiles = new HashMap<String,LogFile>();
-
-        /** JENKINS-27669: try to preload classes that will be needed by {@link #publish} */
-        CustomHandler() {
-            Arrays.hashCode(new Class<?>[] {
-                Map.Entry.class,
-                LogRecorder.class,
-                LogRecorder.Target.class,
-                LogFile.class,
-                RewindableFileOutputStream.class,
-                RewindableRotatingFileOutputStream.class,
-                StreamHandler.class,
-                SupportLogFormatter.class,
-                LogFlusher.class,
-                CopyOnWriteList.class,
-                PrintWriter.class,
-                Throwable.class,
-            });
-        }
-
-        @Override public void publish(LogRecord record) {
-            for (Map.Entry<String,LogRecorder> entry : logRecorders.entrySet()) {
-                for (LogRecorder.Target target : entry.getValue().targets) {
-                    if (target.includes(record)) {
-                        try {
-                            String name = entry.getKey();
-                            LogFile logFile;
-                            synchronized (logFiles) {
-                                logFile = logFiles.get(name);
-                                if (logFile == null) {
-                                    logFile = new LogFile(name);
-                                    logFiles.put(name, logFile);
-                                }
-                            }
-                            logFile.publish(record);
-                        } catch (IOException x) {
-                            x.printStackTrace(); // TODO probably unsafe to log this
-                        }
-                    }
-                }
-            }
-        }
-
-        @Override public void flush() {}
-
-        @Override public void close() throws SecurityException {}
-
-    }
-
-    @Extension public static final class LogFlusher extends PeriodicWork {
-
-        private static final Set<Handler> unflushedHandlers = new HashSet<Handler>();
-
-        static synchronized void scheduleFlush(Handler h) {
-            unflushedHandlers.add(h);
-        }
-
-        @Override public long getRecurrencePeriod() {
-            return 3000; // 3s
-        }
-
-        @Override protected void doRun() throws Exception {
-            flush();
-        }
-
-        @Terminator public static void flush() {
-            Handler[] handlers;
-            synchronized (LogFlusher.class) {
-                handlers = unflushedHandlers.toArray(new Handler[unflushedHandlers.size()]);
-                unflushedHandlers.clear();
-            }
-            for (Handler h : handlers) {
-                h.flush();
-            }
-        }
-
-    }
-
     /**
      * Matches log files and their rotated names, such as "foo.log" or "foo.log.1"
      */
@@ -317,6 +106,4 @@ public class JenkinsLogs extends Component {
             return pattern.matcher(f.getName()).matches() && f.length()>0;
         }
     };
-
-    protected static final Formatter LOG_FORMATTER = new SupportLogFormatter();
 }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/OtherLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/OtherLogs.java
@@ -1,0 +1,62 @@
+package com.cloudbees.jenkins.support.impl;
+
+import com.cloudbees.jenkins.support.api.Component;
+import com.cloudbees.jenkins.support.api.Container;
+import com.cloudbees.jenkins.support.api.FileContent;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.security.Permission;
+import jenkins.model.Jenkins;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Set;
+
+import static com.cloudbees.jenkins.support.impl.JenkinsLogs.ROTATED_LOGFILE_FILTER;
+
+/**
+ * Root Log files from the master node.
+ */
+@Extension(ordinal = 100.0) // put this first as largest content and can let the slower ones complete
+public class OtherLogs extends Component {
+
+    @NonNull
+    @Override
+    public Set<Permission> getRequiredPermissions() {
+        return Collections.singleton(Jenkins.ADMINISTER);
+    }
+
+    @NonNull
+    @Override
+    public String getDisplayName() {
+        return "Master Other Log Recorders";
+    }
+
+    @Override
+    public boolean isSelectedByDefault() {
+        return false;
+    }
+
+    @Override
+    public void addContents(@NonNull Container result) {
+        addOtherMasterLogs(result);
+    }
+    
+    /**
+     * Grabs any files that look like log files directly under {@code $JENKINS_HOME}, just in case
+     * any of them are useful.
+     * Does not add anything if Jenkins instance is unavailable.
+     * Some plugins write log files here.
+     */
+    private void addOtherMasterLogs(Container result) {
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
+        if (jenkins != null) {
+            File[] files = jenkins.getRootDir().listFiles(ROTATED_LOGFILE_FILTER);
+            if (files != null) {
+                for (File f : files) {
+                    result.add(new FileContent("other-logs/{0}", new String[]{f.getName()}, f));
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/support/impl/TaskLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/TaskLogs.java
@@ -76,7 +76,7 @@ public class TaskLogs extends Component {
      * @see hudson.triggers.SafeTimerTask#LOGS_ROOT_PATH_PROPERTY
      * @return the root directory for logs.
      */
-    private File getLogsRoot() {
+    protected static File getLogsRoot() {
         final String overriddenLogsRoot = System.getProperty("hudson.triggers.SafeTimerTask.logsTargetDir");
         if (overriddenLogsRoot == null) {
             return new File(Jenkins.get().getRootDir(), "logs");

--- a/src/main/java/com/cloudbees/jenkins/support/impl/TaskLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/TaskLogs.java
@@ -1,0 +1,87 @@
+package com.cloudbees.jenkins.support.impl;
+
+import com.cloudbees.jenkins.support.api.Component;
+import com.cloudbees.jenkins.support.api.Container;
+import com.cloudbees.jenkins.support.api.FileContent;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.security.Permission;
+import jenkins.model.Jenkins;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Set;
+
+import static com.cloudbees.jenkins.support.impl.JenkinsLogs.ROTATED_LOGFILE_FILTER;
+
+/**
+ * Task Log files from the master node.
+ */
+@Extension(ordinal = 100.0) // put this first as largest content and can let the slower ones complete
+public class TaskLogs extends Component {
+
+    @NonNull
+    @Override
+    public Set<Permission> getRequiredPermissions() {
+        return Collections.singleton(Jenkins.ADMINISTER);
+    }
+
+    @NonNull
+    @Override
+    public String getDisplayName() {
+        return "Master Task Log Recorders";
+    }
+
+    @Override
+    public boolean isSelectedByDefault() {
+        return true;
+    }
+
+    @Override
+    public void addContents(@NonNull Container result) {
+        addOtherMasterLogs(result);
+    }
+    
+    /**
+     * Grabs any files that look like log files directly under <code>$JENKINS_HOME/logs</code>, just in case
+     * any of them are useful.
+     * Does not add anything if Jenkins instance is unavailable.
+     * Some plugins write log files here.
+     */
+    private void addOtherMasterLogs(Container result) {
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
+        if (jenkins != null) {
+            File logs = getLogsRoot();
+            File[] files = logs.listFiles(ROTATED_LOGFILE_FILTER);
+            if (files != null) {
+                for (File f : files) {
+                    result.add(new FileContent("task-logs/{0}", new String[]{f.getName()}, f));
+                }
+            }
+
+            File taskLogs = new File(logs, "tasks");
+            files = taskLogs.listFiles(ROTATED_LOGFILE_FILTER);
+            if (files != null) {
+                for (File f : files) {
+                    result.add(new FileContent("task-logs/{0}", new String[]{f.getName()}, f));
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns the root directory for logs (historically always found under <code>$JENKINS_HOME/logs</code>.
+     * Configurable since Jenkins 2.114.
+     *
+     * @see hudson.triggers.SafeTimerTask#LOGS_ROOT_PATH_PROPERTY
+     * @return the root directory for logs.
+     */
+    private File getLogsRoot() {
+        final String overriddenLogsRoot = System.getProperty("hudson.triggers.SafeTimerTask.logsTargetDir");
+        if (overriddenLogsRoot == null) {
+            return new File(Jenkins.get().getRootDir(), "logs");
+        } else {
+            return new File(overriddenLogsRoot);
+        }
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/support/impl/CustomLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/CustomLogsTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2013 CloudBees, Inc.
+ */
+package com.cloudbees.jenkins.support.impl;
+
+import com.cloudbees.jenkins.support.SupportTestUtils;
+import com.cloudbees.jenkins.support.api.Component;
+import com.cloudbees.jenkins.support.api.Container;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.ExtensionList;
+import hudson.logging.LogRecorder;
+import hudson.security.Permission;
+import jenkins.model.Jenkins;
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class CustomLogsTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testCustomLogsContentEmpty() {
+        String customLogs = SupportTestUtils.invokeComponentToString(
+                Objects.requireNonNull(ExtensionList.lookup(Component.class).get(CustomLogs.class)));
+        assertTrue("Should not write anything", customLogs.isEmpty());
+    }
+
+    @Test
+    public void testCustomLogsContent() {
+        LogRecorder testLogRecorder = new LogRecorder("test");
+        LogRecorder.Target testTarget = new LogRecorder.Target(CustomLogsTest.class.getName(), Level.FINER);
+        testLogRecorder.targets.add(testTarget);
+        j.getInstance().getLog().logRecorders.put("test", testLogRecorder);
+        testTarget.enable();
+        SupportTestUtils.invokeComponentToString(new Component() {
+
+            @NonNull
+            @Override
+            public Set<Permission> getRequiredPermissions() {
+                return Collections.singleton(Jenkins.ADMINISTER);
+            }
+
+            @NonNull
+            @Override
+            public String getDisplayName() {
+                return "";
+            }
+
+            @Override
+            public void addContents(@NonNull Container container) {
+                Logger.getLogger(CustomLogsTest.class.getName()).fine("Testing custom log recorders");
+            }
+        });
+        String customLogs = SupportTestUtils.invokeComponentToString(
+                Objects.requireNonNull(ExtensionList.lookup(Component.class).get(CustomLogs.class)));
+        assertFalse("Should write CustomLogsTest FINE logs", customLogs.isEmpty());
+        assertThat(customLogs , Matchers.containsString("Testing custom log recorders"));
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/support/impl/JenkinsLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/JenkinsLogsTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2013 CloudBees, Inc.
+ */
+package com.cloudbees.jenkins.support.impl;
+
+import com.cloudbees.jenkins.support.SupportTestUtils;
+import com.cloudbees.jenkins.support.api.Component;
+import hudson.ExtensionList;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Objects;
+
+import static org.junit.Assert.assertFalse;
+
+public class JenkinsLogsTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testJenkinsLogsContent() {
+        String jenkinsLogs = SupportTestUtils.invokeComponentToString(
+                Objects.requireNonNull(ExtensionList.lookup(Component.class).get(JenkinsLogs.class)));
+        assertFalse("Should write something", jenkinsLogs.isEmpty());
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/support/impl/OtherLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/OtherLogsTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2013 CloudBees, Inc.
+ */
+package com.cloudbees.jenkins.support.impl;
+
+import com.cloudbees.jenkins.support.SupportTestUtils;
+import com.cloudbees.jenkins.support.api.Component;
+import hudson.ExtensionList;
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.Objects;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class OtherLogsTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testOtherLogsContentEmpty() {
+        String otherLogs = SupportTestUtils.invokeComponentToString(
+                Objects.requireNonNull(ExtensionList.lookup(Component.class).get(OtherLogs.class)));
+        assertTrue("Should not write anything", otherLogs.isEmpty());
+    }
+
+    @Test
+    public void testOtherLogsRootDir() throws IOException {
+        File testFile = new File(j.getInstance().getRootDir(), "test.log");
+        Files.createFile(testFile.toPath());
+        Files.write(testFile.toPath(), Collections.singletonList("This is a test from root dir"), 
+                Charset.defaultCharset());
+        
+        String otherLogs = SupportTestUtils.invokeComponentToString(
+                Objects.requireNonNull(ExtensionList.lookup(Component.class).get(OtherLogs.class)));
+        assertFalse("Should collect *.log under the root dir", otherLogs.isEmpty());
+        assertThat(otherLogs , Matchers.containsString("This is a test from root dir"));
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/support/impl/TaskLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/TaskLogsTest.java
@@ -29,14 +29,14 @@ public class TaskLogsTest {
     public JenkinsRule j = new JenkinsRule();
 
     @Test
-    public void testOtherLogsContentEmpty() {
+    public void testTaskLogsContentEmpty() {
         String otherLogs = SupportTestUtils.invokeComponentToString(
                 Objects.requireNonNull(ExtensionList.lookup(Component.class).get(TaskLogs.class)));
         assertTrue("Should not write anything", otherLogs.isEmpty());
     }
 
     @Test
-    public void testOtherLogsRootSafeTimer() throws IOException {
+    public void testTaskRootSafeTimerLogs() throws IOException {
         File safeTimerTasksDir = SafeTimerTask.getLogsRoot();
         safeTimerTasksDir.mkdir();
         File testFile = new File(safeTimerTasksDir, "test.log");
@@ -45,13 +45,13 @@ public class TaskLogsTest {
                 Charset.defaultCharset());
         
         String otherLogs = SupportTestUtils.invokeComponentToString(
-                Objects.requireNonNull(ExtensionList.lookup(Component.class).get(OtherLogs.class)));
+                Objects.requireNonNull(ExtensionList.lookup(Component.class).get(TaskLogs.class)));
         assertFalse("Should collect *.log under the SafeTimerTask dir", otherLogs.isEmpty());
         assertThat(otherLogs , Matchers.containsString("This is a test from SafeTimerTask dir"));
     }
 
     @Test
-    public void testOtherLogsTasks() throws IOException {
+    public void testTaskLogs() throws IOException {
         File tasksDir = new File(SafeTimerTask.getLogsRoot(), "tasks");
         SafeTimerTask.getLogsRoot().mkdir();
         tasksDir.mkdir();
@@ -61,7 +61,7 @@ public class TaskLogsTest {
                 Charset.defaultCharset());
         
         String otherLogs = SupportTestUtils.invokeComponentToString(
-                Objects.requireNonNull(ExtensionList.lookup(Component.class).get(OtherLogs.class)));
+                Objects.requireNonNull(ExtensionList.lookup(Component.class).get(TaskLogs.class)));
         assertFalse("Should collect *.log under the tasks dir", otherLogs.isEmpty());
         assertThat(otherLogs , Matchers.containsString("This is a test from tasks dir"));
     }

--- a/src/test/java/com/cloudbees/jenkins/support/impl/TaskLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/TaskLogsTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2013 CloudBees, Inc.
+ */
+package com.cloudbees.jenkins.support.impl;
+
+import com.cloudbees.jenkins.support.SupportTestUtils;
+import com.cloudbees.jenkins.support.api.Component;
+import hudson.ExtensionList;
+import hudson.triggers.SafeTimerTask;
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.Objects;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class TaskLogsTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testOtherLogsContentEmpty() {
+        String otherLogs = SupportTestUtils.invokeComponentToString(
+                Objects.requireNonNull(ExtensionList.lookup(Component.class).get(TaskLogs.class)));
+        assertTrue("Should not write anything", otherLogs.isEmpty());
+    }
+
+    @Test
+    public void testOtherLogsRootSafeTimer() throws IOException {
+        File safeTimerTasksDir = SafeTimerTask.getLogsRoot();
+        safeTimerTasksDir.mkdir();
+        File testFile = new File(safeTimerTasksDir, "test.log");
+        Files.createFile(testFile.toPath());
+        Files.write(testFile.toPath(), Collections.singletonList("This is a test from SafeTimerTask dir"), 
+                Charset.defaultCharset());
+        
+        String otherLogs = SupportTestUtils.invokeComponentToString(
+                Objects.requireNonNull(ExtensionList.lookup(Component.class).get(OtherLogs.class)));
+        assertFalse("Should collect *.log under the SafeTimerTask dir", otherLogs.isEmpty());
+        assertThat(otherLogs , Matchers.containsString("This is a test from SafeTimerTask dir"));
+    }
+
+    @Test
+    public void testOtherLogsTasks() throws IOException {
+        File tasksDir = new File(SafeTimerTask.getLogsRoot(), "tasks");
+        SafeTimerTask.getLogsRoot().mkdir();
+        tasksDir.mkdir();
+        File testFile = new File(tasksDir, "test.log");
+        Files.createFile(testFile.toPath());
+        Files.write(testFile.toPath(), Collections.singletonList("This is a test from tasks dir"), 
+                Charset.defaultCharset());
+        
+        String otherLogs = SupportTestUtils.invokeComponentToString(
+                Objects.requireNonNull(ExtensionList.lookup(Component.class).get(OtherLogs.class)));
+        assertFalse("Should collect *.log under the tasks dir", otherLogs.isEmpty());
+        assertThat(otherLogs , Matchers.containsString("This is a test from tasks dir"));
+    }
+}


### PR DESCRIPTION
[JENKINS-62526](https://issues.jenkins-ci.org/browse/JENKINS-62526) Split the "Master Log Recorders" that was taking files from many location (`$JENKINS_HOME/`, `$JENKINS_HOME/logs`, `$JENKINS_HOME/logs/custom`, `$JENKINS_HOME/support`) and generated by different components.

Proposal:

* "Master Log Recorders": 
  * collect Jenkins logs
  * store under `nodes/master/logs/` in the bundle
  * selected by default
* "Master Custom Log Recorders":
  * collect Logs recorders defined by a user
  * store under `nodes/master/logs/custom/` in the bundle
  * selected by default
* "Master Task Log Recorders": selected by default
  * collect Jenkins Tasks logs
  * store under `task-logs/` in the bundle
  * selected by default
* "Master Other Log Recorders": 
  * collect Logs under `$JENKINS_HOME`
  * store under `other-logs/` in the bundle
  * **not selected by default**

I was also wondering if those logs could maybe all be stored under `nodes/master/logs` ? For example `nodes/master/logs/task`, `nodes/master/logs/other`.