### PR TITLE
make unit test compatible with jenkins 2.307+

### DIFF
--- a/src/test/java/com/cloudbees/jenkins/support/filter/ContentMappingsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/filter/ContentMappingsTest.java
@@ -42,7 +42,7 @@ import java.util.Set;
 import java.util.stream.StreamSupport;
 
 import static java.util.stream.Collectors.toList;
-import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInRelativeOrder;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
@@ -97,7 +97,7 @@ public class ContentMappingsTest {
             List<String> originals = StreamSupport.stream(mappings.spliterator(), false)
                     .map(ContentMapping::getOriginal)
                     .collect(toList());
-            assertThat(originals, contains("LongestNameHere", "LongerName", "ShortName"));
+            assertThat(originals, containsInRelativeOrder("LongestNameHere", "LongerName", "ShortName"));
         });
     }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
[ContentMappingsTest.contentMappingsOrderedByLengthDescending](https://github.com/jenkinsci/support-core-plugin/blob/65773ad5ce2327b6802738f493f2395772940a12/src/test/java/com/cloudbees/jenkins/support/filter/ContentMappingsTest.java#L90) fails under Jenkins 2.307+ due to https://github.com/jenkinsci/jenkins/pull/5425

The unit test now fails because additional content mappings are added: `Built-in Node` and `built-in`

cc @MRamonLeon @rsandell @Dohbedoh 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
