### PR TITLE
[JENKINS-60010] OtherLogs should not include GC Logs if activated with the JVM

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
@@ -146,7 +146,7 @@ public class GCLogs extends Component {
     }
 
     @CheckForNull
-    private String getGcLogFileLocation() {
+    public String getGcLogFileLocation() {
 
         String fileLocation;
         
@@ -191,7 +191,7 @@ public class GCLogs extends Component {
                 gcLog.lastModified() > (System.currentTimeMillis() - TimeUnit.DAYS.toMillis(GCLOGS_RETENTION_DAYS));
     }
 
-    private boolean isGcLogRotationConfigured() {
+    public boolean isGcLogRotationConfigured() {
         return isJava8OrBelow() && vmArgumentFinder.findVmArgument(GCLOGS_ROTATION_SWITCH) != null;
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/impl/OtherLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/OtherLogs.java
@@ -78,7 +78,7 @@ public class OtherLogs extends Component {
                         fileFilter = ROTATED_LOGFILE_FILTER;
                     }
                 } catch (IOException e) {
-                    LOGGER.fine("[Support Bundle] Could check if GC Logs file location '" + gcLogsFileLocation 
+                    LOGGER.fine("[Support Bundle] Could not check if GC Logs file location '" + gcLogsFileLocation 
                         + "' is in Jenkins root directory");
                     fileFilter = ROTATED_LOGFILE_FILTER;
                 }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/OtherLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/OtherLogs.java
@@ -9,8 +9,13 @@ import hudson.security.Permission;
 import jenkins.model.Jenkins;
 
 import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.Set;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 import static com.cloudbees.jenkins.support.impl.JenkinsLogs.ROTATED_LOGFILE_FILTER;
 
@@ -19,6 +24,8 @@ import static com.cloudbees.jenkins.support.impl.JenkinsLogs.ROTATED_LOGFILE_FIL
  */
 @Extension(ordinal = 100.0) // put this first as largest content and can let the slower ones complete
 public class OtherLogs extends Component {
+
+    private static final Logger LOGGER = Logger.getLogger(OtherLogs.class.getName());
 
     @NonNull
     @Override
@@ -41,7 +48,7 @@ public class OtherLogs extends Component {
     public void addContents(@NonNull Container result) {
         addOtherControllerLogs(result);
     }
-    
+
     /**
      * Grabs any files that look like log files directly under {@code $JENKINS_HOME}, just in case
      * any of them are useful.
@@ -51,7 +58,33 @@ public class OtherLogs extends Component {
     private void addOtherControllerLogs(Container result) {
         Jenkins jenkins = Jenkins.getInstanceOrNull();
         if (jenkins != null) {
-            File[] files = jenkins.getRootDir().listFiles(ROTATED_LOGFILE_FILTER);
+            GCLogs gcLogsComponents = Jenkins.lookup(GCLogs.class);
+            String gcLogsFileLocation = gcLogsComponents == null ? null : gcLogsComponents.getGcLogFileLocation();
+            
+            FileFilter fileFilter;
+            if (gcLogsFileLocation == null) {
+                fileFilter = ROTATED_LOGFILE_FILTER;
+            } else {
+                try {
+                    // If GC logs are inside the Jenkins root directory, we need to filter them
+                    if(Files.isSameFile(new File(gcLogsFileLocation).getParentFile().toPath(), jenkins.getRootDir().toPath())) {
+                        final Pattern gcLogFilesPattern = 
+                            gcLogsComponents.isFileLocationParameterized(gcLogsFileLocation) || gcLogsComponents.isGcLogRotationConfigured() ?
+                                Pattern.compile("^" + new File(gcLogsFileLocation).getName().replaceAll("%[pt]", ".*") + ".*") :
+                                Pattern.compile("^" + new File(gcLogsFileLocation).getName() + "$");
+                        fileFilter = pathname -> ROTATED_LOGFILE_FILTER.accept(pathname)
+                            && !gcLogFilesPattern.matcher(pathname.getName()).matches();
+                    } else {
+                        fileFilter = ROTATED_LOGFILE_FILTER;
+                    }
+                } catch (IOException e) {
+                    LOGGER.fine("[Support Bundle] Could check if GC Logs file location '" + gcLogsFileLocation 
+                        + "' is in Jenkins root directory");
+                    fileFilter = ROTATED_LOGFILE_FILTER;
+                }
+            }
+            
+            File[] files = jenkins.getRootDir().listFiles(fileFilter);
             if (files != null) {
                 for (File f : files) {
                     result.add(new FileContent("other-logs/{0}", new String[]{f.getName()}, f));

--- a/src/test/java/com/cloudbees/jenkins/support/impl/OtherLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/OtherLogsTest.java
@@ -6,22 +6,35 @@ package com.cloudbees.jenkins.support.impl;
 import com.cloudbees.jenkins.support.SupportTestUtils;
 import com.cloudbees.jenkins.support.api.Component;
 import hudson.ExtensionList;
+import jenkins.model.Jenkins;
+import org.assertj.core.api.Assertions;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({OtherLogs.class, GCLogs.class, Jenkins.class})
 public class OtherLogsTest {
 
     @Rule
@@ -37,7 +50,6 @@ public class OtherLogsTest {
     @Test
     public void testOtherLogsRootDir() throws IOException {
         File testFile = new File(j.getInstance().getRootDir(), "test.log");
-        Files.createFile(testFile.toPath());
         Files.write(testFile.toPath(), Collections.singletonList("This is a test from root dir"), 
                 Charset.defaultCharset());
         
@@ -45,5 +57,173 @@ public class OtherLogsTest {
                 Objects.requireNonNull(ExtensionList.lookup(Component.class).get(OtherLogs.class)));
         assertFalse("Should collect *.log under the root dir", otherLogs.isEmpty());
         assertThat(otherLogs , Matchers.containsString("This is a test from root dir"));
+    }
+
+    @Test
+    public void testOtherLogsExcludeGCSimpleFile() throws Exception {
+        File testFile = new File(j.getInstance().getRootDir(), "test.log");
+        Files.write(testFile.toPath(), Collections.singletonList("This is a test from root dir"),
+            Charset.defaultCharset());
+        
+        File tmpFile = File.createTempFile("gclogs", ".log", j.getInstance().getRootDir());
+        Files.write(tmpFile.toPath(), Collections.singletonList("This is a GC file"));
+
+        GCLogs.VmArgumentFinder finder = mockFinderAndGcLogs();
+
+        if (SupportTestUtils.isJava8OrBelow()) {
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH + tmpFile.getAbsolutePath());
+            assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
+        } else {
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=" + tmpFile.getAbsolutePath());
+            assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
+
+            // The file locations may be wrapped with quotes
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\"" + tmpFile.getAbsolutePath()+ "\"");
+            assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
+        }
+    }
+
+    @Test
+    public void testOtherLogsExcludeGCRotatedFiles() throws Exception {
+        File rootDir = j.getInstance().getRootDir();
+        File testFile = new File(rootDir, "test.log");
+        Files.write(testFile.toPath(), Collections.singletonList("This is a test from root dir"),
+            Charset.defaultCharset());
+        
+        for (int count = 0; count < 5; count++) {
+            File tmpFile = new File(rootDir, "gc.log." + count);
+            Files.write(tmpFile.toPath(), Collections.singletonList("This is a GC file"));
+        }
+
+        GCLogs.VmArgumentFinder finder = mockFinderAndGcLogs();
+
+        if(SupportTestUtils.isJava8OrBelow()) {
+            when(finder.findVmArgument(GCLogs.GCLOGS_ROTATION_SWITCH)).thenReturn(GCLogs.GCLOGS_ROTATION_SWITCH);
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH
+                + rootDir.getAbsolutePath() + File.separator + "gc.log");
+            assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
+        } else {
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file="
+                + rootDir.getAbsolutePath() + File.separator + "gc.log.%p" + ":filecount=10,filesize=50m");
+            assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
+
+            // The file locations may be wrapped with quotes
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\""
+                + rootDir.getAbsolutePath() + File.separator + "gc.log.%p\":filecount=10,filesize=50m");
+            assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
+        }
+    }
+
+    @Test
+    public void testOtherLogsExcludeGCParameterizedFiles() throws Exception {
+        File rootDir = j.getInstance().getRootDir();
+        File testFile = new File(rootDir, "test.log");
+        Files.createFile(testFile.toPath());
+        Files.write(testFile.toPath(), Collections.singletonList("This is a test from root dir"),
+            Charset.defaultCharset());
+        
+        for (int count = 0; count < 5; count++) {
+            File tmpFile = new File(rootDir, "gc." + System.currentTimeMillis() + ".1423.log." + count);
+            Files.write(tmpFile.toPath(), Collections.singletonList("This is a GC file"));
+        }
+
+        GCLogs.VmArgumentFinder finder = mockFinderAndGcLogs();
+
+        if(SupportTestUtils.isJava8OrBelow()) {
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH
+                + new File(rootDir, "gc.%t.%p.log").getAbsolutePath());
+            assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
+        } else {
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file="
+                + rootDir.getAbsolutePath() + File.separator + "gc.%t.%p.log");
+            assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
+
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\""
+                + rootDir.getAbsolutePath() + File.separator + "gc.%t.%p.log\"");
+            assertContentContainsFiles(Collections.singletonList("otrher-logs/test.log"));
+        }
+    }
+    
+    @Test
+    public void testOtherLogsExcludeGCParameterizedAndRotatedFiles() throws Exception {
+        File rootDir = j.getInstance().getRootDir();
+        File testFile = new File(rootDir, "test.log");
+        Files.createFile(testFile.toPath());
+        Files.write(testFile.toPath(), Collections.singletonList("This is a test from root dir"),
+            Charset.defaultCharset());
+        
+        for (int count = 0; count < 5; count++) {
+            Files.write(new File(rootDir, "gc" + System.currentTimeMillis() + ".log." + count).toPath(), 
+                Collections.singletonList("This is a GC file"));
+        }
+        
+        GCLogs.VmArgumentFinder finder = mockFinderAndGcLogs();
+
+        if(SupportTestUtils.isJava8OrBelow()) {
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH 
+                + new File(rootDir, "gc%p.log").getAbsolutePath());
+            when(finder.findVmArgument(GCLogs.GCLOGS_ROTATION_SWITCH)).thenReturn(GCLogs.GCLOGS_ROTATION_SWITCH);
+            assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
+        } else {
+
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file="
+                + rootDir.getAbsolutePath() + File.separator + "gc%t.log.%p" + ":filecount=10,filesize=50m");
+            assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
+
+            // The file locations may be wrapped with quotes
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\""
+                + rootDir.getAbsolutePath() + File.separator + "gc%t.log.%p\"" + ":filecount=10,filesize=50m");
+            assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
+        }
+    }
+
+    @Test
+    public void testOtherLogsNotExcludeGCLogsDirIsNotInRootDir() throws Exception {
+        File rootDir = j.getInstance().getRootDir();
+        File testFile = new File(rootDir, "test.log");
+        Files.write(testFile.toPath(), Collections.singletonList("This is a test from root dir"),
+            Charset.defaultCharset());
+
+        // Create GC Logs file at root
+        for (int count = 0; count < 5; count++) {
+            File tmpFile = new File(rootDir, "gc.log." + count);
+            Files.write(tmpFile.toPath(), Collections.singletonList("This is a GC file"));
+        }
+
+        GCLogs.VmArgumentFinder finder = mockFinderAndGcLogs();
+
+        // Configure GC Logs to go under $JENKINS_ROOT/gc/
+        if(SupportTestUtils.isJava8OrBelow()) {
+            when(finder.findVmArgument(GCLogs.GCLOGS_ROTATION_SWITCH)).thenReturn(GCLogs.GCLOGS_ROTATION_SWITCH);
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH
+                + rootDir.getAbsolutePath() + File.separator + "gc" + File.separator + "gc.log");
+            assertContentContainsFiles(Arrays.asList("other-logs/test.log", "other-logs/gc.log.0", "other-logs/gc.log.1",
+                "other-logs/gc.log.2", "other-logs/gc.log.3", "other-logs/gc.log.4"));
+        } else {
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file="
+                + rootDir.getAbsolutePath() + File.separator + "gc" + File.separator + "gc.log.%p" + ":filecount=10,filesize=50m");
+            assertContentContainsFiles(Arrays.asList("other-logs/test.log", "other-logs/gc.log.0", "other-logs/gc.log.1",
+                "other-logs/gc.log.2", "other-logs/gc.log.3", "other-logs/gc.log.4"));
+
+            // The file locations may be wrapped with quotes
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\""
+                + rootDir.getAbsolutePath() + File.separator + "gc" + File.separator + "gc.log.%p\":filecount=10,filesize=50m");
+            assertContentContainsFiles(Arrays.asList("other-logs/test.log", "other-logs/gc.log.0", "other-logs/gc.log.1",
+                "other-logs/gc.log.2", "other-logs/gc.log.3", "other-logs/gc.log.4"));
+        }
+    }
+
+    private void assertContentContainsFiles(Collection<String> fileNames) {
+        Assertions.assertThat(SupportTestUtils.invokeComponentToMap(
+            ExtensionList.lookupSingleton((Class<? extends Component>) OtherLogs.class)))
+                .containsOnlyKeys(fileNames);
+    }
+    
+    private GCLogs.VmArgumentFinder mockFinderAndGcLogs() {
+        GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
+        GCLogs gcLogs = new GCLogs(finder);
+        PowerMockito.mockStatic(Jenkins.class, Mockito.CALLS_REAL_METHODS);
+        when(Jenkins.lookup(GCLogs.class)).thenReturn(gcLogs);
+        return finder;
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/support/impl/OtherLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/OtherLogsTest.java
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -35,6 +36,8 @@ import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({OtherLogs.class, GCLogs.class, Jenkins.class})
+// Need to ignore some packages due to Powermockito issue with JDK 11 https://github.com/powermock/powermock/issues/864
+@PowerMockIgnore({ "javax.xml.*" })
 public class OtherLogsTest {
 
     @Rule
@@ -140,7 +143,7 @@ public class OtherLogsTest {
 
             when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\""
                 + rootDir.getAbsolutePath() + File.separator + "gc.%t.%p.log\"");
-            assertContentContainsFiles(Collections.singletonList("otrher-logs/test.log"));
+            assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
         }
     }
     


### PR DESCRIPTION
[JENKINS-60010](https://issues.jenkins.io/browse/JENKINS-60010):

* made GCLogs#isGcLogRotationConfigured and GCLogs#getGcLogFileLocation public
* Filter out GC Logs from Other Logs component if the GC Logs are configured for the JVM

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue