### PR TITLE
Update year format for BundleNamePrefixTest

### DIFF
--- a/src/test/java/com/cloudbees/jenkins/support/BundleNamePrefixTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/BundleNamePrefixTest.java
@@ -14,7 +14,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class BundleNamePrefixTest {
 
-    private static final String CURRENT_YEAR = new SimpleDateFormat("YYYY").format(new Date());
+    private static final String CURRENT_YEAR = new SimpleDateFormat("yyyy").format(new Date());
 
     @Rule
     public JenkinsRule j = new JenkinsRule();


### PR DESCRIPTION
The format is wrong. It should be "yyyy" instead of "YYYY". "YYYY" stands for the week year, not the year, which makes the latest week of the year this test is failing (see https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html)

Thanks Thierry Wasylczenko for getting the root cause of the issue.