### PR TITLE
[JENKINS-64547] AdministrativeMonitors should stop if a monitor is disabled

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/AdministrativeMonitors.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AdministrativeMonitors.java
@@ -33,11 +33,9 @@ import hudson.diagnosis.ReverseProxySetupMonitor;
 import hudson.model.AdministrativeMonitor;
 import hudson.model.Saveable;
 import hudson.security.Permission;
-import hudson.util.VersionNumber;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Collections;
 import java.util.Comparator;
@@ -59,7 +57,7 @@ import java.util.Set;
 
     @Override public void addContents(Container result) {
         result.add(new PrintedContent("admin-monitors.md") {
-            @Override protected void printTo(PrintWriter out) throws IOException {
+            @Override protected void printTo(PrintWriter out) {
                 out.println("Monitors");
                 out.println("========");
                 AdministrativeMonitor.all().stream()
@@ -72,7 +70,7 @@ import java.util.Set;
                         out.println();
                         out.println("`" + monitor.id + "`");
                         out.println("--------------");
-                        if (monitor instanceof OldDataMonitor && !suffersFromJENKINS24358()) {
+                        if (monitor instanceof OldDataMonitor) {
                             OldDataMonitor odm = (OldDataMonitor) monitor;
                             for (Map.Entry<Saveable, OldDataMonitor.VersionRange> entry : odm.getData().entrySet()) {
                                 out.println("  * Problematic object: `" + entry.getKey() + "`");
@@ -99,22 +97,5 @@ import java.util.Set;
                 return false;
             }
         });
-    }
-
-    private static boolean suffersFromJENKINS24358() {
-        VersionNumber version = Jenkins.getVersion();
-        if (version == null) {
-            return false;
-        } else if (version.compareTo(/*JENKINS-19544*/new VersionNumber("1.557")) >=0 && version.compareTo(new VersionNumber(/*JENKINS-24358*/"1.578")) < 0) {
-            if (version.toString().startsWith("1.565.") && version.compareTo(new VersionNumber(/* predicting JENKINS-24358 to be backported here */"1.565.3")) >=0) {
-                return false;
-            } else {
-                return true;
-            }
-        } else if (version.toString().startsWith(/* JENKINS-19544 backported to 1.554.1 */"1.554.")) {
-            return true;
-        } else { // before regression or after fix
-            return false;
-        }
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/support/impl/AdministrativeMonitorsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/AdministrativeMonitorsTest.java
@@ -1,0 +1,5 @@
+package com.cloudbees.jenkins.support.impl;/**
+ * @author Allan Burdajewicz
+ */
+public class AdministrativeMonitorsTest {
+}

--- a/src/test/java/com/cloudbees/jenkins/support/impl/AdministrativeMonitorsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/AdministrativeMonitorsTest.java
@@ -1,5 +1,54 @@
-package com.cloudbees.jenkins.support.impl;/**
- * @author Allan Burdajewicz
- */
+package com.cloudbees.jenkins.support.impl;
+
+import com.cloudbees.jenkins.support.SupportTestUtils;
+import com.cloudbees.jenkins.support.api.Component;
+import hudson.ExtensionList;
+import hudson.diagnosis.OldDataMonitor;
+import hudson.diagnosis.ReverseProxySetupMonitor;
+import hudson.model.AdministrativeMonitor;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 public class AdministrativeMonitorsTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testAdministrativeMonitorsContent() throws IOException {
+        String monitorsMdToString = SupportTestUtils.invokeComponentToString(Objects.requireNonNull(ExtensionList.lookup(Component.class).get(AdministrativeMonitors.class)));
+        // Enable all monitors and check that there is an output for all activated monitors
+        j.jenkins.administrativeMonitors.stream()
+            .filter(monitor -> !(monitor instanceof ReverseProxySetupMonitor || monitor instanceof OldDataMonitor))
+            .filter(monitor -> monitor.isEnabled() && monitor.isActivated())
+            .forEach(monitor -> 
+                assertThat(monitorsMdToString, containsString(
+                    "`" + monitor.id + "`\n" +
+                        "--------------\n" +
+                        "(active and enabled)"))
+            );
+
+        // Disable all monitors and check there is not output for any even if activated
+        for (AdministrativeMonitor monitor : j.jenkins.administrativeMonitors) {
+            monitor.disable(true);
+        }
+        String monitorsDisabledMdToString = SupportTestUtils.invokeComponentToString(Objects.requireNonNull(ExtensionList.lookup(Component.class).get(AdministrativeMonitors.class)));
+        j.jenkins.administrativeMonitors.stream()
+            .filter(monitor -> !(monitor instanceof ReverseProxySetupMonitor || monitor instanceof OldDataMonitor))
+            .filter(AdministrativeMonitor::isActivated)
+            .forEach(monitor ->
+                assertThat(monitorsDisabledMdToString, not(containsString(
+                    "`" + monitor.id + "`\n" +
+                        "--------------\n" +
+                        "(active and enabled)")))
+            );
+    }
 }

--- a/src/test/java/com/cloudbees/jenkins/support/impl/AdministrativeMonitorsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/AdministrativeMonitorsTest.java
@@ -31,8 +31,8 @@ public class AdministrativeMonitorsTest {
             .filter(monitor -> monitor.isEnabled() && monitor.isActivated())
             .forEach(monitor -> 
                 assertThat(monitorsMdToString, containsString(
-                    "`" + monitor.id + "`\n" +
-                        "--------------\n" +
+                    "`" + monitor.id + "`" + System.getProperty("line.separator") +
+                        "--------------" + System.getProperty("line.separator") +
                         "(active and enabled)"))
             );
 
@@ -46,8 +46,8 @@ public class AdministrativeMonitorsTest {
             .filter(AdministrativeMonitor::isActivated)
             .forEach(monitor ->
                 assertThat(monitorsDisabledMdToString, not(containsString(
-                    "`" + monitor.id + "`\n" +
-                        "--------------\n" +
+                    "`" + monitor.id + "`" + System.getProperty("line.separator") +
+                        "--------------" + System.getProperty("line.separator") +
                         "(active and enabled)")))
             );
     }


### PR DESCRIPTION
[JENKINS-64547](https://issues.jenkins.io/browse/JENKINS-64547):

* Check if the monitor is enabled first, if not then stop there
* Refactor the `AdministrativeMonitors` with java 8 /lambda expressions
* Add a test for the component