### PR TITLE
[JENKINS-65097] Add information about websocket in nodes.md

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
   <properties>
     <revision>2.73</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.204.6</jenkins.version>
+    <jenkins.version>2.222.1</jenkins.version>
     <java.level>8</java.level>
     <configuration-as-code.version>1.36</configuration-as-code.version>
   </properties>

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
@@ -31,6 +31,7 @@ import hudson.model.Slave;
 import hudson.remoting.Launcher;
 import hudson.remoting.VirtualChannel;
 import hudson.security.Permission;
+import hudson.slaves.JNLPLauncher;
 import hudson.util.IOUtils;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
@@ -659,6 +660,9 @@ public class AboutJenkins extends Component {
                 if (node instanceof Slave) {
                     Slave slave = (Slave) node;
                     out.println("      - Launch method:  " + getDescriptorName(slave.getLauncher()));
+                    if (slave.getLauncher() instanceof JNLPLauncher) {
+                        out.println("      - WebSocket:      " + ((JNLPLauncher) slave.getLauncher()).isWebSocket());
+                    }
                     out.println("      - Availability:   " + getDescriptorName(slave.getRetentionStrategy()));
                 }
                 VirtualChannel channel = node.getChannel();


### PR DESCRIPTION
[JENKINS-65097](https://issues.jenkins.io/browse/JENKINS-65097): Add a field to Nodes with JNLPLauncher, whether they use Websocket or no. This requires to update the Core dependency to 2.222 (see https://github.com/jenkinsci/jenkins/commit/5b5040298f5fbf9d5ff7ea7fbfd34f7169e94d75)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue