### PR TITLE
more performant nic gatherer and falky test improvements

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/NetworkInterfaces.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/NetworkInterfaces.java
@@ -103,8 +103,6 @@ public class NetworkInterfaces extends Component {
     private static final class GetNetworkInterfaces extends MasterToSlaveCallable<String, RuntimeException> {
 
         public String call() {
-            long nanos = System.nanoTime();
-
             try {
                 // we need to do this in parallel otherwise we can not complete in a reasonable time (each nic will take about 10ms and on windows we can easily have 60)
                 List<NetworkInterface> nics = new ArrayList<>();
@@ -114,9 +112,8 @@ public class NetworkInterfaces extends Component {
                         nics.add(networkInterfaces.nextElement());
                     }
                 }
-                String details =  nics.parallelStream().map(n -> nicDetails(n)).collect(Collectors.joining("\n"));
-                System.err.println("***** Callable took : " + ((System.nanoTime() - nanos)) + " ns");
-                return details;
+                
+                return nics.parallelStream().map(n -> nicDetails(n)).collect(Collectors.joining("\n"));
             } catch (SocketException e) {
                 return e.getMessage();
             }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/NetworkInterfaces.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/NetworkInterfaces.java
@@ -39,10 +39,15 @@ import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.Set;
 import java.util.WeakHashMap;
+import java.util.stream.Collectors;
 import jenkins.security.MasterToSlaveCallable;
 
 /**
@@ -70,7 +75,7 @@ public class NetworkInterfaces extends Component {
                 new Content("nodes/master/networkInterface.md") {
                     @Override
                     public void writeTo(OutputStream os) throws IOException {
-                        os.write(getNetworkInterface(Jenkins.getInstance()).getBytes("UTF-8"));
+                        os.write(getNetworkInterface(Jenkins.get()).getBytes(StandardCharsets.UTF_8));
                     }
                 }
         );
@@ -80,7 +85,7 @@ public class NetworkInterfaces extends Component {
                     new Content("nodes/slave/{0}/networkInterface.md", node.getNodeName()) {
                         @Override
                         public void writeTo(OutputStream os) throws IOException {
-                            os.write(getNetworkInterface(node).getBytes("UTF-8"));
+                            os.write(getNetworkInterface(node).getBytes(StandardCharsets.UTF_8));
                         }
                     }
             );
@@ -96,45 +101,60 @@ public class NetworkInterfaces extends Component {
     }
 
     private static final class GetNetworkInterfaces extends MasterToSlaveCallable<String, RuntimeException> {
+
         public String call() {
-            StringBuilder bos = new StringBuilder();
+            long nanos = System.nanoTime();
 
             try {
-                Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
-                while (networkInterfaces.hasMoreElements()) {
-                    bos.append("-----------\n");
-
-                    NetworkInterface ni = networkInterfaces.nextElement();
-                    bos.append(" * Name ").append(ni.getDisplayName()).append("\n");
-
-                    byte[] hardwareAddress = ni.getHardwareAddress();
-
-                    // Do not have permissions or address does not exist
-                    if (hardwareAddress != null && hardwareAddress.length != 0)
-                        bos.append(" ** Hardware Address - ").append(Util.toHexString(hardwareAddress)).append("\n");
-
-                    bos.append(" ** Index - ").append(ni.getIndex()).append("\n");
-                    Enumeration<InetAddress> inetAddresses = ni.getInetAddresses();
-                    while (inetAddresses.hasMoreElements()) {
-                        InetAddress inetAddress =  inetAddresses.nextElement();
-                        bos.append(" ** InetAddress - ").append(inetAddress).append("\n");
-                    }
-                    bos.append(" ** MTU - ").append(ni.getMTU()).append("\n");
-                    bos.append(" ** Is Up - ").append(ni.isUp()).append("\n");
-                    bos.append(" ** Is Virtual - ").append(ni.isVirtual()).append("\n");
-                    bos.append(" ** Is Loopback - ").append(ni.isLoopback()).append("\n");
-                    bos.append(" ** Is Point to Point - ").append(ni.isPointToPoint()).append("\n");
-                    bos.append(" ** Supports multicast - ").append(ni.supportsMulticast()).append("\n");
-
-                    if (ni.getParent() != null) {
-                        bos.append(" ** Child of - ").append(ni.getParent().getDisplayName()).append("\n");
+                // we need to do this in parallel otherwise we can not complete in a reasonable time (each nic will take about 10ms and on windows we can easily have 60)
+                List<NetworkInterface> nics = new ArrayList<>();
+                {
+                    Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
+                    while (networkInterfaces.hasMoreElements()) {
+                        nics.add(networkInterfaces.nextElement());
                     }
                 }
+                String details =  nics.parallelStream().map(n -> nicDetails(n)).collect(Collectors.joining("\n"));
+                System.err.println("***** Callable took : " + ((System.nanoTime() - nanos)) + " ns");
+                return details;
             } catch (SocketException e) {
-                bos.append(e.getMessage());
+                return e.getMessage();
             }
-
-            return bos.toString();
         }
+
+        public static String nicDetails(NetworkInterface ni) {
+            StringBuilder sb = new StringBuilder();
+            sb.append(" * Name ").append(ni.getDisplayName()).append('\n');
+
+            try {
+                byte[] hardwareAddress = ni.getHardwareAddress();
+
+                // Do not have permissions or address does not exist
+                if (hardwareAddress != null && hardwareAddress.length != 0) {
+                    sb.append(" ** Hardware Address - ").append(Util.toHexString(hardwareAddress)).append("\n");
+                }
+                sb.append(" ** Index - ").append(ni.getIndex()).append('\n');
+                Enumeration<InetAddress> inetAddresses = ni.getInetAddresses();
+                while (inetAddresses.hasMoreElements()) {
+                    InetAddress inetAddress =  inetAddresses.nextElement();
+                    sb.append(" ** InetAddress - ").append(inetAddress).append('\n');
+                }
+                sb.append(" ** MTU - ").append(ni.getMTU()).append('\n');
+                sb.append(" ** Is Up - ").append(ni.isUp()).append('\n');
+                sb.append(" ** Is Virtual - ").append(ni.isVirtual()).append('\n');
+                sb.append(" ** Is Loopback - ").append(ni.isLoopback()).append('\n');
+                sb.append(" ** Is Point to Point - ").append(ni.isPointToPoint()).append('\n');
+                sb.append(" ** Supports multicast - ").append(ni.supportsMulticast()).append('\n');
+
+                if (ni.getParent() != null) {
+                    sb.append(" ** Child of - ").append(ni.getParent().getDisplayName()).append('\n');
+                }
+            } catch (SocketException e) {
+                sb.append(e.getMessage()).append('\n');
+            }
+            return sb.toString();
+        }
+
     }
+
 }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/NetworkInterfaces.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/NetworkInterfaces.java
@@ -39,7 +39,6 @@ import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/test/java/com/cloudbees/jenkins/support/impl/NetworkInterfacesTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/NetworkInterfacesTest.java
@@ -47,5 +47,6 @@ public class NetworkInterfacesTest {
         assertThat("Should at least contain one network interface.",
                 controllerNetworkInterfaces,
                 containsString(expectedName));
+        System.err.println(controllerNetworkInterfaces);
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/support/impl/NetworkInterfacesTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/NetworkInterfacesTest.java
@@ -47,6 +47,5 @@ public class NetworkInterfacesTest {
         assertThat("Should at least contain one network interface.",
                 controllerNetworkInterfaces,
                 containsString(expectedName));
-        System.err.println(controllerNetworkInterfaces);
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/support/impl/OtherLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/OtherLogsTest.java
@@ -4,14 +4,11 @@
 package com.cloudbees.jenkins.support.impl;
 
 import com.cloudbees.jenkins.support.SupportTestUtils;
-import jenkins.model.Jenkins;
 import org.assertj.core.api.Assertions;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,7 +23,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 public class OtherLogsTest {
@@ -205,15 +201,11 @@ public class OtherLogsTest {
         Assertions.assertThat(SupportTestUtils.invokeComponentToMap(new OtherLogs()))
                 .containsOnlyKeys(fileNames);
     }
-    
+
     private GCLogs.VmArgumentFinder mockFinderAndGcLogs(Consumer<GCLogs.VmArgumentFinder> consumer) {
         GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
         GCLogs gcLogs = new GCLogs(finder);
-        try(MockedStatic<Jenkins> jenkinsMock = mockStatic(Jenkins.class, Mockito.CALLS_REAL_METHODS)) {
-            jenkinsMock.when(() -> Jenkins.lookup(GCLogs.class)).thenReturn(gcLogs);
-            jenkinsMock.when(() -> Jenkins.lookup(OtherLogs.class)).thenReturn(new OtherLogs());
-            consumer.accept(finder);
-        }
+        j.jenkins.lookup.set(GCLogs.class, gcLogs);
         return finder;
     }
 }


### PR DESCRIPTION
Gathering NetworkInterfaces would reliable timeout when runnign locally for the Jenkins controller on windows with a large (but somewhat standard) number of NICs.

on my laptop with 58 NICs in the enumeration (filter drivers, hyper-v....) it took over 900ms to just run the code in the `call` method which is longer than the `500`ms allowed for the callable to complete.
Subsequent to this change the callable code now completes in ~390ms on the same machine.

This caused the test to reliably fail (and is a little flaky in CI also) so restructured the code to build the individual NIC strings in parallel.

At the same time I removed some gratuitous use of static mocking in a test class.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
