### PR TITLE
[chore] Fix javadoc warning in SupportPluginManagement

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/config/SupportPluginManagement.java
+++ b/src/main/java/com/cloudbees/jenkins/support/config/SupportPluginManagement.java
@@ -155,7 +155,6 @@ public class SupportPluginManagement extends ManagementLink implements Describab
     }
 
     /**
-     * @return
      * @see Describable#getDescriptor()
      */
     @Override


### PR DESCRIPTION
Quick fix of a warning in CI:

```
17:39:22  [WARNING] Javadoc Warnings
17:39:22  [WARNING] /home/jenkins/workspace/ugins_support-core-plugin_master/src/main/java/com/cloudbees/jenkins/support/config/SupportPluginManagement.java:158: warning: no description for @return
17:39:22  [WARNING] * @return
17:39:22  [WARNING] ^
```

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
