### PR TITLE
Revert #275 and update async-http-client update to 1.7.24.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>async-http-client</artifactId>
-      <version>1.9.40.0</version>
+      <version>1.7.8</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>async-http-client</artifactId>
-      <version>1.7.8</version>
+      <version>1.7.24.3</version>
       <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
Revert the change to version 1.9.40.0 proposed by dependabot in https://github.com/jenkinsci/support-core-plugin/pull/275 that is an old branch of the async-http-plugin and use the latest 1.7.24.3 instead.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue