### PR TITLE
[JENKINS-64549] Use PowerMockito and versions from plugin-pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,16 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.2.15</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/com/cloudbees/jenkins/support/impl/GCLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/GCLogsTest.java
@@ -6,16 +6,16 @@ import com.cloudbees.jenkins.support.api.Content;
 import com.google.common.io.Files;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import org.assertj.core.api.Assertions;
-import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.Issue;
-import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -24,87 +24,57 @@ import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({GCLogs.class, GCLogs.VmArgumentFinder.class})
+@PrepareForTest(GCLogs.class)
 public class GCLogsTest {
 
     @Test
     public void simpleFile() throws Exception {
-        Assume.assumeTrue(SupportTestUtils.isJava8OrBelow());
         File tmpFile = File.createTempFile("gclogs", "");
         Files.touch(tmpFile);
 
         GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
-        PowerMockito.when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH + tmpFile.getAbsolutePath());
+        
+        if (SupportTestUtils.isJava8OrBelow()) {
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH + tmpFile.getAbsolutePath());
+            assertContentWithFinderContainsFiles(finder, 1);
+        } else {
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=" + tmpFile.getAbsolutePath());
+            assertContentWithFinderContainsFiles(finder, 1);
 
-        TestContainer container = new TestContainer();
-
-        new GCLogs(finder).addContents(container);
-
-        assertEquals(1, container.getContents().size());
+            // The file locations may be wrapped with quotes
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\"" + tmpFile.getAbsolutePath()+ "\"");
+            assertContentWithFinderContainsFiles(finder, 1);
+        }
     }
 
     @Test
     public void rotatedFiles() throws Exception {
-        Assume.assumeTrue(SupportTestUtils.isJava8OrBelow());
         File tempDir = Files.createTempDir();
         for (int count = 0; count < 5; count++) {
             Files.touch(new File(tempDir, "gc.log." + count));
         }
-
         GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
-        when(finder.findVmArgument(GCLogs.GCLOGS_ROTATION_SWITCH)).thenReturn(GCLogs.GCLOGS_ROTATION_SWITCH);
-        when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH
+        
+        if(SupportTestUtils.isJava8OrBelow()) {
+            when(finder.findVmArgument(GCLogs.GCLOGS_ROTATION_SWITCH)).thenReturn(GCLogs.GCLOGS_ROTATION_SWITCH);
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH
                 + tempDir.getAbsolutePath() + File.separator + "gc.log");
+            assertContentWithFinderContainsFiles(finder, 5);
+        } else {
 
-        TestContainer container = new TestContainer();
-
-        new GCLogs(finder).addContents(container);
-
-        assertEquals(5, container.getContents().size());
-    }
-
-    @Test
-    public void rotatedJava9Files() throws Exception {
-        Assume.assumeTrue(!SupportTestUtils.isJava8OrBelow());
-        File tempDir = Files.createTempDir();
-        for (int count = 0; count < 5; count++) {
-            Files.touch(new File(tempDir, "gc.log." + count));
-        }
-
-        GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
-        when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file="
-            + tempDir.getAbsolutePath() + File.separator + "gc.log.%p" + ":filecount=10,filesize=50m");
-
-        TestContainer container = new TestContainer();
-
-        new GCLogs(finder).addContents(container);
-
-        assertEquals(5, container.getContents().size());
-    }
-
-    @Test
-    public void rotatedJava9FilesWithQuotes() throws Exception {
-        Assume.assumeTrue(!SupportTestUtils.isJava8OrBelow());
-        File tempDir = Files.createTempDir();
-        for (int count = 0; count < 5; count++) {
-            Files.touch(new File(tempDir, "gc.log." + count));
-        }
-
-        GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
-        // The file locations may be wrapped with quotes
-        when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\""
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file="
+                + tempDir.getAbsolutePath() + File.separator + "gc.log.%p" + ":filecount=10,filesize=50m");
+            assertContentWithFinderContainsFiles(finder, 5);
+            
+            // The file locations may be wrapped with quotes
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\""
                 + tempDir.getAbsolutePath() + File.separator + "gc.log.%p\":filecount=10,filesize=50m");
-
-        TestContainer container = new TestContainer();
-
-        new GCLogs(finder).addContents(container);
-
-        assertEquals(5, container.getContents().size());
+            assertContentWithFinderContainsFiles(finder, 5);
+        }
     }
 
     @Test
     public void parameterizedFiles() throws Exception {
-        Assume.assumeTrue(SupportTestUtils.isJava8OrBelow());
         File tempDir = Files.createTempDir();
         for (int count = 0; count < 5; count++) {
             Files.touch(new File(tempDir, "gc." + System.currentTimeMillis() + ".1423.log." + count));
@@ -112,66 +82,25 @@ public class GCLogsTest {
         for (int count = 0; count < 3; count++) {
             Files.touch(new File(tempDir, "gc." + System.currentTimeMillis() + ".2534.log." + count));
         }
-
         GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
-        when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH
+        
+        if(SupportTestUtils.isJava8OrBelow()) {
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH
                 + new File(tempDir, "gc.%t.%p.log").getAbsolutePath());
-
-        TestContainer container = new TestContainer();
-
-        new GCLogs(finder).addContents(container);
-
-        assertEquals(8, container.getContents().size());
-    }
-
-    @Test
-    public void parameterizedJava9Files() throws Exception {
-        Assume.assumeTrue(!SupportTestUtils.isJava8OrBelow());
-        File tempDir = Files.createTempDir();
-        for (int count = 0; count < 5; count++) {
-            Files.touch(new File(tempDir, "gc." + System.currentTimeMillis() + ".1423.log." + count));
-        }
-        for (int count = 0; count < 3; count++) {
-            Files.touch(new File(tempDir, "gc." + System.currentTimeMillis() + ".2534.log." + count));
-        }
-
-        GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
-        when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file="
+            assertContentWithFinderContainsFiles(finder, 8);
+        } else {
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file="
                 + tempDir.getAbsolutePath() + File.separator + "gc.%t.%p.log");
+            assertContentWithFinderContainsFiles(finder, 8);
 
-        TestContainer container = new TestContainer();
-
-        new GCLogs(finder).addContents(container);
-
-        assertEquals(8, container.getContents().size());
-    }
-
-    @Test
-    public void parameterizedJava9FilesWithQuotes() throws Exception {
-        Assume.assumeTrue(!SupportTestUtils.isJava8OrBelow());
-        File tempDir = Files.createTempDir();
-        for (int count = 0; count < 5; count++) {
-            Files.touch(new File(tempDir, "gc." + System.currentTimeMillis() + ".1423.log." + count));
-        }
-        for (int count = 0; count < 3; count++) {
-            Files.touch(new File(tempDir, "gc." + System.currentTimeMillis() + ".2534.log." + count));
-        }
-
-        GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
-        // The file locations may be wrapped with quotes
-        when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\""
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\""
                 + tempDir.getAbsolutePath() + File.separator + "gc.%t.%p.log\"");
-
-        TestContainer container = new TestContainer();
-
-        new GCLogs(finder).addContents(container);
-
-        assertEquals(8, container.getContents().size());
+            assertContentWithFinderContainsFiles(finder, 8);
+        }
     }
 
     @Test
     public void parameterizedAndRotatedFiles() throws Exception {
-        Assume.assumeTrue(SupportTestUtils.isJava8OrBelow());
         File tempDir = Files.createTempDir();
         for (int count = 0; count < 10; count++) {
             Files.touch(new File(tempDir, "gc5625.log." + count));
@@ -179,23 +108,28 @@ public class GCLogsTest {
         for (int count = 0; count < 5; count++) {
             Files.touch(new File(tempDir, "gc3421.log." + count));
         }
-
         GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
-        when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH + new File(tempDir, "gc%p.log").getAbsolutePath());
-        when(finder.findVmArgument(GCLogs.GCLOGS_ROTATION_SWITCH)).thenReturn(GCLogs.GCLOGS_ROTATION_SWITCH);
+        
+        if(SupportTestUtils.isJava8OrBelow()) {
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH + new File(tempDir, "gc%p.log").getAbsolutePath());
+            when(finder.findVmArgument(GCLogs.GCLOGS_ROTATION_SWITCH)).thenReturn(GCLogs.GCLOGS_ROTATION_SWITCH);
+            assertContentWithFinderContainsFiles(finder, 15);
+        } else {
+            
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file="
+                + tempDir.getAbsolutePath() + File.separator + "gc%t.log.%p" + ":filecount=10,filesize=50m");
+            assertContentWithFinderContainsFiles(finder, 15);
 
-        TestContainer container = new TestContainer();
-
-        new GCLogs(finder).addContents(container);
-
-        assertEquals(15, container.getContents().size());
+            // The file locations may be wrapped with quotes
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\""
+                + tempDir.getAbsolutePath() + File.separator + "gc%t.log.%p\"" + ":filecount=10,filesize=50m");
+            assertContentWithFinderContainsFiles(finder, 15);
+        }
     }
 
     @Test
     @Issue("JENKINS-58980")
-    public void latestFiles() throws Exception {
-        Assume.assumeTrue(SupportTestUtils.isJava8OrBelow());
-        File tempDir = Files.createTempDir();
+    public void latestFiles() throws Exception {File tempDir = Files.createTempDir();
         long currentTime = System.currentTimeMillis();
         for (int count = 0; count < 10; count++) {
             File gcLogFile = new File(tempDir, "gc5625.log" + count);
@@ -205,20 +139,59 @@ public class GCLogsTest {
         for (int count = 0; count < 5; count++) {
             Files.touch(new File(tempDir, "gc3421.log" + count));
         }
-
         GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
-        when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH + new File(tempDir, "gc%p.log").getAbsolutePath());
-        when(finder.findVmArgument(GCLogs.GCLOGS_ROTATION_SWITCH)).thenReturn(GCLogs.GCLOGS_ROTATION_SWITCH);
+        
+        if(SupportTestUtils.isJava8OrBelow()) {
 
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH + new File(tempDir, "gc%p.log").getAbsolutePath());
+            when(finder.findVmArgument(GCLogs.GCLOGS_ROTATION_SWITCH)).thenReturn(GCLogs.GCLOGS_ROTATION_SWITCH);
+            assertContentWithFinderContainsFiles(finder,
+                Arrays.asList("gc3421.log0", "gc3421.log1", "gc3421.log2", "gc3421.log3", "gc3421.log4"));
+
+        } else {
+
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file="
+                + tempDir.getAbsolutePath() + File.separator + "gc%t.log%p" + ":filecount=10,filesize=50m");
+            assertContentWithFinderContainsFiles(finder,
+                Arrays.asList("gc3421.log0", "gc3421.log1", "gc3421.log2", "gc3421.log3", "gc3421.log4"));
+
+            // The file locations may be wrapped with quotes
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\""
+                + tempDir.getAbsolutePath() + File.separator + "gc%t.log%p\"" + ":filecount=10,filesize=50m");
+            assertContentWithFinderContainsFiles(finder, 
+                Arrays.asList("gc3421.log0", "gc3421.log1", "gc3421.log2", "gc3421.log3", "gc3421.log4"));
+        }
+    }
+
+    /**
+     * Assert that a specific number of files is included in the content, given the 
+     * {@link com.cloudbees.jenkins.support.impl.GCLogs.VmArgumentFinder} passed in.
+     * 
+     * @param finder a {@link com.cloudbees.jenkins.support.impl.GCLogs.VmArgumentFinder}
+     * @param numberOfFiles the expected number of files to be included
+     */
+    private void assertContentWithFinderContainsFiles(GCLogs.VmArgumentFinder finder, int numberOfFiles) {
         TestContainer container = new TestContainer();
-
         new GCLogs(finder).addContents(container);
+        assertEquals(numberOfFiles, container.getContents().size());
+    }
 
-        assertEquals(5, container.getContents().size());
+
+    /**
+     * Assert that a specific set of file is included in the content, given the 
+     * {@link com.cloudbees.jenkins.support.impl.GCLogs.VmArgumentFinder} passed in.
+     *
+     * @param finder a {@link com.cloudbees.jenkins.support.impl.GCLogs.VmArgumentFinder}
+     * @param fileNames the expected set of files names
+     */
+    private void assertContentWithFinderContainsFiles(GCLogs.VmArgumentFinder finder, Collection<String> fileNames) {
+        TestContainer container = new TestContainer();
+        new GCLogs(finder).addContents(container);
+        assertEquals(fileNames.size(), container.getContents().size());
         Assertions.assertThat(container.getContents())
-                .extracting("file", File.class)
-                .extractingResultOf("getName")
-                .contains("gc3421.log0", "gc3421.log1", "gc3421.log2", "gc3421.log3", "gc3421.log4");
+            .extracting("file", File.class)
+            .extractingResultOf("getName")
+            .containsAll(fileNames);
     }
 
     private static class TestContainer extends Container {

--- a/src/test/java/com/cloudbees/jenkins/support/impl/GCLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/GCLogsTest.java
@@ -8,7 +8,11 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import org.assertj.core.api.Assertions;
 import org.junit.Assume;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.Issue;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -16,9 +20,11 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({GCLogs.class, GCLogs.VmArgumentFinder.class})
 public class GCLogsTest {
 
     @Test
@@ -28,7 +34,7 @@ public class GCLogsTest {
         Files.touch(tmpFile);
 
         GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
-        when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH + tmpFile.getAbsolutePath());
+        PowerMockito.when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH + tmpFile.getAbsolutePath());
 
         TestContainer container = new TestContainer();
 


### PR DESCRIPTION
[JENKINS-64549](https://issues.jenkins.io/browse/JENKINS-64549) Upgrade to Mockito is failing on the mock of a static inner class. Switching to PowerMockito and the version managed in plugin-pom.

Amends https://github.com/jenkinsci/support-core-plugin/pull/262