### PR TITLE
[JENKINS-66023] Ability to provide additional Stop Words

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,12 +127,12 @@ filtering names (case-insensitive full match).
 Additional Stop Words can be provided in a text file located at 
 `$JENKINS_HOME/support/additional-stop-words.txt`. Each non-blank line of
 the file is treated as a stop word. The following contains 3 stop words `abc`,
-`john doe` and `https://core.example.com`
+`john doe` and `https://test.example.com`
 
 ```
 abc
 john doe
-abc
+https://test.example.com
 ```
 
 The system property `com.cloudbees.jenkins.support.filter.ContentMappings.additionalStopWordsFile`

--- a/README.md
+++ b/README.md
@@ -122,6 +122,22 @@ the original values with their anonymized counterpart. Note that the
 Stop Words list on that page shows which terms are ignored when
 filtering names (case-insensitive full match).
 
+### Additional Stop Words
+
+Additional Stop Words can be provided in a text file located at 
+`$JENKINS_HOME/support/additional-stop-words.txt`. Each non-blank line of
+the file is treated as a stop word. The following contains 3 stop words `abc`,
+`john doe` and `https://core.example.com`
+
+```
+abc
+john doe
+abc
+```
+
+The system property `com.cloudbees.jenkins.support.filter.ContentMappings.additionalStopWordsFile`
+can be used to override the file location.
+
 ### Limitations
 
 Anonymization filters only apply to text files. It cannot handle

--- a/src/test/java/com/cloudbees/jenkins/support/filter/ContentMappingsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/filter/ContentMappingsTest.java
@@ -25,6 +25,7 @@ package com.cloudbees.jenkins.support.filter;
 
 import hudson.model.FreeStyleProject;
 import jenkins.model.Jenkins;
+import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -187,6 +188,25 @@ public class ContentMappingsTest {
 
             // Previous mappings with the operating system are ignored
             assertTrue(mappings.getMappings().isEmpty());
+        });
+    }
+
+    @Issue("JENKINS-66023")
+    @Test
+    @LocalData
+    public void additionalStopWordsIncludedAsStopWord() {
+        String[] expectedStopWords = {
+            "abc", 
+            "https://core.example.com", 
+            "john doe", 
+            "192.168.0.1", 
+            "<h1>",
+            "  leadingspaces", 
+            "trailingspaces  "
+        };
+        rr.then(r -> {
+            ContentMappings mappings = ContentMappings.get();
+            MatcherAssert.assertThat(mappings.getStopWords(), hasItems(expectedStopWords));
         });
     }
 

--- a/src/test/resources/com/cloudbees/jenkins/support/filter/ContentMappingsTest/additionalStopWordsIncludedAsStopWord/support/additional-stop-words.txt
+++ b/src/test/resources/com/cloudbees/jenkins/support/filter/ContentMappingsTest/additionalStopWordsIncludedAsStopWord/support/additional-stop-words.txt
@@ -1,0 +1,11 @@
+abc
+ 
+https://core.example.com
+ 
+john doe
+a very long sentence
+agents
+192.168.0.1
+<h1>
+  leadingspaces
+trailingspaces  


### PR DESCRIPTION
[JENKINS-66023](https://issues.jenkins.io/browse/JENKINS-66023): Add a feature to provide additional stop words from a text file `$JENKINS_HOME/support/additional-stop-words.txt`. Location is overridable via System Property `com.cloudbees.jenkins.support.filter.ContentMappings.additionalStopWordsFile`.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue