### PR TITLE
Use current year instead of fiscal year

### DIFF
--- a/src/test/java/com/cloudbees/jenkins/support/BundleNamePrefixTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/BundleNamePrefixTest.java
@@ -14,7 +14,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class BundleNamePrefixTest {
 
-    private static final String CURRENT_YEAR = new SimpleDateFormat("YYYY").format(new Date());
+    private static final String CURRENT_YEAR = new SimpleDateFormat("yyyy").format(new Date());
 
     @Rule
     public JenkinsRule j = new JenkinsRule();


### PR DESCRIPTION
- Before this PR, I'm getting issues on these tests:
```
com.cloudbees.jenkins.support.BundleNamePrefixTest.tooManyProviders
com.cloudbees.jenkins.support.BundleNamePrefixTest.checkWithOneProvider
com.cloudbees.jenkins.support.BundleNamePrefixTest.withSysProp
com.cloudbees.jenkins.support.BundleNamePrefixTest.checkOriginalBehaviour
```
- Assertion is wrong because is based on evaluating a fiscal year 
```
19:57:01  java.lang.AssertionError: 
19:57:01  
19:57:01  Expected: a string starting with "support_Zis_2021"
19:57:01       but: was "support_Zis_2020-12-28_18.56.58.zip"
```
- Upper Y stands for the week year, not the year, so from 12/28, it provides 2021, but expected is 2020.
