### PR TITLE
[JENKINS-63722] Fix getId() of nested components

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/JVMProcessSystemMetricsContents.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/JVMProcessSystemMetricsContents.java
@@ -55,6 +55,12 @@ public abstract class JVMProcessSystemMetricsContents extends AdvancedProcFilesR
             return Jenkins.get().getDescriptorByType(DescriptorImpl.class);
         }
 
+        @NonNull
+        @Override
+        public String getId() {
+            return "MasterJVMProcessSystemMetricsContents";
+        }
+
         @Extension
         @Symbol("masterJVMProcessSystemMetricsComponent")
         public static class DescriptorImpl extends ObjectComponentDescriptor<Computer> {
@@ -108,6 +114,12 @@ public abstract class JVMProcessSystemMetricsContents extends AdvancedProcFilesR
         @Override
         public DescriptorImpl getDescriptor() {
             return Jenkins.get().getDescriptorByType(DescriptorImpl.class);
+        }
+
+        @NonNull
+        @Override
+        public String getId() {
+            return "AgentsJVMProcessSystemMetricsContents";
         }
 
         @Extension

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SystemConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SystemConfiguration.java
@@ -91,6 +91,12 @@ public abstract class SystemConfiguration extends AdvancedProcFilesRetriever {
             return Jenkins.get().getDescriptorByType(DescriptorImpl.class);
         }
 
+        @NonNull
+        @Override
+        public String getId() {
+            return "MasterSystemConfiguration";
+        }
+
         @Extension
         @Symbol("masterSystemConfigurationComponent")
         public static class DescriptorImpl extends ObjectComponentDescriptor<Computer> {
@@ -144,6 +150,12 @@ public abstract class SystemConfiguration extends AdvancedProcFilesRetriever {
         @Override
         public DescriptorImpl getDescriptor() {
             return Jenkins.get().getDescriptorByType(DescriptorImpl.class);
+        }
+
+        @NonNull
+        @Override
+        public String getId() {
+            return "AgentsSystemConfiguration";
         }
 
         @Extension

--- a/src/main/resources/com/cloudbees/jenkins/support/Messages.properties
+++ b/src/main/resources/com/cloudbees/jenkins/support/Messages.properties
@@ -34,6 +34,7 @@ SupportAction_DefaultActionBlurb=\
   nodes, computers, labels, users, items (including jobs), views, and IP addresses.
 
 SupportCommand.generates_a_diagnostic_support_bundle_=Generates a diagnostic support bundle.
+SupportCommand.jenkins_63722_deprecated_ids=[JENKINS-63722] The component name ''{0}'' is deprecated, please use ''{0}JVMProcessSystemMetricsContents'' and / or ''{0}SystemConfiguration'' depending on the use case.
 SupportCommand.if_no_arguments_are_given_generate_a_bun=Sends the compressed support bundle to standard out or alternatively to a local file only if the deprecated remoting protocol is used.\nIf no arguments are given, generate a bundle with all components. Otherwise specify components by ID:
 SupportPlugin_PermissionGroup=Support
 SupportPlugin_CreateBundle=Generate bundle

--- a/src/test/java/com/cloudbees/jenkins/support/SupportPluginTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportPluginTest.java
@@ -25,8 +25,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.zip.ZipFile;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -37,6 +39,16 @@ public class SupportPluginTest {
 
     @Rule
     public TemporaryFolder temp = new TemporaryFolder();
+    
+    @Test
+    @Issue("JENKINS-63722")
+    public void testComponentIdsAreUnique() {
+        // If component IDs have duplicate, the Set size should be different because it only add an item if it is unique
+        assertEquals("Components ids should be unique", 
+            SupportPlugin.getComponents().stream().map(Component::getId).collect(Collectors.toSet()).size(),
+            SupportPlugin.getComponents().stream().map(Component::getId).count()
+            );
+    }
 
     @Test
     @Issue("JENKINS-58393")


### PR DESCRIPTION
[JENKINS-63722](https://issues.jenkins-ci.org/browse/JENKINS-63722) Fixing this by overriding `getId()`. We are also adding a `WARNING` for the different REST APIs and make sure that the old IDs `Master` and `Agents` are still working identically.