### PR TITLE
JENKINS-64667 - Check for more reverse proxy headers

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/ReverseProxy.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/ReverseProxy.java
@@ -3,6 +3,7 @@ package com.cloudbees.jenkins.support.impl;
 import com.cloudbees.jenkins.support.api.Component;
 import com.cloudbees.jenkins.support.api.Container;
 import com.cloudbees.jenkins.support.api.PrintedContent;
+import com.google.common.collect.ImmutableList;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.security.Permission;
@@ -11,6 +12,7 @@ import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.PrintWriter;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 
@@ -24,7 +26,16 @@ public class ReverseProxy extends Component {
     TRUE, FALSE, UNKNOWN
   }
 
+  // [RFC 7239, section 4: Forwarded](https://tools.ietf.org/html/rfc7239#section-4) standard header.
+  static final String FORWARDED_HEADER = "Forwarded";
+  // Non-standard headers.
   static final String X_FORWARDED_FOR_HEADER = "X-Forwarded-For";
+  static final String X_FORWARDED_PROTO_HEADER = "X-Forwarded-Proto";
+  static final String X_FORWARDED_HOST_HEADER = "X-Forwarded-Host";
+  static final String X_FORWARDED_PORT_HEADER = "X-Forwarded-Port";
+
+  private static final Collection<String> FORWARDED_HEADERS = ImmutableList.of(FORWARDED_HEADER, X_FORWARDED_FOR_HEADER,
+          X_FORWARDED_PROTO_HEADER, X_FORWARDED_HOST_HEADER, X_FORWARDED_PORT_HEADER);
 
   @NonNull
   @Override
@@ -44,7 +55,9 @@ public class ReverseProxy extends Component {
       @Override protected void printTo(PrintWriter out) {
         out.println("Reverse Proxy");
         out.println("=============");
-        out.println(String.format(" * Detected `%s` header: %s", X_FORWARDED_FOR_HEADER, isXForwardForHeaderDetected()));
+        for (String xForwardedHeader : FORWARDED_HEADERS) {
+          out.println(String.format(" * Detected `%s` header: %s", xForwardedHeader, isXForwardedHeaderDetected(xForwardedHeader)));
+        }
       }
 
       @Override
@@ -55,12 +68,12 @@ public class ReverseProxy extends Component {
     });
   }
 
-  private Trilean isXForwardForHeaderDetected() {
+  private Trilean isXForwardedHeaderDetected(String xForwardedHeader) {
     StaplerRequest req = getCurrentRequest();
     if (req == null) {
       return Trilean.UNKNOWN;
     }
-    return req.getHeader(X_FORWARDED_FOR_HEADER) != null ? Trilean.TRUE : Trilean.FALSE;
+    return req.getHeader(xForwardedHeader) != null ? Trilean.TRUE : Trilean.FALSE;
   }
 
   protected StaplerRequest getCurrentRequest() {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/ReverseProxy.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/ReverseProxy.java
@@ -27,14 +27,14 @@ public class ReverseProxy extends Component {
   }
 
   // [RFC 7239, section 4: Forwarded](https://tools.ietf.org/html/rfc7239#section-4) standard header.
-  static final String FORWARDED_HEADER = "Forwarded";
+  private static final String FORWARDED_HEADER = "Forwarded";
   // Non-standard headers.
-  static final String X_FORWARDED_FOR_HEADER = "X-Forwarded-For";
-  static final String X_FORWARDED_PROTO_HEADER = "X-Forwarded-Proto";
-  static final String X_FORWARDED_HOST_HEADER = "X-Forwarded-Host";
-  static final String X_FORWARDED_PORT_HEADER = "X-Forwarded-Port";
+  private static final String X_FORWARDED_FOR_HEADER = "X-Forwarded-For";
+  private static final String X_FORWARDED_PROTO_HEADER = "X-Forwarded-Proto";
+  private static final String X_FORWARDED_HOST_HEADER = "X-Forwarded-Host";
+  private static final String X_FORWARDED_PORT_HEADER = "X-Forwarded-Port";
 
-  private static final Collection<String> FORWARDED_HEADERS = ImmutableList.of(FORWARDED_HEADER, X_FORWARDED_FOR_HEADER,
+  static final Collection<String> FORWARDED_HEADERS = ImmutableList.of(FORWARDED_HEADER, X_FORWARDED_FOR_HEADER,
           X_FORWARDED_PROTO_HEADER, X_FORWARDED_HOST_HEADER, X_FORWARDED_PORT_HEADER);
 
   @NonNull
@@ -55,8 +55,9 @@ public class ReverseProxy extends Component {
       @Override protected void printTo(PrintWriter out) {
         out.println("Reverse Proxy");
         out.println("=============");
-        for (String xForwardedHeader : FORWARDED_HEADERS) {
-          out.println(String.format(" * Detected `%s` header: %s", xForwardedHeader, isXForwardedHeaderDetected(xForwardedHeader)));
+        StaplerRequest currentRequest = getCurrentRequest();
+        for (String forwardedHeader : FORWARDED_HEADERS) {
+          out.println(String.format(" * Detected `%s` header: %s", forwardedHeader, isForwardedHeaderDetected(currentRequest, forwardedHeader)));
         }
       }
 
@@ -68,12 +69,11 @@ public class ReverseProxy extends Component {
     });
   }
 
-  private Trilean isXForwardedHeaderDetected(String xForwardedHeader) {
-    StaplerRequest req = getCurrentRequest();
+  private Trilean isForwardedHeaderDetected(StaplerRequest req, String header) {
     if (req == null) {
       return Trilean.UNKNOWN;
     }
-    return req.getHeader(xForwardedHeader) != null ? Trilean.TRUE : Trilean.FALSE;
+    return req.getHeader(header) != null ? Trilean.TRUE : Trilean.FALSE;
   }
 
   protected StaplerRequest getCurrentRequest() {

--- a/src/test/java/com/cloudbees/jenkins/support/impl/ReverseProxyTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/ReverseProxyTest.java
@@ -17,7 +17,7 @@ import java.io.OutputStream;
 
 import static com.cloudbees.jenkins.support.impl.ReverseProxy.X_FORWARDED_FOR_HEADER;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)


### PR DESCRIPTION
Presence of the standard `Forwarded` header and the rest of non-standard headers are added:

- `X-Forwarded-Proto`
- `X-Forwarded-Host`
- `X-Forwarded-Port`