### PR TITLE
Cleanup pom for bom-2.222.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,6 @@
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.222.1</jenkins.version>
     <java.level>8</java.level>
-    <configuration-as-code.version>1.36</configuration-as-code.version>
   </properties>
 
   <repositories>
@@ -88,13 +87,13 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
-
+  
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.204.x</artifactId>
-        <version>10</version>
+        <artifactId>bom-2.222.x</artifactId>
+        <version>11</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -133,14 +132,12 @@
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
-      <version>${configuration-as-code.version}</version>
       <!-- Optional instead of scope=test to add the category when exporting the configuration -->
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.20</version>
     </dependency>
     <!-- test dependencies -->
     <dependency>
@@ -195,7 +192,6 @@
     <dependency>
       <groupId>io.jenkins.configuration-as-code</groupId>
       <artifactId>test-harness</artifactId>
-      <version>${configuration-as-code.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- MockFolder that was used for SupportAbstractItem test does not have UI, hence need full Folder implementation.-->


### PR DESCRIPTION
Bump to 2.222.x to match the Jenkins version requirement. Need to stick with version 10 unless we move to baseline 2.222.4.
Also removed the dependency version that are already in the bom. Should supersede https://github.com/jenkinsci/support-core-plugin/pull/274.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue