### PR TITLE
Log startup performance of Support Core components

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -51,6 +51,7 @@ import hudson.Main;
 import hudson.Plugin;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
+import hudson.model.AbstractCIBase;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
 import hudson.model.Node;
@@ -623,7 +624,12 @@ public class SupportPlugin extends Plugin {
         super.postInitialize();
         for (Component component : getComponents()) {
             try {
+                long initializerStart = System.currentTimeMillis();
                 component.start(getContext());
+                if (AbstractCIBase.LOG_STARTUP_PERFORMANCE) {
+                    long delta = System.currentTimeMillis() - initializerStart;
+                    logger.info(String.format("Took %dms for support component %s startup", delta, component.getId()));
+                }
             } catch (Throwable t) {
                 LogRecord logRecord = new LogRecord(Level.WARNING, "Exception propagated from component: {0}");
                 logRecord.setThrown(t);


### PR DESCRIPTION
There is a Support Core component which takes 5 seconds to startup on my instance. 
This change captures startup performance when Jenkins core flags are set.
