### PR TITLE
Update BOM and metrics plugin to fix test warnings on jdk11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
   <properties>
     <revision>2.78</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.222.1</jenkins.version>
+    <jenkins.version>2.222.4</jenkins.version>
     <java.level>8</java.level>
   </properties>
 
@@ -93,7 +93,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.222.x</artifactId>
-        <version>11</version>
+        <version>887.vae9c8ac09ff7</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -116,7 +116,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>metrics</artifactId>
-      <version>3.1.2.6</version>
+      <version>4.0.2.8</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
This removes

```
1) Error injecting constructor,
   java.lang.reflect.InaccessibleObjectException: Unable to make public
   long
   com.sun.management.internal.OperatingSystemImpl.getProcessCpuTime()
   accessible: module jdk.management does not "opens
   com.sun.management.internal" to unnamed module @7fd4acee
     at
     jenkins.metrics.impl.VMMetricProviderImpl.<init>(VMMetricProviderImpl.java:56)
```

as recent metrics plugin doesn't rely on this private method as of
https://github.com/jenkinsci/metrics-plugin/pull/42

This was also causing flakes when running tests on jdk11 because of https://github.com/jenkinsci/support-core-plugin/blob/2f2dbb41d3be70a42c588f05921eddb1f72b0ee8/src/test/java/com/cloudbees/jenkins/support/SupportTestUtils.java#L192

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
