### PR TITLE
[chore] Remove deprecated usage of MockitoJUnitRunner

### DIFF
--- a/src/test/java/com/cloudbees/jenkins/support/impl/ReverseProxyTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/ReverseProxyTest.java
@@ -6,11 +6,11 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.kohsuke.stapler.StaplerRequest;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
@@ -20,7 +20,6 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
 public class ReverseProxyTest {
 
     private static final String HEADER_VALUE = "value";
@@ -31,6 +30,9 @@ public class ReverseProxyTest {
     @Rule
     public JenkinsRule j = new JenkinsRule();
 
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+    
     @Mock
     private StaplerRequest staplerRequest;
 

--- a/src/test/java/com/cloudbees/jenkins/support/util/IgnoreCloseOutputStreamTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/util/IgnoreCloseOutputStreamTest.java
@@ -23,19 +23,22 @@
  */
 package com.cloudbees.jenkins.support.util;
 
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import java.io.IOException;
 import java.io.OutputStream;
 
 import static org.mockito.BDDMockito.then;
 
-@RunWith(MockitoJUnitRunner.class)
 public class IgnoreCloseOutputStreamTest {
 
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+    
     @Mock
     private OutputStream out;
 

--- a/src/test/java/com/cloudbees/jenkins/support/util/IgnoreCloseWriterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/util/IgnoreCloseWriterTest.java
@@ -23,19 +23,22 @@
  */
 package com.cloudbees.jenkins.support.util;
 
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import java.io.IOException;
 import java.io.Writer;
 
 import static org.mockito.BDDMockito.then;
 
-@RunWith(MockitoJUnitRunner.class)
 public class IgnoreCloseWriterTest {
 
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+    
     @Mock
     private Writer out;
 


### PR DESCRIPTION
Remove deprecated usage of MockitoJUnitRunner. Should allow to update latest plugin-pom dep https://github.com/jenkinsci/support-core-plugin/pull/318

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
