### PR TITLE
[JENKINS-35342] Allow to download a bundle

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
@@ -235,7 +235,7 @@ public class SupportAction implements RootAction, StaplerProxy {
         File rootDirectory = SupportPlugin.getRootDirectory();
         File zipFile = File.createTempFile(
             String.format("multiBundle(%s)-", bundles.size()), ".zip");
-
+        zipFile.deleteOnExit();
         try(FileOutputStream fos = new FileOutputStream(zipFile);
             ZipOutputStream zos = new ZipOutputStream(fos)) {
             byte[] buffer = new byte[1024]; 
@@ -252,7 +252,6 @@ public class SupportAction implements RootAction, StaplerProxy {
         } catch (IOException e) {
             logger.log(Level.SEVERE, "Error creating zip file: " + zipFile.getAbsolutePath(), e);
         }
-        zipFile.deleteOnExit();
         return zipFile;
     }
 

--- a/src/main/resources/com/cloudbees/jenkins/support/Messages.properties
+++ b/src/main/resources/com/cloudbees/jenkins/support/Messages.properties
@@ -38,6 +38,7 @@ SupportCommand.if_no_arguments_are_given_generate_a_bun=Sends the compressed sup
 SupportPlugin_PermissionGroup=Support
 SupportPlugin_CreateBundle=Generate bundle
 SupportPlugin_DeleteBundle=Delete bundle
+SupportPlugin_DownloadBundle=Download bundle
 SupportPlugin_ListBundle=Existing support bundles
 SupportPlugin_loadConfig=Read support plugin configuration
 

--- a/src/main/resources/com/cloudbees/jenkins/support/SupportAction/index.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/support/SupportAction/index.jelly
@@ -77,7 +77,7 @@
       </f:form>
       <f:section title="${%Existing support bundles}">
 
-      <f:form name="bundle-contents" method="POST" action="deleteBundles">
+      <f:form name="bundle-contents" method="POST">
         <j:forEach var="bundle" items="${it.bundles}">
           <f:entry field="bundle">
           <div name="bundles">
@@ -88,9 +88,14 @@
           </f:entry>
         </j:forEach>
         <f:entry>
+          <span class="yui-button yui-submit-button submit-button primary">
+            <span class="first-child">
+              <button type="submit" formaction="downloadBundles">${%Download Bundle}</button>
+            </span>
+          </span>
           <span class="yui-button yui-submit-button submit-button danger">
             <span class="first-child">
-              <button type="submit">${%Delete Bundle}</button>
+              <button type="submit" formaction="deleteBundles">${%Delete Bundle}</button>
             </span>
           </span>
         </f:entry>

--- a/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
@@ -102,7 +102,7 @@ public class SupportActionTest {
         String bundle = "../config.xml";
         logger.record(SupportAction.class, Level.FINE).capture(1);
         deleteBundle(bundle, "admin");
-        assertTrue(logger.getMessages().stream().anyMatch(m -> m.startsWith(String.format("The bundle to delete %s does not exist", bundle))));
+        assertTrue(logger.getMessages().stream().anyMatch(m -> m.startsWith(String.format("The bundle selected %s does not exist", bundle))));
     }
 
     /*


### PR DESCRIPTION
Initial approach which add a new `Download` button in the `Existing support bundles` section which allows:

- Download one single file
- Download multiple files grouping all of the them in a single zip file (multiBundle(n).zip) where n is the number of files zipped)

This is how it looks the UI

<img width="280" alt="JENKINS-35342" src="https://user-images.githubusercontent.com/4355331/96261492-d06eec80-0fc0-11eb-8088-c59879d17ee4.png">