### PR TITLE
JENKINS-64172: Support Action names are made distinct

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/BundleFileName.java
+++ b/src/main/java/com/cloudbees/jenkins/support/BundleFileName.java
@@ -1,0 +1,85 @@
+package com.cloudbees.jenkins.support;
+
+import com.cloudbees.jenkins.support.api.SupportProvider;
+import org.apache.commons.lang.StringUtils;
+
+import javax.annotation.Nonnull;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+
+/**
+ * <p>Generate the support bundle names.</p>
+ *
+ * <p>Format: {@code "${support-provider-name}[_${qualifier}][_${instance_type}]_${date_time}}</p>
+ * <dl>
+ *     <dt>support-provider-name</dt>
+ *     <dd>"support" or the value of {@link SupportProvider#getName()}</dd>
+ *     <dt>qualifier</dt>
+ *     <dd>arbitrary string to help distinguish between potentially different support bundles</dd>
+ *     <dt>instance_type</dt>
+ *     <dd>See {@link BundleNameInstanceTypeProvider}</dd>
+ *     <dt>date_time</dt>
+ *     <dd>Date Time of the generation of the support bundle in UTC.</dd>
+ * </dl>
+ */
+public final class BundleFileName {
+    private BundleFileName() {
+        throw new UnsupportedOperationException();
+    }
+
+    private static final Clock DEFAULT_CLOCK = Clock.systemUTC();
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH.mm.ss");
+
+    /**
+     * @return the bundle name without qualifier.
+     */
+    @Nonnull
+    public static String generate() {
+        return generate(DEFAULT_CLOCK, null);
+    }
+
+    /**
+     * @return the bundle name with qualifier.
+     */
+    @Nonnull
+    public static String generate(String qualifier) {
+        return generate(DEFAULT_CLOCK, qualifier);
+    }
+
+    static String generate(Clock clock, String qualifier) {
+        Objects.requireNonNull(clock);
+
+        StringBuilder filename = new StringBuilder();
+        filename.append(getSupportProviderName());
+        if (StringUtils.isNotBlank(qualifier)) {
+            filename.append('_').append(qualifier.trim());
+        }
+        final String instanceType = BundleNameInstanceTypeProvider.getInstance().getInstanceType();
+        if (StringUtils.isNotBlank(instanceType)) {
+            filename.append("_").append(instanceType);
+        }
+        filename.append("_").append(LocalDateTime.now(clock).format(DATE_TIME_FORMATTER));
+        filename.append(".zip");
+        return filename.toString();
+    }
+
+    /**
+     * Returns the prefix of the bundle name.
+     *
+     * @return the prefix of the bundle name.
+     */
+    private static String getSupportProviderName() {
+        String filename = "support"; // default bundle filename
+        final SupportPlugin instance = SupportPlugin.getInstance();
+        if (instance != null) {
+            SupportProvider supportProvider = instance.getSupportProvider();
+            if (supportProvider != null) {
+                // let the provider name it
+                filename = supportProvider.getName();
+            }
+        }
+        return filename;
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/support/BundleNameInstanceTypeProvider.java
+++ b/src/main/java/com/cloudbees/jenkins/support/BundleNameInstanceTypeProvider.java
@@ -26,11 +26,11 @@ package com.cloudbees.jenkins.support;
 
 import com.cloudbees.jenkins.support.api.SupportProvider;
 import com.google.common.annotations.VisibleForTesting;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 
+import javax.annotation.Nonnull;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -57,7 +57,7 @@ public abstract class BundleNameInstanceTypeProvider implements ExtensionPoint {
 
     private static final Logger LOGGER = Logger.getLogger(BundleNameInstanceTypeProvider.class.getName());
 
-    @NonNull
+    @Nonnull
     static BundleNameInstanceTypeProvider getInstance() {
         final ExtensionList<BundleNameInstanceTypeProvider> all = ExtensionList.lookup(BundleNameInstanceTypeProvider.class);
         final int extensionCount = all.size();
@@ -93,7 +93,7 @@ public abstract class BundleNameInstanceTypeProvider implements ExtensionPoint {
      *
      * @return the instance type specification to be used for generated support bundles.
      */
-    @NonNull
+    @Nonnull
     public abstract String getInstanceType();
 
     // We want this to be always picked up last in case others are found Double.MIN_VALUE does NOT work
@@ -101,6 +101,7 @@ public abstract class BundleNameInstanceTypeProvider implements ExtensionPoint {
     public static final class DEFAULT_STRATEGY extends BundleNameInstanceTypeProvider {
 
         @Override
+        @Nonnull
         public String getInstanceType() {
             return System.getProperty(BundleNameInstanceTypeProvider.SUPPORT_BUNDLE_NAMING_INSTANCE_SPEC_PROPERTY, "");
         }

--- a/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
@@ -254,7 +254,7 @@ public class SupportAction implements RootAction, StaplerProxy {
     private void prepareBundle(StaplerResponse rsp, List<Component> components) throws IOException {
         logger.fine("Preparing response...");
         rsp.setContentType("application/zip");
-        rsp.addHeader("Content-Disposition", "inline; filename=" + SupportPlugin.getBundleFileName() + ";");
+        rsp.addHeader("Content-Disposition", "inline; filename=" + BundleFileName.generate() + ";");
         final ServletOutputStream servletOutputStream = rsp.getOutputStream();
         try {
             SupportPlugin.setRequesterAuthentication(Jenkins.getAuthentication());

--- a/src/main/java/com/cloudbees/jenkins/support/SupportCommand.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportCommand.java
@@ -82,7 +82,7 @@ public class SupportCommand extends CLICommand {
             try (ACLContext old = ACL.as(ACL.SYSTEM)) {
                 OutputStream os;
                 if (channel != null) { // Remoting mode
-                    os = channel.call(new SaveBundle(SupportPlugin.getBundleFileName()));
+                    os = channel.call(new SaveBundle(BundleFileName.generate()));
                 } else { // redirect output to a ZIP file yourself
                     os = new CloseProofOutputStream(stdout);
                 }

--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -711,40 +711,12 @@ public class SupportPlugin extends Plugin {
      * Returns the full bundle name.
      *
      * @return the full bundle name.
+     * @deprecated use {@link BundleFileName#generate()} instead
      */
+    @Deprecated
     @NonNull
     public static String getBundleFileName() {
-        StringBuilder filename = new StringBuilder();
-        filename.append(getBundlePrefix());
-
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd_HH.mm.ss");
-        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-        filename.append("_").append(dateFormat.format(new Date()));
-
-        filename.append(".zip");
-        return filename.toString();
-    }
-
-    /**
-     * Returns the prefix of the bundle name.
-     *
-     * @return the prefix of the bundle name.
-     */
-    private static String getBundlePrefix() {
-        String filename = "support"; // default bundle filename
-        final SupportPlugin instance = getInstance();
-        if (instance != null) {
-            SupportProvider supportProvider = instance.getSupportProvider();
-            if (supportProvider != null) {
-                // let the provider name it
-                filename = supportProvider.getName();
-            }
-        }
-        final String instanceType = BundleNameInstanceTypeProvider.getInstance().getInstanceType();
-        if (StringUtils.isNotBlank(instanceType)) {
-            filename = filename + "_" + instanceType;
-        }
-        return filename;
+        return BundleFileName.generate();
     }
 
     public static class LogHolder {
@@ -879,7 +851,7 @@ public class SupportPlugin extends Plugin {
                                 }
                             }
 
-                            File file = new File(bundleDir, SupportPlugin.getBundleFileName());
+                            File file = new File(bundleDir, BundleFileName.generate());
                             thread.setName(String.format("%s periodic bundle generator: writing %s since %s",
                                     SupportPlugin.class.getSimpleName(), file.getName(), new Date()));
                             try (FileOutputStream fos = new FileOutputStream(file)) {

--- a/src/main/java/com/cloudbees/jenkins/support/actions/SupportAbstractItemAction.java
+++ b/src/main/java/com/cloudbees/jenkins/support/actions/SupportAbstractItemAction.java
@@ -22,7 +22,7 @@ public class SupportAbstractItemAction extends SupportObjectAction<AbstractItem>
 
     @Override
     public String getDisplayName() {
-        return Messages.SupportItemAction_DisplayName();
+        return Messages.SupportItemAction_DisplayName(getObject().getPronoun());
     }
     
     @Extension

--- a/src/main/java/com/cloudbees/jenkins/support/actions/SupportAbstractItemAction.java
+++ b/src/main/java/com/cloudbees/jenkins/support/actions/SupportAbstractItemAction.java
@@ -24,7 +24,12 @@ public class SupportAbstractItemAction extends SupportObjectAction<AbstractItem>
     public String getDisplayName() {
         return Messages.SupportItemAction_DisplayName(getObject().getPronoun());
     }
-    
+
+    @Override
+    protected String getBundleNameQualifier() {
+        return "item";
+    }
+
     @Extension
     public static class Factory extends TransientActionFactory<AbstractItem> {
 

--- a/src/main/java/com/cloudbees/jenkins/support/actions/SupportComputerAction.java
+++ b/src/main/java/com/cloudbees/jenkins/support/actions/SupportComputerAction.java
@@ -26,6 +26,11 @@ public class SupportComputerAction extends SupportObjectAction<Computer> {
         return Messages.SupportComputerAction_DisplayName();
     }
 
+    @Override
+    protected String getBundleNameQualifier() {
+        return "agent";
+    }
+
     @Extension
     public static class Factory extends TransientActionFactory<Computer> {
 

--- a/src/main/java/com/cloudbees/jenkins/support/actions/SupportObjectAction.java
+++ b/src/main/java/com/cloudbees/jenkins/support/actions/SupportObjectAction.java
@@ -1,5 +1,6 @@
 package com.cloudbees.jenkins.support.actions;
 
+import com.cloudbees.jenkins.support.BundleFileName;
 import com.cloudbees.jenkins.support.SupportPlugin;
 import com.cloudbees.jenkins.support.api.Component;
 import com.cloudbees.jenkins.support.api.ComponentVisitor;
@@ -66,6 +67,8 @@ public abstract class SupportObjectAction<T extends AbstractModelObject> impleme
     public String getIconFileName() {
         return "/plugin/support-core/images/24x24/support.png";
     }
+
+    protected abstract String getBundleNameQualifier();
 
     @DataBoundSetter
     public void setComponents(List<? extends ObjectComponent<T>> components) {
@@ -134,7 +137,7 @@ public abstract class SupportObjectAction<T extends AbstractModelObject> impleme
         LOGGER.fine("Parsing request...");
         List<ObjectComponent<T>> components = new ArrayList<>(parseRequest(req));
 
-        rsp.addHeader("Content-Disposition", "inline; filename=" + SupportPlugin.getBundleFileName() + ";");
+        rsp.addHeader("Content-Disposition", "inline; filename=" + BundleFileName.generate(getBundleNameQualifier()) + ";");
         
         try {
             SupportPlugin.setRequesterAuthentication(Jenkins.getAuthentication());

--- a/src/main/java/com/cloudbees/jenkins/support/actions/SupportObjectAction.java
+++ b/src/main/java/com/cloudbees/jenkins/support/actions/SupportObjectAction.java
@@ -68,7 +68,9 @@ public abstract class SupportObjectAction<T extends AbstractModelObject> impleme
         return "/plugin/support-core/images/24x24/support.png";
     }
 
-    protected abstract String getBundleNameQualifier();
+    protected String getBundleNameQualifier() {
+        return "object";
+    }
 
     @DataBoundSetter
     public void setComponents(List<? extends ObjectComponent<T>> components) {

--- a/src/main/java/com/cloudbees/jenkins/support/actions/SupportRunAction.java
+++ b/src/main/java/com/cloudbees/jenkins/support/actions/SupportRunAction.java
@@ -22,7 +22,7 @@ public class SupportRunAction extends SupportObjectAction<Run> {
 
     @Override
     public String getDisplayName() {
-        return Messages.SupportRunAction_DisplayName();
+        return Messages.SupportRunAction_DisplayName(getObject().getParent().getTaskNoun());
     }
 
     @Extension

--- a/src/main/java/com/cloudbees/jenkins/support/actions/SupportRunAction.java
+++ b/src/main/java/com/cloudbees/jenkins/support/actions/SupportRunAction.java
@@ -25,6 +25,11 @@ public class SupportRunAction extends SupportObjectAction<Run> {
         return Messages.SupportRunAction_DisplayName(getObject().getParent().getTaskNoun());
     }
 
+    @Override
+    protected String getBundleNameQualifier() {
+        return "build";
+    }
+
     @Extension
     public static class Factory extends TransientActionFactory<Run> {
 

--- a/src/main/resources/com/cloudbees/jenkins/support/actions/Messages.properties
+++ b/src/main/resources/com/cloudbees/jenkins/support/actions/Messages.properties
@@ -22,15 +22,15 @@
 # THE SOFTWARE.
 #
 
-SupportRunAction_DisplayName=Support
+SupportRunAction_DisplayName={0} Support
 SupportRunAction_DefaultActionTitle=Support
 SupportRunAction_CreateBundle=Generate bundle
 
-SupportItemAction_DisplayName=Support
+SupportItemAction_DisplayName={0} Support
 SupportItemAction_DefaultActionTitle=Support
 SupportItemAction_CreateBundle=Generate bundle
 
-SupportComputerAction_DisplayName=Support
+SupportComputerAction_DisplayName=Agent Support
 SupportComputerAction_DefaultActionTitle=Support
 SupportComputerAction_CreateBundle=Generate bundle
 

--- a/src/test/java/com/cloudbees/jenkins/support/BundleFileNameTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/BundleFileNameTest.java
@@ -1,0 +1,82 @@
+package com.cloudbees.jenkins.support;
+
+import com.cloudbees.jenkins.support.api.SupportProvider;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.jvnet.localizer.Localizable;
+
+import javax.annotation.Nonnull;
+import java.io.PrintWriter;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class BundleFileNameTest {
+
+    private static final Clock TEST_CLOCK = Clock.fixed(Instant.parse("2020-10-01T10:20:30Z"), ZoneOffset.UTC);
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testGenerate_Default() {
+        assertThat(BundleFileName.generate(TEST_CLOCK, null), equalTo("support_2020-10-01_10.20.30.zip"));
+    }
+
+    @Ignore("Relies on SupportPlugin object which is not instantiated by TestPluginManager")
+    @Test
+    public void testGenerate_WithSupportProvider() {
+        assertThat(BundleFileName.generate(TEST_CLOCK, null), equalTo("amazing-support_2020-10-01_10.20.30.zip"));
+    }
+
+    @TestExtension("testGenerate_WithSupportProvider")
+    public static class AmazingSupportProvider extends SupportProvider {
+        @Override
+        public String getName() {
+            return "amazing-support";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Amazing Support";
+        }
+
+        @Override
+        public Localizable getActionTitle() {
+            return null;
+        }
+
+        @Override
+        public Localizable getActionBlurb() {
+            return null;
+        }
+
+        @Override
+        public void printAboutJenkins(PrintWriter out) { }
+    }
+
+    @Test
+    public void testGenerate_WithQualifier() {
+        assertThat(BundleFileName.generate(TEST_CLOCK, "qualifier"), equalTo("support_qualifier_2020-10-01_10.20.30.zip"));
+    }
+
+    @Test
+    public void testGenerate_WithQualifierAndInstanceType() {
+        assertThat(BundleFileName.generate(TEST_CLOCK, "qualifier"), equalTo("support_qualifier_instance_type_2020-10-01_10.20.30.zip"));
+    }
+
+    @TestExtension("testGenerate_WithQualifierAndInstanceType")
+    public static class TestBundleNameInstanceTypeProvider extends BundleNameInstanceTypeProvider {
+        @Override
+        @Nonnull
+        public String getInstanceType() {
+            return "instance_type";
+        }
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/support/BundleNamePrefixTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/BundleNamePrefixTest.java
@@ -10,7 +10,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import static org.hamcrest.core.StringStartsWith.startsWith;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class BundleNamePrefixTest {
 
@@ -20,24 +20,24 @@ public class BundleNamePrefixTest {
     public JenkinsRule j = new JenkinsRule();
 
     @Test
-    public void checkOriginalBehaviour() throws Exception {
-        assertThat(SupportPlugin.getBundleFileName(), startsWith("support_" + CURRENT_YEAR));
+    public void checkOriginalBehaviour() {
+        assertThat(BundleFileName.generate(), startsWith("support_" + CURRENT_YEAR));
     }
 
     @Test
-    public void checkWithOneProvider() throws Exception {
-        assertThat(SupportPlugin.getBundleFileName(), startsWith("support_pouet_" + CURRENT_YEAR));
+    public void checkWithOneProvider() {
+        assertThat(BundleFileName.generate(), startsWith("support_pouet_" + CURRENT_YEAR));
     }
 
     @Test
-    public void tooManyProviders() throws Exception {
-        assertThat(SupportPlugin.getBundleFileName(), startsWith("support_Zis_" + CURRENT_YEAR));
+    public void tooManyProviders() {
+        assertThat(BundleFileName.generate(), startsWith("support_Zis_" + CURRENT_YEAR));
     }
 
     @Test
-    public void withSysProp() throws Exception {
+    public void withSysProp() {
         System.setProperty(BundleNameInstanceTypeProvider.SUPPORT_BUNDLE_NAMING_INSTANCE_SPEC_PROPERTY, "paf");
-        assertThat(SupportPlugin.getBundleFileName(), startsWith("support_paf_" + CURRENT_YEAR));
+        assertThat(BundleFileName.generate(), startsWith("support_paf_" + CURRENT_YEAR));
         System.getProperties().remove(BundleNameInstanceTypeProvider.SUPPORT_BUNDLE_NAMING_INSTANCE_SPEC_PROPERTY);
     }
 


### PR DESCRIPTION
To avoid confusion include the name of the Object for which support bundle is generated into the action naem.