### PR TITLE
[chore] Remove powermock that breaks CI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,13 +152,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/com/cloudbees/jenkins/support/impl/GCLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/GCLogsTest.java
@@ -7,10 +7,8 @@ import com.google.common.io.Files;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.Issue;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.Mockito;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -20,11 +18,9 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(GCLogs.class)
 public class GCLogsTest {
 
     @Test
@@ -32,19 +28,17 @@ public class GCLogsTest {
         File tmpFile = File.createTempFile("gclogs", "");
         Files.touch(tmpFile);
 
-        GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
-        
+        GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class, Mockito.CALLS_REAL_METHODS);
         if (SupportTestUtils.isJava8OrBelow()) {
             when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH + tmpFile.getAbsolutePath());
-            assertContentWithFinderContainsFiles(finder, 1);
         } else {
             when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=" + tmpFile.getAbsolutePath());
             assertContentWithFinderContainsFiles(finder, 1);
 
             // The file locations may be wrapped with quotes
-            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\"" + tmpFile.getAbsolutePath()+ "\"");
-            assertContentWithFinderContainsFiles(finder, 1);
+            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\"" + tmpFile.getAbsolutePath() + "\"");
         }
+        assertContentWithFinderContainsFiles(finder, 1);
     }
 
     @Test
@@ -53,13 +47,13 @@ public class GCLogsTest {
         for (int count = 0; count < 5; count++) {
             Files.touch(new File(tempDir, "gc.log." + count));
         }
-        GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
         
-        if(SupportTestUtils.isJava8OrBelow()) {
+        GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class, Mockito.CALLS_REAL_METHODS);
+
+        if (SupportTestUtils.isJava8OrBelow()) {
             when(finder.findVmArgument(GCLogs.GCLOGS_ROTATION_SWITCH)).thenReturn(GCLogs.GCLOGS_ROTATION_SWITCH);
             when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH
                 + tempDir.getAbsolutePath() + File.separator + "gc.log");
-            assertContentWithFinderContainsFiles(finder, 5);
         } else {
 
             when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file="
@@ -69,8 +63,8 @@ public class GCLogsTest {
             // The file locations may be wrapped with quotes
             when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\""
                 + tempDir.getAbsolutePath() + File.separator + "gc.log.%p\":filecount=10,filesize=50m");
-            assertContentWithFinderContainsFiles(finder, 5);
         }
+        assertContentWithFinderContainsFiles(finder, 5);
     }
 
     @Test
@@ -83,11 +77,10 @@ public class GCLogsTest {
             Files.touch(new File(tempDir, "gc." + System.currentTimeMillis() + ".2534.log." + count));
         }
         GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
-        
-        if(SupportTestUtils.isJava8OrBelow()) {
+
+        if (SupportTestUtils.isJava8OrBelow()) {
             when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH
                 + new File(tempDir, "gc.%t.%p.log").getAbsolutePath());
-            assertContentWithFinderContainsFiles(finder, 8);
         } else {
             when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file="
                 + tempDir.getAbsolutePath() + File.separator + "gc.%t.%p.log");
@@ -95,8 +88,8 @@ public class GCLogsTest {
 
             when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\""
                 + tempDir.getAbsolutePath() + File.separator + "gc.%t.%p.log\"");
-            assertContentWithFinderContainsFiles(finder, 8);
         }
+        assertContentWithFinderContainsFiles(finder, 8);
     }
 
     @Test
@@ -109,11 +102,10 @@ public class GCLogsTest {
             Files.touch(new File(tempDir, "gc3421.log." + count));
         }
         GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
-        
-        if(SupportTestUtils.isJava8OrBelow()) {
+
+        if (SupportTestUtils.isJava8OrBelow()) {
             when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH + new File(tempDir, "gc%p.log").getAbsolutePath());
             when(finder.findVmArgument(GCLogs.GCLOGS_ROTATION_SWITCH)).thenReturn(GCLogs.GCLOGS_ROTATION_SWITCH);
-            assertContentWithFinderContainsFiles(finder, 15);
         } else {
             
             when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file="
@@ -123,8 +115,8 @@ public class GCLogsTest {
             // The file locations may be wrapped with quotes
             when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\""
                 + tempDir.getAbsolutePath() + File.separator + "gc%t.log.%p\"" + ":filecount=10,filesize=50m");
-            assertContentWithFinderContainsFiles(finder, 15);
         }
+        assertContentWithFinderContainsFiles(finder, 15);
     }
 
     @Test
@@ -140,13 +132,11 @@ public class GCLogsTest {
             Files.touch(new File(tempDir, "gc3421.log" + count));
         }
         GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
-        
-        if(SupportTestUtils.isJava8OrBelow()) {
+
+        if (SupportTestUtils.isJava8OrBelow()) {
 
             when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH + new File(tempDir, "gc%p.log").getAbsolutePath());
             when(finder.findVmArgument(GCLogs.GCLOGS_ROTATION_SWITCH)).thenReturn(GCLogs.GCLOGS_ROTATION_SWITCH);
-            assertContentWithFinderContainsFiles(finder,
-                Arrays.asList("gc3421.log0", "gc3421.log1", "gc3421.log2", "gc3421.log3", "gc3421.log4"));
 
         } else {
 
@@ -158,9 +148,9 @@ public class GCLogsTest {
             // The file locations may be wrapped with quotes
             when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\""
                 + tempDir.getAbsolutePath() + File.separator + "gc%t.log%p\"" + ":filecount=10,filesize=50m");
-            assertContentWithFinderContainsFiles(finder, 
-                Arrays.asList("gc3421.log0", "gc3421.log1", "gc3421.log2", "gc3421.log3", "gc3421.log4"));
         }
+        assertContentWithFinderContainsFiles(finder,
+            Arrays.asList("gc3421.log0", "gc3421.log1", "gc3421.log2", "gc3421.log3", "gc3421.log4"));
     }
 
     /**

--- a/src/test/java/com/cloudbees/jenkins/support/impl/OtherLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/OtherLogsTest.java
@@ -4,20 +4,14 @@
 package com.cloudbees.jenkins.support.impl;
 
 import com.cloudbees.jenkins.support.SupportTestUtils;
-import com.cloudbees.jenkins.support.api.Component;
-import hudson.ExtensionList;
 import jenkins.model.Jenkins;
 import org.assertj.core.api.Assertions;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,18 +20,15 @@ import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Objects;
+import java.util.function.Consumer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({OtherLogs.class, GCLogs.class, Jenkins.class})
-// Need to ignore some packages due to Powermockito issue with JDK 11 https://github.com/powermock/powermock/issues/864
-@PowerMockIgnore({ "javax.xml.*" })
 public class OtherLogsTest {
 
     @Rule
@@ -45,9 +36,10 @@ public class OtherLogsTest {
 
     @Test
     public void testOtherLogsContentEmpty() {
-        String otherLogs = SupportTestUtils.invokeComponentToString(
-                Objects.requireNonNull(ExtensionList.lookup(Component.class).get(OtherLogs.class)));
-        assertTrue("Should not write anything", otherLogs.isEmpty());
+        mockFinderAndGcLogs(finder -> {
+            String otherLogs = SupportTestUtils.invokeComponentToString(new OtherLogs());
+            assertTrue("Should not write anything", otherLogs.isEmpty());
+        });
     }
 
     @Test
@@ -55,9 +47,7 @@ public class OtherLogsTest {
         File testFile = new File(j.getInstance().getRootDir(), "test.log");
         Files.write(testFile.toPath(), Collections.singletonList("This is a test from root dir"), 
                 Charset.defaultCharset());
-        
-        String otherLogs = SupportTestUtils.invokeComponentToString(
-                Objects.requireNonNull(ExtensionList.lookup(Component.class).get(OtherLogs.class)));
+        String otherLogs = SupportTestUtils.invokeComponentToString(new OtherLogs());
         assertFalse("Should collect *.log under the root dir", otherLogs.isEmpty());
         assertThat(otherLogs , Matchers.containsString("This is a test from root dir"));
     }
@@ -71,19 +61,18 @@ public class OtherLogsTest {
         File tmpFile = File.createTempFile("gclogs", ".log", j.getInstance().getRootDir());
         Files.write(tmpFile.toPath(), Collections.singletonList("This is a GC file"));
 
-        GCLogs.VmArgumentFinder finder = mockFinderAndGcLogs();
+        mockFinderAndGcLogs(finder -> {
+            if (SupportTestUtils.isJava8OrBelow()) {
+                when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH + tmpFile.getAbsolutePath());
+            } else {
+                when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=" + tmpFile.getAbsolutePath());
+                assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
 
-        if (SupportTestUtils.isJava8OrBelow()) {
-            when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH + tmpFile.getAbsolutePath());
+                // The file locations may be wrapped with quotes
+                when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\"" + tmpFile.getAbsolutePath() + "\"");
+            }
             assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
-        } else {
-            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=" + tmpFile.getAbsolutePath());
-            assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
-
-            // The file locations may be wrapped with quotes
-            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\"" + tmpFile.getAbsolutePath()+ "\"");
-            assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
-        }
+        });
     }
 
     @Test
@@ -98,23 +87,23 @@ public class OtherLogsTest {
             Files.write(tmpFile.toPath(), Collections.singletonList("This is a GC file"));
         }
 
-        GCLogs.VmArgumentFinder finder = mockFinderAndGcLogs();
 
-        if(SupportTestUtils.isJava8OrBelow()) {
-            when(finder.findVmArgument(GCLogs.GCLOGS_ROTATION_SWITCH)).thenReturn(GCLogs.GCLOGS_ROTATION_SWITCH);
-            when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH
-                + rootDir.getAbsolutePath() + File.separator + "gc.log");
+        mockFinderAndGcLogs(finder -> {
+            if (SupportTestUtils.isJava8OrBelow()) {
+                when(finder.findVmArgument(GCLogs.GCLOGS_ROTATION_SWITCH)).thenReturn(GCLogs.GCLOGS_ROTATION_SWITCH);
+                when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH
+                    + rootDir.getAbsolutePath() + File.separator + "gc.log");
+            } else {
+                when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file="
+                    + rootDir.getAbsolutePath() + File.separator + "gc.log.%p" + ":filecount=10,filesize=50m");
+                assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
+    
+                // The file locations may be wrapped with quotes
+                when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\""
+                    + rootDir.getAbsolutePath() + File.separator + "gc.log.%p\":filecount=10,filesize=50m");
+            }
             assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
-        } else {
-            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file="
-                + rootDir.getAbsolutePath() + File.separator + "gc.log.%p" + ":filecount=10,filesize=50m");
-            assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
-
-            // The file locations may be wrapped with quotes
-            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\""
-                + rootDir.getAbsolutePath() + File.separator + "gc.log.%p\":filecount=10,filesize=50m");
-            assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
-        }
+        });
     }
 
     @Test
@@ -130,21 +119,20 @@ public class OtherLogsTest {
             Files.write(tmpFile.toPath(), Collections.singletonList("This is a GC file"));
         }
 
-        GCLogs.VmArgumentFinder finder = mockFinderAndGcLogs();
+        mockFinderAndGcLogs(finder -> {
+            if (SupportTestUtils.isJava8OrBelow()) {
+                when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH
+                    + new File(rootDir, "gc.%t.%p.log").getAbsolutePath());
+            } else {
+                when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file="
+                    + rootDir.getAbsolutePath() + File.separator + "gc.%t.%p.log");
+                assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
 
-        if(SupportTestUtils.isJava8OrBelow()) {
-            when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH
-                + new File(rootDir, "gc.%t.%p.log").getAbsolutePath());
+                when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\""
+                    + rootDir.getAbsolutePath() + File.separator + "gc.%t.%p.log\"");
+            }
             assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
-        } else {
-            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file="
-                + rootDir.getAbsolutePath() + File.separator + "gc.%t.%p.log");
-            assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
-
-            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\""
-                + rootDir.getAbsolutePath() + File.separator + "gc.%t.%p.log\"");
-            assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
-        }
+        });
     }
     
     @Test
@@ -159,25 +147,24 @@ public class OtherLogsTest {
             Files.write(new File(rootDir, "gc" + System.currentTimeMillis() + ".log." + count).toPath(), 
                 Collections.singletonList("This is a GC file"));
         }
-        
-        GCLogs.VmArgumentFinder finder = mockFinderAndGcLogs();
 
-        if(SupportTestUtils.isJava8OrBelow()) {
-            when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH 
-                + new File(rootDir, "gc%p.log").getAbsolutePath());
-            when(finder.findVmArgument(GCLogs.GCLOGS_ROTATION_SWITCH)).thenReturn(GCLogs.GCLOGS_ROTATION_SWITCH);
-            assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
-        } else {
+        mockFinderAndGcLogs(finder -> {
+            if (SupportTestUtils.isJava8OrBelow()) {
+                when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH
+                    + new File(rootDir, "gc%p.log").getAbsolutePath());
+                when(finder.findVmArgument(GCLogs.GCLOGS_ROTATION_SWITCH)).thenReturn(GCLogs.GCLOGS_ROTATION_SWITCH);
+            } else {
 
-            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file="
-                + rootDir.getAbsolutePath() + File.separator + "gc%t.log.%p" + ":filecount=10,filesize=50m");
-            assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
+                when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file="
+                    + rootDir.getAbsolutePath() + File.separator + "gc%t.log.%p" + ":filecount=10,filesize=50m");
+                assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
 
-            // The file locations may be wrapped with quotes
-            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\""
-                + rootDir.getAbsolutePath() + File.separator + "gc%t.log.%p\"" + ":filecount=10,filesize=50m");
+                // The file locations may be wrapped with quotes
+                when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\""
+                    + rootDir.getAbsolutePath() + File.separator + "gc%t.log.%p\"" + ":filecount=10,filesize=50m");
+            }
             assertContentContainsFiles(Collections.singletonList("other-logs/test.log"));
-        }
+        });
     }
 
     @Test
@@ -193,40 +180,40 @@ public class OtherLogsTest {
             Files.write(tmpFile.toPath(), Collections.singletonList("This is a GC file"));
         }
 
-        GCLogs.VmArgumentFinder finder = mockFinderAndGcLogs();
+        mockFinderAndGcLogs(finder -> {
+            // Configure GC Logs to go under $JENKINS_ROOT/gc/
+            if(SupportTestUtils.isJava8OrBelow()) {
+                when(finder.findVmArgument(GCLogs.GCLOGS_ROTATION_SWITCH)).thenReturn(GCLogs.GCLOGS_ROTATION_SWITCH);
+                when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH
+                    + rootDir.getAbsolutePath() + File.separator + "gc" + File.separator + "gc.log");
+            } else {
+                when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file="
+                    + rootDir.getAbsolutePath() + File.separator + "gc" + File.separator + "gc.log.%p" + ":filecount=10,filesize=50m");
+                assertContentContainsFiles(Arrays.asList("other-logs/test.log", "other-logs/gc.log.0", "other-logs/gc.log.1",
+                    "other-logs/gc.log.2", "other-logs/gc.log.3", "other-logs/gc.log.4"));
 
-        // Configure GC Logs to go under $JENKINS_ROOT/gc/
-        if(SupportTestUtils.isJava8OrBelow()) {
-            when(finder.findVmArgument(GCLogs.GCLOGS_ROTATION_SWITCH)).thenReturn(GCLogs.GCLOGS_ROTATION_SWITCH);
-            when(finder.findVmArgument(GCLogs.GCLOGS_JRE_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE_SWITCH
-                + rootDir.getAbsolutePath() + File.separator + "gc" + File.separator + "gc.log");
+                // The file locations may be wrapped with quotes
+                when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\""
+                    + rootDir.getAbsolutePath() + File.separator + "gc" + File.separator + "gc.log.%p\":filecount=10,filesize=50m");
+            }
             assertContentContainsFiles(Arrays.asList("other-logs/test.log", "other-logs/gc.log.0", "other-logs/gc.log.1",
                 "other-logs/gc.log.2", "other-logs/gc.log.3", "other-logs/gc.log.4"));
-        } else {
-            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file="
-                + rootDir.getAbsolutePath() + File.separator + "gc" + File.separator + "gc.log.%p" + ":filecount=10,filesize=50m");
-            assertContentContainsFiles(Arrays.asList("other-logs/test.log", "other-logs/gc.log.0", "other-logs/gc.log.1",
-                "other-logs/gc.log.2", "other-logs/gc.log.3", "other-logs/gc.log.4"));
-
-            // The file locations may be wrapped with quotes
-            when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\""
-                + rootDir.getAbsolutePath() + File.separator + "gc" + File.separator + "gc.log.%p\":filecount=10,filesize=50m");
-            assertContentContainsFiles(Arrays.asList("other-logs/test.log", "other-logs/gc.log.0", "other-logs/gc.log.1",
-                "other-logs/gc.log.2", "other-logs/gc.log.3", "other-logs/gc.log.4"));
-        }
+        });
     }
 
     private void assertContentContainsFiles(Collection<String> fileNames) {
-        Assertions.assertThat(SupportTestUtils.invokeComponentToMap(
-            ExtensionList.lookupSingleton((Class<? extends Component>) OtherLogs.class)))
+        Assertions.assertThat(SupportTestUtils.invokeComponentToMap(new OtherLogs()))
                 .containsOnlyKeys(fileNames);
     }
     
-    private GCLogs.VmArgumentFinder mockFinderAndGcLogs() {
+    private GCLogs.VmArgumentFinder mockFinderAndGcLogs(Consumer<GCLogs.VmArgumentFinder> consumer) {
         GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
         GCLogs gcLogs = new GCLogs(finder);
-        PowerMockito.mockStatic(Jenkins.class, Mockito.CALLS_REAL_METHODS);
-        when(Jenkins.lookup(GCLogs.class)).thenReturn(gcLogs);
+        try(MockedStatic<Jenkins> jenkinsMock = mockStatic(Jenkins.class, Mockito.CALLS_REAL_METHODS)) {
+            jenkinsMock.when(() -> Jenkins.lookup(GCLogs.class)).thenReturn(gcLogs);
+            jenkinsMock.when(() -> Jenkins.lookup(OtherLogs.class)).thenReturn(new OtherLogs());
+            consumer.accept(finder);
+        }
         return finder;
     }
 }


### PR DESCRIPTION
* Removed Powermock that is currently breaking CI and also learnt from https://github.com/jenkinsci/jenkins/pull/5736 that it is not straightforward to make it work in Java 17 and is unmaintained. We can do everything with Mockito.
* Applied checkstyles

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue