### PR TITLE
[JENKINS-42012] Wrapper to make Channel.callAsync really async

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/AsyncResultCache.java
+++ b/src/main/java/com/cloudbees/jenkins/support/AsyncResultCache.java
@@ -1,5 +1,6 @@
 package com.cloudbees.jenkins.support;
 
+import com.cloudbees.jenkins.support.util.CallAsyncWrapper;
 import hudson.model.Computer;
 import hudson.model.Node;
 import hudson.remoting.Callable;
@@ -43,7 +44,7 @@ public class AsyncResultCache<T> implements Runnable {
                 return cache.get(node);
             }
         }
-        Future<V> future = channel.callAsync(operation);
+        Future<V> future = CallAsyncWrapper.callAsync(channel, operation);
         try {
             final V result = future.get(SupportPlugin.REMOTE_OPERATION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
             synchronized (cache) {

--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -37,6 +37,7 @@ import com.cloudbees.jenkins.support.filter.ContentMappings;
 import com.cloudbees.jenkins.support.filter.FilteredOutputStream;
 import com.cloudbees.jenkins.support.filter.PrefilteredContent;
 import com.cloudbees.jenkins.support.impl.ThreadDumps;
+import com.cloudbees.jenkins.support.util.CallAsyncWrapper;
 import com.cloudbees.jenkins.support.util.IgnoreCloseOutputStream;
 import com.cloudbees.jenkins.support.util.OutputStreamSelector;
 import com.codahale.metrics.Histogram;
@@ -649,7 +650,7 @@ public class SupportPlugin extends Plugin {
         if (node != null) {
             VirtualChannel channel = node.getChannel();
             if (channel != null) {
-                final Future<List<LogRecord>> future = channel.callAsync(new LogFetcher());
+                final Future<List<LogRecord>> future = CallAsyncWrapper.callAsync(channel, new LogFetcher());
                 try {
                     return future.get(REMOTE_OPERATION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
                 } catch (ExecutionException e) {
@@ -823,7 +824,7 @@ public class SupportPlugin extends Plugin {
                 if (channel != null) {
                     final FilePath rootPath = node.getRootPath();
                     if (rootPath != null) {
-                        channel.callAsync(new LogInitializer(rootPath, getLogLevel()));
+                        CallAsyncWrapper.callAsync(channel, new LogInitializer(rootPath, getLogLevel()));
                     }
                 }
             } catch (IOException e) {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/ThreadDumps.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/ThreadDumps.java
@@ -7,6 +7,7 @@ import com.cloudbees.jenkins.support.api.ObjectComponent;
 import com.cloudbees.jenkins.support.api.ObjectComponentDescriptor;
 import com.cloudbees.jenkins.support.api.StringContent;
 import com.cloudbees.jenkins.support.filter.ContentFilter;
+import com.cloudbees.jenkins.support.util.CallAsyncWrapper;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
@@ -191,7 +192,7 @@ public class ThreadDumps extends ObjectComponent<Computer> {
         if (channel == null) {
             return null;
         }
-        return channel.callAsync(new GetThreadDump());
+        return CallAsyncWrapper.callAsync(channel, new GetThreadDump());
     }
 
     @Deprecated

--- a/src/main/java/com/cloudbees/jenkins/support/util/CallAsyncWrapper.java
+++ b/src/main/java/com/cloudbees/jenkins/support/util/CallAsyncWrapper.java
@@ -14,10 +14,9 @@ import java.util.concurrent.TimeoutException;
 public final class CallAsyncWrapper {
 
     public static <V,T extends Throwable> hudson.remoting.Future<V> callAsync(final VirtualChannel channel, final Callable<V,T> callable) throws IOException {
-
         Future<hudson.remoting.Future<V>> future = Computer.threadPoolForRemoting.submit(new java.util.concurrent.Callable<hudson.remoting.Future<V>>() {
             @Override
-            public hudson.remoting.Future<V> call() throws Exception {
+            public hudson.remoting.Future<V> call() throws IOException {
                 return channel.callAsync(callable);
             }
         });

--- a/src/main/java/com/cloudbees/jenkins/support/util/CallAsyncWrapper.java
+++ b/src/main/java/com/cloudbees/jenkins/support/util/CallAsyncWrapper.java
@@ -1,0 +1,31 @@
+package com.cloudbees.jenkins.support.util;
+
+import com.cloudbees.jenkins.support.SupportPlugin;
+import hudson.model.Computer;
+import hudson.remoting.Callable;
+import hudson.remoting.VirtualChannel;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public final class CallAsyncWrapper {
+
+    public static <V,T extends Throwable> hudson.remoting.Future<V> callAsync(final VirtualChannel channel, final Callable<V,T> callable) throws IOException {
+
+        Future<hudson.remoting.Future<V>> future = Computer.threadPoolForRemoting.submit(new java.util.concurrent.Callable<hudson.remoting.Future<V>>() {
+            @Override
+            public hudson.remoting.Future<V> call() throws Exception {
+                return channel.callAsync(callable);
+            }
+        });
+        try {
+            return future.get(SupportPlugin.REMOTE_OPERATION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            throw new IOException(e);
+        }
+
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/support/util/CallAsyncWrapper.java
+++ b/src/main/java/com/cloudbees/jenkins/support/util/CallAsyncWrapper.java
@@ -22,9 +22,11 @@ public final class CallAsyncWrapper {
         });
         try {
             return future.get(SupportPlugin.REMOTE_OPERATION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+        } catch (InterruptedException | ExecutionException e) {
             throw new IOException(e);
+        } catch (TimeoutException te) {
+            future.cancel(true);
+            throw new IOException(te);
         }
-
     }
 }


### PR DESCRIPTION
Create a wrapper to make `Channel.callAsync` really async. The problem is that `callAsync` is performing a remoting call before returning the Future, so the call is not really async - see https://github.com/jenkinsci/remoting/blob/remoting-4.6/src/main/java/hudson/remoting/Request.java#L238 

This PR should fix both Jira issues below:

* https://issues.jenkins-ci.org/browse/JENKINS-42011 
* https://issues.jenkins.io/browse/JENKINS-42012