### PR TITLE
[JENKINS-66002] Recover Agent Launch Logs component

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLaunchLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLaunchLogs.java
@@ -29,6 +29,7 @@ import com.cloudbees.jenkins.support.api.Container;
 import com.cloudbees.jenkins.support.api.FileContent;
 import com.cloudbees.jenkins.support.timer.FileListCapComponent;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
 import hudson.model.Node;
 import hudson.security.Permission;
 import hudson.slaves.Cloud;
@@ -47,6 +48,7 @@ import static com.cloudbees.jenkins.support.impl.JenkinsLogs.ROTATED_LOGFILE_FIL
  * Adds agent launch logs, which captures the current and past running connections to the agent.
  *
  */
+@Extension
 public class SlaveLaunchLogs extends Component{
     @NonNull
     @Override

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLaunchLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLaunchLogs.java
@@ -49,7 +49,7 @@ import static com.cloudbees.jenkins.support.impl.JenkinsLogs.ROTATED_LOGFILE_FIL
  *
  */
 @Extension
-public class SlaveLaunchLogs extends Component{
+public class SlaveLaunchLogs extends Component {
     @NonNull
     @Override
     public Set<Permission> getRequiredPermissions() {
@@ -84,8 +84,8 @@ public class SlaveLaunchLogs extends Component{
             /**
              * Launch log directory of the agent: logs/slaves/NAME
              */
-            File dir;
-            long time;
+            final File dir;
+            final long time;
 
             Agent(File dir, File lastLog) {
                 this.dir = dir;
@@ -101,11 +101,7 @@ public class SlaveLaunchLogs extends Component{
              * sort in descending order; newer ones first.
              */
             public int compareTo(Agent that) {
-                long lhs = this.time;
-                long rhs = that.time;
-                if (lhs<rhs)    return 1;
-                if (lhs>rhs)    return -1;
-                return 0;
+                return Long.compare(that.time, this.time);
             }
 
             @Override
@@ -115,9 +111,7 @@ public class SlaveLaunchLogs extends Component{
 
                 Agent agent = (Agent) o;
 
-                if (time != agent.time) return false;
-
-                return true;
+                return time == agent.time;
             }
 
             @Override
@@ -137,7 +131,7 @@ public class SlaveLaunchLogs extends Component{
 
         {// find all the agent launch log files and sort them newer ones first
 
-            File agentLogsDir = new File(Jenkins.getInstance().getRootDir(), "logs/slaves");
+            File agentLogsDir = new File(Jenkins.get().getRootDir(), "logs/slaves");
             File[] logs = agentLogsDir.listFiles();
             if (logs!=null) {
                 for (File dir : logs) {
@@ -153,7 +147,7 @@ public class SlaveLaunchLogs extends Component{
             Collections.sort(all);
         }
         {// this might be still too many, so try to cap them.
-            int acceptableSize = Math.max(256, Jenkins.getInstance().getNodes().size() * 5);
+            int acceptableSize = Math.max(256, Jenkins.get().getNodes().size() * 5);
 
             if (all.size() > acceptableSize)
                 all = all.subList(0, acceptableSize);

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLaunchLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLaunchLogs.java
@@ -162,4 +162,9 @@ public class SlaveLaunchLogs extends Component {
                 }
         }
     }
+
+    @Override
+    public boolean isSelectedByDefault() {
+        return false;
+    }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLaunchLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLaunchLogs.java
@@ -120,10 +120,10 @@ public class SlaveLaunchLogs extends Component {
             }
 
             /**
-             * If the file is more than a year old, can't imagine how that'd be of any interest.
+             * If the file is more than 7 days old, it is considered too old.
              */
             public boolean isTooOld() {
-                return time < System.currentTimeMillis()- TimeUnit.DAYS.toMillis(365);
+                return time < System.currentTimeMillis()- TimeUnit.DAYS.toMillis(7);
             }
         }
 

--- a/src/test/java/com/cloudbees/jenkins/support/SupportTestUtils.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportTestUtils.java
@@ -91,7 +91,40 @@ public class SupportTestUtils {
     }
 
     /**
-     * Invoke an object component, and return the component contents as a String.
+     * Invoke a component, and return the component contents as a Map<String,String> where the key is the 
+     * zip key and the value is the string content.
+     */
+    public static Map<String, String> invokeComponentToMap(final Component component) {
+
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final Map<String, String> contents = new TreeMap<>();
+        component.addContents(
+            new Container() {
+                @Override
+                public void add(@CheckForNull Content content) {
+                    try {
+                        Objects.requireNonNull(content).writeTo(baos);
+                        contents.put(
+                            SupportPlugin.getNameFiltered(
+                                SupportPlugin.getContentFilter(),
+                                content.getName(),
+                                content.getFilterableParameters()
+                            ),
+                            baos.toString());
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    } finally {
+                        baos.reset();
+                    }
+                }
+            });
+
+        return contents;
+    }
+
+    /**
+     * Invoke an object component, and return the component contents as a Map<String,String> where the key is the 
+     * zip key and the value is the string content.
      */
     public static <T extends AbstractModelObject> Map<String, String> invokeComponentToMap(
             final ObjectComponent<T> component, T object) {

--- a/src/test/java/com/cloudbees/jenkins/support/impl/SlaveLaunchLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/SlaveLaunchLogsTest.java
@@ -1,0 +1,27 @@
+package com.cloudbees.jenkins.support.impl;
+
+import com.cloudbees.jenkins.support.SupportTestUtils;
+import hudson.ExtensionList;
+import hudson.slaves.DumbSlave;
+import org.hamcrest.MatcherAssert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.hasKey;
+
+public class SlaveLaunchLogsTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void smokes() throws Exception {
+        DumbSlave s = j.createSlave();
+        Map<String, String> output = SupportTestUtils.invokeComponentToMap(ExtensionList.lookupSingleton(SlaveLaunchLogs.class));
+        String key = "nodes/slave/" + s.getNodeName() + "/launchLogs/slave.log";
+        MatcherAssert.assertThat(output, hasKey(key));
+    }
+}


### PR DESCRIPTION
[JENKINS-66002](https://issues.jenkins.io/browse/JENKINS-66002): Recover the Agent Launch Logs component that was mistakenly removed in support-core:2.33 by https://github.com/jenkinsci/support-core-plugin/commit/8ce4b3baf504f834ae421e8095532188bbd92e3a#diff-6208542ddc2fa48456c666e0478afaefcc2ff037fa1f94cb7b5c1f51bc224e22. But also:

* Adjust the retention of files collected to 7 days instead of 1 year
* Do not select the component by default (nobody reported this for years so I do not think this should be selected by default)

****

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
