### PR TITLE
[chore] Remove deprecated javaLevel from Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildPlugin(configurations: [
-    [ platform: "linux", jdk: "8", jenkins: null ],
-    [ platform: "linux", jdk: "11", jenkins: null, javaLevel: "8" ],
-    [ platform: "windows", jdk: "8", jenkins: null, javaLevel: "8" ],
+    [ platform: "linux", jdk: "8", jenkins: null],
+    [ platform: "linux", jdk: "11", jenkins: null],
+    [ platform: "windows", jdk: "8", jenkins: null],
 ])


### PR DESCRIPTION
Addresses the warning:

```
WARNING: Ignoring deprecated "javaLevel" parameter. This parameter should be removed from your "Jenkinsfile".
```

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue