### PR TITLE
Noisy warnings from `SupportPlugin.writeBundle` about `ChannelClosedException`

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -59,6 +59,7 @@ import hudson.model.Descriptor;
 import hudson.model.Node;
 import hudson.model.PeriodicWork;
 import hudson.model.TaskListener;
+import hudson.remoting.ChannelClosedException;
 import hudson.remoting.Future;
 import hudson.remoting.VirtualChannel;
 import hudson.security.ACL;
@@ -378,7 +379,7 @@ public class SupportPlugin extends Plugin {
                         out.flush();
                     } catch (Throwable e) {
                         String msg = "Could not attach ''" + name + "'' to support bundle";
-                        logger.log(Level.WARNING, msg, e);
+                        logger.log(e instanceof ChannelClosedException ? Level.FINE : Level.WARNING, msg, e);
                         errorWriter.println(msg);
                         errorWriter.println("-----------------------------------------------------------------------");
                         errorWriter.println();


### PR DESCRIPTION
Reviewing a support bundle, I saw that the main system log was filled with noise about K8s agents of the form

```
…	WARNING	c.c.j.support.SupportPlugin#writeBundle: Could not attach ''nodes/slave/… to support bundle
java.nio.channels.ClosedChannelException
	at org.jenkinsci.remoting.protocol.impl.ChannelApplicationLayer.onReadClosed(ChannelApplicationLayer.java:238)
	at …
	at org.jenkinsci.remoting.protocol.impl.ChannelApplicationLayer$ByteBufferCommandTransport.closeWrite(ChannelApplicationLayer.java:340)
	at hudson.remoting.Channel.close(Channel.java:1501)
	at hudson.remoting.Channel.close(Channel.java:1454)
	at hudson.slaves.SlaveComputer.closeChannel(SlaveComputer.java:887)
	at hudson.slaves.SlaveComputer.kill(SlaveComputer.java:853)
	at hudson.model.AbstractCIBase.killComputer(AbstractCIBase.java:91)
	at hudson.model.AbstractCIBase.updateComputerList(AbstractCIBase.java:276)
	at jenkins.model.Jenkins.updateComputerList(Jenkins.java:1668)
	at jenkins.model.Nodes$5.run(Nodes.java:279)
	at hudson.model.Queue._withLock(Queue.java:1390)
	at hudson.model.Queue.withLock(Queue.java:1266)
	at jenkins.model.Nodes.removeNode(Nodes.java:270)
	at jenkins.model.Jenkins.removeNode(Jenkins.java:2211)
	at hudson.slaves.AbstractCloudSlave.terminate(AbstractCloudSlave.java:92)
	at org.jenkinsci.plugins.durabletask.executors.OnceRetentionStrategy$1$1.run(OnceRetentionStrategy.java:128)
	at hudson.model.Queue._withLock(Queue.java:1390)
	at hudson.model.Queue.withLock(Queue.java:1266)
	at org.jenkinsci.plugins.durabletask.executors.OnceRetentionStrategy$1.run(OnceRetentionStrategy.java:123)
	at …
Caused: hudson.remoting.ChannelClosedException: Channel "hudson.remoting.Channel@…:JNLP4-connect connection from …": Remote call on JNLP4-connect connection from … failed. The channel is closing down or has closed down
	at hudson.remoting.Channel.call(Channel.java:994)
	at hudson.FilePath.act(FilePath.java:1166)
	at hudson.FilePath.act(FilePath.java:1155)
	at hudson.FilePath.lastModified(FilePath.java:1716)
	at com.cloudbees.jenkins.support.api.FilePathContent.getTime(FilePathContent.java:90)
	at com.cloudbees.jenkins.support.SupportPlugin.writeBundle(SupportPlugin.java:368)
	at com.cloudbees.jenkins.support.SupportPlugin.writeBundle(SupportPlugin.java:315)
	at com.cloudbees.jenkins.support.SupportPlugin$PeriodicWorkImpl.lambda$doRun$0(SupportPlugin.java:888)
	at java.lang.Thread.run(Thread.java:748)
```

While something may be wrong with the agent here, and it is fine to include details in the support bundle itself, the stack trace in the system logs is not interesting.
