### PR TITLE
[FIXED JENKINS-64601] Improve write performance for big files under $JENKINS_HOME/logs/tasks/ by using BufferedOutputStream instead of OutputStream

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -81,7 +81,6 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;

--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -81,6 +81,7 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
@@ -329,7 +330,7 @@ public class SupportPlugin extends Plugin {
                 OutputStream textOut = maybeFilteredOut.map(OutputStream.class::cast).orElse(binaryOut);
                 OutputStreamSelector selector = new OutputStreamSelector(() -> binaryOut, () -> textOut);
                 IgnoreCloseOutputStream unfilteredOut = new IgnoreCloseOutputStream(binaryOut);
-                IgnoreCloseOutputStream filteredOut = new IgnoreCloseOutputStream(selector);
+                IgnoreCloseOutputStream filteredOut = new IgnoreCloseOutputStream(new FilterOutputStream(selector));
                 boolean entryCreated = false;
                 for (Content content : contents) {
                     if (content == null) {

--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -330,7 +330,7 @@ public class SupportPlugin extends Plugin {
                 OutputStream textOut = maybeFilteredOut.map(OutputStream.class::cast).orElse(binaryOut);
                 OutputStreamSelector selector = new OutputStreamSelector(() -> binaryOut, () -> textOut);
                 IgnoreCloseOutputStream unfilteredOut = new IgnoreCloseOutputStream(binaryOut);
-                IgnoreCloseOutputStream filteredOut = new IgnoreCloseOutputStream(new FilterOutputStream(selector));
+                IgnoreCloseOutputStream filteredOut = new IgnoreCloseOutputStream(selector);
                 boolean entryCreated = false;
                 for (Content content : contents) {
                     if (content == null) {

--- a/src/main/java/com/cloudbees/jenkins/support/util/IgnoreCloseOutputStream.java
+++ b/src/main/java/com/cloudbees/jenkins/support/util/IgnoreCloseOutputStream.java
@@ -28,6 +28,7 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.annotation.Nonnull;
+import java.io.BufferedOutputStream;
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -38,9 +39,19 @@ import java.io.OutputStream;
  * @since TODO
  */
 @Restricted(NoExternalUse.class)
-public final class IgnoreCloseOutputStream extends FilterOutputStream implements WrapperOutputStream {
-    public IgnoreCloseOutputStream(@Nonnull OutputStream out) {
+public final class IgnoreCloseOutputStream extends BufferedOutputStream implements WrapperOutputStream {
+    /**
+     * The underlying output stream to be filtered.
+     */
+    public IgnoreCloseOutputStream(OutputStream out) {
         super(out);
+    }
+
+    /**
+     * The underlying output stream to be filtered.
+     */
+    public IgnoreCloseOutputStream(OutputStream out, int size) {
+        super(out, size);
     }
 
     @Override

--- a/src/main/java/com/cloudbees/jenkins/support/util/IgnoreCloseOutputStream.java
+++ b/src/main/java/com/cloudbees/jenkins/support/util/IgnoreCloseOutputStream.java
@@ -29,12 +29,11 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.annotation.Nonnull;
 import java.io.BufferedOutputStream;
-import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
 /**
- * Provides a {@link FilterOutputStream} that ignores calls to close its underlying stream and instead simply flushes it.
+ * Provides a {@link BufferedOutputStream} that ignores calls to close its underlying stream and instead simply flushes it.
  *
  * @since TODO
  */

--- a/src/main/java/com/cloudbees/jenkins/support/util/IgnoreCloseOutputStream.java
+++ b/src/main/java/com/cloudbees/jenkins/support/util/IgnoreCloseOutputStream.java
@@ -44,18 +44,8 @@ public final class IgnoreCloseOutputStream extends BufferedOutputStream implemen
      *
      * @param out the underlying output stream.
      */
-    public IgnoreCloseOutputStream(OutputStream out) {
+    public IgnoreCloseOutputStream(@Nonnull OutputStream out) {
         super(out);
-    }
-
-    /**
-     * The underlying output stream to be filtered.
-     *
-     * @param   out    the underlying output stream.
-     * @param   size   the buffer size.
-     */
-    public IgnoreCloseOutputStream(OutputStream out, int size) {
-        super(out, size);
     }
 
     @Override

--- a/src/main/java/com/cloudbees/jenkins/support/util/IgnoreCloseOutputStream.java
+++ b/src/main/java/com/cloudbees/jenkins/support/util/IgnoreCloseOutputStream.java
@@ -41,6 +41,8 @@ import java.io.OutputStream;
 public final class IgnoreCloseOutputStream extends BufferedOutputStream implements WrapperOutputStream {
     /**
      * The underlying output stream to be filtered.
+     *
+     * @param out the underlying output stream.
      */
     public IgnoreCloseOutputStream(OutputStream out) {
         super(out);
@@ -48,6 +50,9 @@ public final class IgnoreCloseOutputStream extends BufferedOutputStream implemen
 
     /**
      * The underlying output stream to be filtered.
+     *
+     * @param   out    the underlying output stream.
+     * @param   size   the buffer size.
      */
     public IgnoreCloseOutputStream(OutputStream out, int size) {
         super(out, size);


### PR DESCRIPTION
See the Jira for all the details https://issues.jenkins.io/browse/JENKINS-64401

Basically, there is a performance issue which happens for all support bundles generated when {{$JENKINS_HOME/logs/tasks/}} have big text files (you can reproduce the issue with around 6 files bigger than 50 MB each of them).

The current proposal is to use {{BufferedOutputStream}} instead of {{FilterOutputStream}} as stream so we can write bytes to the underlying output stream without necessarily causing a call to the underlying system for each byte written. 

In my example, without the fix, a support bundle with the issue exposed is taking around 15 minutes to be generated. With the current implementation, the support bundle is generated in less than 20 seconds.