### PR TITLE
Render current item's sidepanel instead of the Jenkins one

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,12 @@
       <version>${configuration-as-code.version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- MockFolder that was used for SupportAbstractItem test does not have UI, hence need full Folder implementation.-->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>cloudbees-folder</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/src/main/resources/com/cloudbees/jenkins/support/actions/SupportAbstractItemAction/index.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/support/actions/SupportAbstractItemAction/index.jelly
@@ -27,7 +27,7 @@
          xmlns:l="/lib/layout"
          xmlns:f="/lib/form">
     <l:layout title="${it.actionTitle}" norefresh="true" permission="${Jenkins.ADMINISTER}">
-        <st:include page="sidepanel.jelly" it="${app}"/>
+        <st:include page="sidepanel.jelly" it="${it.object}"/>
         <l:main-panel>
             <h1>
                 <img src="${resURL}/plugin/support-core/images/32x32/support.png" alt=""/>

--- a/src/main/resources/com/cloudbees/jenkins/support/actions/SupportComputerAction/index.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/support/actions/SupportComputerAction/index.jelly
@@ -27,7 +27,7 @@
          xmlns:l="/lib/layout"
          xmlns:f="/lib/form">
     <l:layout title="${it.actionTitle}" norefresh="true" permission="${Jenkins.ADMINISTER}">
-        <st:include page="sidepanel.jelly" it="${app}"/>
+        <st:include page="sidepanel.jelly" it="${it.object}"/>
         <l:main-panel>
             <h1>
                 <img src="${resURL}/plugin/support-core/images/32x32/support.png" alt=""/>

--- a/src/main/resources/com/cloudbees/jenkins/support/actions/SupportRunAction/index.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/support/actions/SupportRunAction/index.jelly
@@ -27,7 +27,7 @@
          xmlns:l="/lib/layout"
          xmlns:f="/lib/form">
     <l:layout title="${it.actionTitleText}" norefresh="true" permission="${Jenkins.ADMINISTER}">
-        <st:include page="sidepanel.jelly" it="${app}"/>
+        <st:include page="sidepanel.jelly" it="${it.object}"/>
         <l:main-panel>
             <h1>
                 <img src="${resURL}/plugin/support-core/images/32x32/support.png" alt=""/>

--- a/src/test/java/com/cloudbees/jenkins/support/actions/SupportAbstractItemActionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/actions/SupportAbstractItemActionTest.java
@@ -13,7 +13,6 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.MockFolder;
 
 import java.util.Optional;
 import java.util.zip.ZipFile;
@@ -40,7 +39,7 @@ public class SupportAbstractItemActionTest {
 
         // Check that the generation does not show any warnings
         ZipFile z = SupportTestUtils.generateBundleWithoutWarnings(folder.getUrl(),
-                new SupportAbstractItemAction(j.jenkins.getItemByFullName("testFolder", MockFolder.class)),
+                new SupportAbstractItemAction(j.jenkins.getItemByFullName("testFolder", Folder.class)),
                 SupportPlugin.class,
                 j.createWebClient());
 
@@ -55,7 +54,7 @@ public class SupportAbstractItemActionTest {
      */
     @Test
     public void generateFreestyleBundleDefaultsAndCheckContent() throws Exception {
-        MockFolder folder = j.createFolder("testFolder");
+        Folder folder = j.createProject(Folder.class, "testFolder");
         FreeStyleProject p = folder.createProject(FreeStyleProject.class, "testFreestyle");
         QueueTaskFuture<FreeStyleBuild> freeStyleBuildQueueTaskFuture = p.scheduleBuild2(0);
         FreeStyleBuild fBuild = freeStyleBuildQueueTaskFuture.waitForStart();
@@ -63,7 +62,7 @@ public class SupportAbstractItemActionTest {
 
         // Check that the generation does not show any warnings
         ZipFile z = SupportTestUtils.generateBundleWithoutWarnings(p.getUrl(),
-                new SupportAbstractItemAction(j.jenkins.getItemByFullName("testFolder/testFreestyle", MockFolder.class)),
+                new SupportAbstractItemAction(j.jenkins.getItemByFullName("testFolder/testFreestyle", FreeStyleProject.class)),
                 SupportPlugin.class,
                 j.createWebClient());
 

--- a/src/test/java/com/cloudbees/jenkins/support/actions/SupportAbstractItemActionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/actions/SupportAbstractItemActionTest.java
@@ -1,5 +1,6 @@
 package com.cloudbees.jenkins.support.actions;
 
+import com.cloudbees.hudson.plugins.folder.Folder;
 import com.cloudbees.jenkins.support.SupportPlugin;
 import com.cloudbees.jenkins.support.SupportTestUtils;
 import hudson.model.FreeStyleBuild;
@@ -33,8 +34,8 @@ public class SupportAbstractItemActionTest {
      */
     @Test
     public void generateFolderBundleDefaultsAndCheckContent() throws Exception {
-        MockFolder folder = j.createFolder("testFolder");
-        MockFolder subFolder = folder.createProject(MockFolder.class, "subFolder");
+        Folder folder = j.createProject(Folder.class, "testFolder");
+        Folder subFolder = folder.createProject(Folder.class, "subFolder");
         subFolder.createProject(FreeStyleProject.class, "testFreestyle");
 
         // Check that the generation does not show any warnings


### PR DESCRIPTION
When generating support bundle for items and nodes, make sure
that sidepanel of the current item is rendered, not the Jenkins one.