### PR TITLE
[JENKINS-63635] Retrieve recent agent logs

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/LogFilenameAgentFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/LogFilenameAgentFilter.java
@@ -1,0 +1,50 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2020, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cloudbees.jenkins.support.impl;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.Serializable;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Matches agent log files in an interval of time
+ */
+class LogFilenameAgentFilter implements FilenameFilter, Serializable {
+
+    public static final long MAX_TIME_AGENT_LOG_RETRIEVAL = Long.getLong(System.getProperty(LogFilenameAgentFilter.class.getName() + ".maxTimeAgentLogRetrieval"), TimeUnit.DAYS.toMillis(7));
+
+    public boolean accept(File dir, String name) {
+        // We should avoid taking agent files which are very old
+        // as they are not usually very helpful to troubleshoot
+        // 1 week should be enough in most of the cases
+        if (new Date().getTime() -  dir.lastModified() < MAX_TIME_AGENT_LOG_RETRIEVAL) {
+            return name.endsWith(".log");
+        }
+        return false;
+    }
+    private static final long serialVersionUID = 1L;
+}

--- a/src/main/java/com/cloudbees/jenkins/support/impl/LogFilenameAgentFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/LogFilenameAgentFilter.java
@@ -41,8 +41,8 @@ class LogFilenameAgentFilter implements FilenameFilter, Serializable {
         // We should avoid taking agent files which are very old
         // as they are not usually very helpful to troubleshoot
         // 1 week should be enough in most of the cases
-        if (new Date().getTime() -  dir.lastModified() < MAX_TIME_AGENT_LOG_RETRIEVAL) {
-            return name.endsWith(".log");
+        if (name.endsWith(".log") && new Date().getTime() -  dir.lastModified() < MAX_TIME_AGENT_LOG_RETRIEVAL) {
+            return true;
         }
         return false;
     }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLogs.java
@@ -90,7 +90,7 @@ public class SlaveLogs extends Component {
     public void addContents(@NonNull Container container) {
         // expensive remote computation are pooled together and executed later concurrently across all the agents
         List<java.util.concurrent.Callable<List<FileContent>>> tasks = Lists.newArrayList();
-        SmartLogFetcher logFetcher = new SmartLogFetcher("cache", new LogFilenameFilter()); // id is awkward because of backward compatibility
+        SmartLogFetcher logFetcher = new SmartLogFetcher("cache", new LogFilenameAgentFilter()); // id is awkward because of backward compatibility
         SmartLogFetcher winswLogFetcher = new SmartLogFetcher("winsw", new WinswLogfileFilter());
 
         for (final Node node : Jenkins.get().getNodes()) {


### PR DESCRIPTION
When there is a big quantity of agents and there are a lot of logs on these agents, the agent's log folder could take more than 600MB of space. This means the Jenkins master might suffer from performance issues while compressing.

The main issue here is that we are capturing logs in the agents even of those who are 1 year old, which does not make a lot of sense in the troubleshooting.

Given this situation, the support-core should not grab from the agent the log files which are very old

Example of what is happening in a real case for a specific agent.

```
2.0M	jenkins-slave.0.err.log
2.0M	jenkins-slave.1.err.log
2.0M	jenkins-slave.2.err.log
2.0M	jenkins-slave.3.err.log
2.0M	jenkins-slave.4.err.log
2.0M	jenkins-slave.5.err.log
2.0M	jenkins-slave.6.err.log
2.0M	jenkins-slave.7.err.log
1.2M	jenkins-slave.err.log
884K	jenkins-slave.out.log
```

This is kind of a partial fix, because I should also check if the very old files really gets deleted from the support cache or not - although at the very least this is already something good to go in.

* https://issues.jenkins-ci.org/browse/JENKINS-63635

CC @Dohbedoh 