### PR TITLE
[chore] Address current deprecated API usage

### DIFF
--- a/src/findbugs/excludesFilter.xml
+++ b/src/findbugs/excludesFilter.xml
@@ -1,5 +1,0 @@
-<FindBugsFilter>
-  <Match>
-    <Class name="~.*\.Messages"/>
-  </Match>
-</FindBugsFilter>

--- a/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
@@ -374,9 +374,9 @@ public class SupportAction implements RootAction, StaplerProxy {
         rsp.addHeader("Content-Disposition", "inline; filename=" + BundleFileName.generate() + ";");
         final ServletOutputStream servletOutputStream = rsp.getOutputStream();
         try {
-            SupportPlugin.setRequesterAuthentication(Jenkins.getAuthentication());
+            SupportPlugin.setRequesterAuthentication(Jenkins.getAuthentication2());
             try {
-                try (ACLContext old = ACL.as(ACL.SYSTEM)) {
+                try (ACLContext ignored = ACL.as2(ACL.SYSTEM2)) {
                      SupportPlugin.writeBundle(servletOutputStream, components);
                 } catch (IOException e) {
                     logger.log(Level.FINE, e.getMessage(), e);

--- a/src/main/java/com/cloudbees/jenkins/support/SupportCommand.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportCommand.java
@@ -48,7 +48,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Level;
 
 @Extension
 public class SupportCommand extends CLICommand {
@@ -95,9 +94,9 @@ public class SupportCommand extends CLICommand {
                 selected.add(c);
             }
         }
-        SupportPlugin.setRequesterAuthentication(Jenkins.getAuthentication());
+        SupportPlugin.setRequesterAuthentication(Jenkins.getAuthentication2());
         try {
-            try (ACLContext old = ACL.as(ACL.SYSTEM)) {
+            try (ACLContext ignored = ACL.as2(ACL.SYSTEM2)) {
                 OutputStream os;
                 if (channel != null) { // Remoting mode
                     os = channel.call(new SaveBundle(BundleFileName.generate()));

--- a/src/main/java/com/cloudbees/jenkins/support/SupportLogHandler.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportLogHandler.java
@@ -200,6 +200,10 @@ public class SupportLogHandler extends Handler {
         }
     }
 
+    @SuppressFBWarnings(
+        value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE", 
+        justification = "https://github.com/spotbugs/spotbugs/issues/756"
+    )
     private void setWriter(Writer writer) {
         outputLock.lock();
         try (Writer oldWriter = this.writer) {

--- a/src/main/java/com/cloudbees/jenkins/support/SupportLogHandler.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportLogHandler.java
@@ -36,12 +36,11 @@ import java.io.FileOutputStream;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
-import java.io.UnsupportedEncodingException;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
@@ -142,12 +141,10 @@ public class SupportLogHandler extends Handler {
                     }
                 });
                 if (files != null && files.length > maxFiles) {
-                    Arrays.sort(files, new Comparator<File>() {
-                        public int compare(File o1, File o2) {
-                            long lm1 = o1.lastModified();
-                            long lm2 = o2.lastModified();
-                            return lm1 < lm2 ? -1 : lm1 == lm2 ? 0 : +1;
-                        }
+                    Arrays.sort(files, (o1, o2) -> {
+                        long lm1 = o1.lastModified();
+                        long lm2 = o2.lastModified();
+                        return Long.compare(lm1, lm2);
                     });
                     for (int i = 0; i < files.length - maxFiles; i++) {
                         files[i].delete();
@@ -244,11 +241,7 @@ public class SupportLogHandler extends Handler {
             try {
                 fos = new FileOutputStream(file);
                 bos = new BufferedOutputStream(fos);
-                try {
-                    writer = new OutputStreamWriter(bos, "utf-8");
-                } catch (UnsupportedEncodingException e) {
-                    writer = new OutputStreamWriter(bos); // fall back to something sensible
-                }
+                writer = new OutputStreamWriter(bos, StandardCharsets.UTF_8);
                 setWriter(writer);
                 fileCount = 0;
                 success = true;

--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -121,6 +121,8 @@ import java.util.stream.Collectors;
  */
 public class SupportPlugin extends Plugin {
 
+    private static final Logger LOGGER = Logger.getLogger(SupportPlugin.class.getName()); 
+
     /**
      * How long remote operations can block support bundle generation for.
      */
@@ -865,7 +867,7 @@ public class SupportPlugin extends Plugin {
             }
             if (nextBundleWrite.get() < System.currentTimeMillis() && AUTO_BUNDLE_PERIOD_HOURS > 0) {
                 if (thread != null && thread.isAlive()) {
-                    logger.log(Level.INFO, "Periodic bundle generating thread is still running. Execution aborted.");
+                    LOGGER.log(Level.INFO, "Periodic bundle generating thread is still running. Execution aborted.");
                     return;
                 }
                 try {
@@ -891,12 +893,12 @@ public class SupportPlugin extends Plugin {
                                 cleanupOldBundles(bundleDir, file);   
                             }
                         } catch (Throwable t) {
-                            logger.log(Level.WARNING, "Could not save support bundle", t);
+                            LOGGER.log(Level.WARNING, "Could not save support bundle", t);
                         }
                     }, SupportPlugin.class.getSimpleName() + " periodic bundle generator");
                     thread.start();
                 } catch (Throwable t) {
-                    logger.log(Level.SEVERE, "Periodic bundle generating thread failed with error", t);
+                    LOGGER.log(Level.SEVERE, "Periodic bundle generating thread failed with error", t);
                 }
             }
         }
@@ -911,7 +913,7 @@ public class SupportPlugin extends Plugin {
                     SupportPlugin.class.getSimpleName(), new Date()));
             File[] files = bundleDir.listFiles((dir, name) -> name.endsWith(".zip"));
             if (files == null) {
-                logger.log(Level.WARNING, "Something is wrong: {0} does not exist or there was an IO issue.",
+                LOGGER.log(Level.WARNING, "Something is wrong: {0} does not exist or there was an IO issue.",
                         bundleDir.getAbsolutePath());
                 return;
             }
@@ -926,7 +928,7 @@ public class SupportPlugin extends Plugin {
                     if (l <= age && age < l * 2) {
                         if (seen) {
                             f.delete();
-                            logger.log(Level.INFO, "Deleted old bundle {0}", f.getName());
+                            LOGGER.log(Level.INFO, "Deleted old bundle {0}", f.getName());
                         } else {
                             seen = true;
                         }

--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -73,13 +73,13 @@ import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
 import net.sf.json.JSONObject;
-import org.acegisecurity.Authentication;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.StaplerRequest;
+import org.springframework.security.core.Authentication;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -876,7 +876,7 @@ public class SupportPlugin extends Plugin {
                         thread.setName(String.format("%s periodic bundle generator: since %s",
                                 SupportPlugin.class.getSimpleName(), new Date()));
                         clearRequesterAuthentication();
-                        try (ACLContext old = ACL.as(ACL.SYSTEM)) {
+                        try (ACLContext ignored = ACL.as2(ACL.SYSTEM2)) {
                              File bundleDir = getRootDirectory();
                             if (!bundleDir.exists()) {
                                 if (!bundleDir.mkdirs()) {

--- a/src/main/java/com/cloudbees/jenkins/support/actions/SupportObjectAction.java
+++ b/src/main/java/com/cloudbees/jenkins/support/actions/SupportObjectAction.java
@@ -142,8 +142,8 @@ public abstract class SupportObjectAction<T extends AbstractModelObject> impleme
         rsp.addHeader("Content-Disposition", "inline; filename=" + BundleFileName.generate(getBundleNameQualifier()) + ";");
         
         try {
-            SupportPlugin.setRequesterAuthentication(Jenkins.getAuthentication());
-            try (ACLContext old = ACL.as(ACL.SYSTEM)) {
+            SupportPlugin.setRequesterAuthentication(Jenkins.getAuthentication2());
+            try (ACLContext old = ACL.as2(ACL.SYSTEM2)) {
                 SupportPlugin.writeBundle(rsp.getOutputStream(), components, new ComponentVisitor() {
                     @Override
                     public <C extends Component> void visit(Container container, C component) {

--- a/src/main/java/com/cloudbees/jenkins/support/api/BaseCommandOutputContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/BaseCommandOutputContent.java
@@ -13,6 +13,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.charset.Charset;
 import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -39,7 +40,7 @@ class BaseCommandOutputContent {
             PrintWriter pw = new PrintWriter(bos);
             try {
                 Process proc = new ProcessBuilder().command(command).redirectErrorStream(true).start();
-                IOUtils.copy(proc.getInputStream(), pw);
+                IOUtils.copy(proc.getInputStream(), pw, Charset.defaultCharset());
             } catch (Exception e) {
                 Functions.printStackTrace(e, pw);
             }

--- a/src/main/java/com/cloudbees/jenkins/support/api/Component.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/Component.java
@@ -92,7 +92,7 @@ public abstract class Component implements ExtensionPoint {
      */
     @Exported
     public boolean isEnabled() {
-        ACL acl = Jenkins.getInstance().getAuthorizationStrategy().getRootACL();
+        ACL acl = Jenkins.get().getAuthorizationStrategy().getRootACL();
         if (acl != null) {
             Authentication authentication = Jenkins.getAuthentication();
             assert authentication != null;

--- a/src/main/java/com/cloudbees/jenkins/support/api/Component.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/Component.java
@@ -31,7 +31,7 @@ import hudson.model.AbstractModelObject;
 import hudson.security.ACL;
 import hudson.security.Permission;
 import jenkins.model.Jenkins;
-import org.acegisecurity.Authentication;
+import org.springframework.security.core.Authentication;
 import org.jvnet.localizer.Localizable;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
@@ -93,13 +93,10 @@ public abstract class Component implements ExtensionPoint {
     @Exported
     public boolean isEnabled() {
         ACL acl = Jenkins.get().getAuthorizationStrategy().getRootACL();
-        if (acl != null) {
-            Authentication authentication = Jenkins.getAuthentication();
-            assert authentication != null;
-            for (Permission p : _getRequiredPermissions()) {
-                if (!acl.hasPermission(authentication, p)) {
-                    return false;
-                }
+        Authentication authentication = Jenkins.getAuthentication2();
+        for (Permission p : _getRequiredPermissions()) {
+            if (!acl.hasPermission2(authentication, p)) {
+                return false;
             }
         }
         return true;

--- a/src/main/java/com/cloudbees/jenkins/support/configfiles/SecretHandler.java
+++ b/src/main/java/com/cloudbees/jenkins/support/configfiles/SecretHandler.java
@@ -24,6 +24,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -110,7 +111,7 @@ class SecretHandler {
                 super.characters(ch, start, length);
             }
         };
-        String str = FileUtils.readFileToString(xmlFile);
+        String str = FileUtils.readFileToString(xmlFile, Charset.defaultCharset());
         Source src = createSafeSource(xr, new InputSource(new StringReader(str)));
         final ByteArrayOutputStream result = new ByteArrayOutputStream();
         Result res = new StreamResult(result);

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
@@ -449,7 +449,7 @@ public class AboutJenkins extends Component {
                 if (w.isActive()) {
                     out.println("  * " + w.getShortName() + ":" + w.getVersion() + (w.hasUpdate()
                             ? " *(update available)*"
-                            : "") + " '" + w.getLongName() + "'");
+                            : "") + " '" + w.getDisplayName() + "'");
                 }
             }
             SupportPlugin supportPlugin = SupportPlugin.getInstance();

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
@@ -188,9 +188,7 @@ public class AboutJenkins extends Component {
                 justification = "Findbugs mis-diagnosing closeQuietly's built-in null check"
         )
         public String call() throws RuntimeException {
-            InputStream is = null;
-            try {
-                is = hudson.remoting.Channel.class.getResourceAsStream("/jenkins/remoting/jenkins-version.properties");
+            try (InputStream is = hudson.remoting.Channel.class.getResourceAsStream("/jenkins/remoting/jenkins-version.properties")) {
                 if (is == null) {
                     return "N/A";
                 }
@@ -201,8 +199,9 @@ public class AboutJenkins extends Component {
                 } catch (IOException e) {
                     return "N/A";
                 }
-            } finally {
-                IOUtils.closeQuietly(is);
+            } catch (IOException e) {
+                logger.fine(String.format("Could not find remoting version in agent {}", e.getMessage()));
+                return "N/A";
             }
         }
     }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
@@ -184,8 +184,8 @@ public class AboutJenkins extends Component {
         private static final long serialVersionUID = 1L;
 
         @SuppressFBWarnings(
-                value = "NP_LOAD_OF_KNOWN_NULL_VALUE",
-                justification = "Findbugs mis-diagnosing closeQuietly's built-in null check"
+                value = {"NP_LOAD_OF_KNOWN_NULL_VALUE", "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE", "RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE"},
+                justification = "{Findbugs mis-diagnosing closeQuietly's built-in null check, https://github.com/spotbugs/spotbugs/issues/756}"
         )
         public String call() throws RuntimeException {
             try (InputStream is = hudson.remoting.Channel.class.getResourceAsStream("/jenkins/remoting/jenkins-version.properties")) {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
@@ -130,7 +130,7 @@ public class AboutJenkins extends Component {
         container.add(new Dockerfile(activePlugins, disabledPlugins));
 
         container.add(new ControllerChecksumsContent());
-        for (final Node node : Jenkins.getInstance().getNodes()) {
+        for (final Node node : Jenkins.get().getNodes()) {
             container.add(new NodeChecksumsContent(node));
         }
     }
@@ -527,7 +527,7 @@ public class AboutJenkins extends Component {
 
         @Override
         protected void printTo(PrintWriter out) throws IOException {
-            PluginManager pluginManager = Jenkins.getInstance().getPluginManager();
+            PluginManager pluginManager = Jenkins.get().getPluginManager();
             List<PluginManager.FailedPlugin> plugins = pluginManager.getFailedPlugins();
             // no need to sort
             for (PluginManager.FailedPlugin w : plugins) {
@@ -561,7 +561,7 @@ public class AboutJenkins extends Component {
         @Override
         protected void printTo(PrintWriter out) throws IOException {
 
-            PluginManager pluginManager = Jenkins.getInstance().getPluginManager();
+            PluginManager pluginManager = Jenkins.get().getPluginManager();
             String fullVersion = Jenkins.VERSION;
             int s = fullVersion.indexOf(' ');
             if (s > 0 && fullVersion.contains("CloudBees")) {
@@ -726,7 +726,7 @@ public class AboutJenkins extends Component {
             super("nodes/master/checksums.md5");
         }
         @Override protected void printTo(PrintWriter out) throws IOException {
-            final Jenkins jenkins = Jenkins.getInstance();
+            final Jenkins jenkins = Jenkins.get();
             if (jenkins == null) {
                 // Lifecycle.get() depends on Jenkins instance, hence this method won't work in any case
                 throw new IOException("Jenkins has not been started, or was already shut down");
@@ -837,7 +837,7 @@ public class AboutJenkins extends Component {
      * @return new copy of the PluginManager.getPlugins sorted
      */
     private static Iterable<PluginWrapper> getPluginsSorted() {
-        PluginManager pluginManager = Jenkins.getInstance().getPluginManager();
+        PluginManager pluginManager = Jenkins.get().getPluginManager();
         return getPluginsSorted(pluginManager);
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutUser.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutUser.java
@@ -8,11 +8,12 @@ import com.cloudbees.jenkins.support.filter.ContentFilter;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.security.Permission;
-import org.acegisecurity.Authentication;
-import org.acegisecurity.GrantedAuthority;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 
@@ -49,7 +50,7 @@ public class AboutUser extends Component {
                     out.println();
                     out.println("  * Authenticated: " + authentication.isAuthenticated());
                     out.println("  * Name: " + ContentFilter.filter(filter, authentication.getName()));
-                    GrantedAuthority[] authorities = authentication.getAuthorities();
+                    Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
                     if (authorities != null) {
                         out.println("  * Authorities ");
                         for (GrantedAuthority authority : authorities) {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/BuildQueue.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/BuildQueue.java
@@ -70,7 +70,7 @@ public class BuildQueue extends Component {
         @Override
         public void printTo(PrintWriter out, ContentFilter filter) {
           try {
-            Queue.Item[] items = Jenkins.getInstance().getQueue().getItems();
+            Queue.Item[] items = Jenkins.get().getQueue().getItems();
             out.println("Current build queue has " +  items.length + " item(s).");
             out.println("---------------");
 
@@ -96,7 +96,7 @@ public class BuildQueue extends Component {
               out.println("----");
               out.println();
             }
-            out.println("Is quieting down: " + Jenkins.getInstance().isQuietingDown());
+            out.println("Is quieting down: " + Jenkins.get().isQuietingDown());
           } finally {
             out.flush();
           }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/CustomLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/CustomLogs.java
@@ -150,7 +150,7 @@ public class CustomLogs extends Component {
         @Override public void publish(LogRecord record) {
             for (final LogRecorder recorder : logRecorders) {
                 for (LogRecorder.Target target : recorder.getLoggers()) {
-                    if (target.includes(record)) {
+                    if (Boolean.TRUE.equals(target.matches(record))) {
                         String name = recorder.getName();
                         try {
                             LogFile logFile;

--- a/src/main/java/com/cloudbees/jenkins/support/impl/EnvironmentVariables.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/EnvironmentVariables.java
@@ -56,7 +56,7 @@ public class EnvironmentVariables extends Component {
                     @Override
                     protected void printTo(PrintWriter out) throws IOException {
                         try {
-                            Map<String, String> environmentVariables = getEnvironmentVariables(Jenkins.getInstance());
+                            Map<String, String> environmentVariables = getEnvironmentVariables(Jenkins.get());
                             for (Map.Entry<String, String> entry : PasswordRedactor.get().redact(environmentVariables).entrySet()) {
                                 out.println(entry.getKey() + "=" + entry.getValue());
                             }
@@ -66,7 +66,7 @@ public class EnvironmentVariables extends Component {
                     }
                 }
         );
-        for (final Node node : Jenkins.getInstance().getNodes()) {
+        for (final Node node : Jenkins.get().getNodes()) {
             result.add(
                     new PrintedContent("nodes/slave/{0}/environment.txt", node.getNodeName()) {
                         @Override

--- a/src/main/java/com/cloudbees/jenkins/support/impl/LoadStats.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/LoadStats.java
@@ -90,7 +90,7 @@ public class LoadStats extends Component {
      */
     @Override
     public void addContents(@NonNull Container container) {
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.get();
         add(container, "no-label", jenkins.unlabeledLoad);
         add(container, "overall", jenkins.overallLoad);
         for (Label l : jenkins.getLabels()) {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/NetworkInterfaces.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/NetworkInterfaces.java
@@ -79,7 +79,7 @@ public class NetworkInterfaces extends Component {
                 }
         );
 
-        for (final Node node : Jenkins.getInstance().getNodes()) {
+        for (final Node node : Jenkins.get().getNodes()) {
             result.add(
                     new Content("nodes/slave/{0}/networkInterface.md", node.getNodeName()) {
                         @Override

--- a/src/main/java/com/cloudbees/jenkins/support/impl/NodeMonitors.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/NodeMonitors.java
@@ -50,7 +50,7 @@ public class NodeMonitors extends Component{
                         }
                         if (!monitor.isIgnored()) {
                             out.println(" - Computers:");
-                            for (Computer c : Jenkins.getInstance().getComputers()) {
+                            for (Computer c : Jenkins.get().getComputers()) {
                                 out.println("   * " + ContentFilter.filter(filter, c.getDisplayName()) + ": " + monitor.data(c));
                             }
                         }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/RootCAs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/RootCAs.java
@@ -74,7 +74,7 @@ public class RootCAs extends Component {
 
   @Override
   public void addContents(@NonNull Container container) {
-    Jenkins j = Jenkins.getInstance();
+    Jenkins j = Jenkins.get();
     addContents(container, j);
     for (Node node : j.getNodes()) {
       addContents(container, node);

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SmartLogFetcher.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SmartLogFetcher.java
@@ -1,6 +1,7 @@
 package com.cloudbees.jenkins.support.impl;
 
 import com.cloudbees.jenkins.support.SupportPlugin;
+import com.cloudbees.jenkins.support.util.StreamUtils;
 import hudson.FilePath;
 import hudson.Util;
 import hudson.model.Node;
@@ -201,13 +202,7 @@ class SmartLogFetcher {
                 }
                 return Hex.encodeHexString(digest.digest());
             } finally {
-                if (stream != null) {
-                    try {
-                        stream.close();
-                    } catch (IOException e) {
-                        // ignore
-                    }
-                }
+                StreamUtils.closeQuietly(stream);
             }
         }
     }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SystemConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SystemConfiguration.java
@@ -44,6 +44,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -237,7 +238,7 @@ public abstract class SystemConfiguration extends AdvancedProcFilesRetriever {
                         sb.append(file.getName());
                         sb.append(": ");
                         try {
-                            sb.append(Util.loadFile(file).trim());
+                            sb.append(Util.loadFile(file, Charset.defaultCharset()).trim());
                         } catch (IOException e) {
                             sb.append("failed, " + e.getMessage());
                         }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SystemProperties.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SystemProperties.java
@@ -62,7 +62,7 @@ public class SystemProperties extends Component {
                        public void writeTo(OutputStream os) {
                            try {
                                Properties properties = new SortedProperties();
-                               Map<Object, Object> systemProperties = RemotingDiagnostics.getSystemProperties(Jenkins.getInstance().getChannel());
+                               Map<Object, Object> systemProperties = RemotingDiagnostics.getSystemProperties(Jenkins.get().getChannel());
                                Map<String, String> redactedProperties = PasswordRedactor.get().redact(systemProperties.entrySet().stream()
                                        .collect(Collectors.toMap(e -> (String) e.getKey(), e -> (String) e.getValue())));
                                properties.putAll(redactedProperties);
@@ -73,7 +73,7 @@ public class SystemProperties extends Component {
                        }
                    }
         );
-        for (final Node node : Jenkins.getInstance().getNodes()) {
+        for (final Node node : Jenkins.get().getNodes()) {
             result.add(
                     new Content("nodes/slave/{0}/system.properties", node.getNodeName()) {
                         @Override

--- a/src/main/java/com/cloudbees/jenkins/support/slowrequest/SlowRequestChecker.java
+++ b/src/main/java/com/cloudbees/jenkins/support/slowrequest/SlowRequestChecker.java
@@ -16,6 +16,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Optional;
@@ -58,7 +59,7 @@ public class SlowRequestChecker extends PeriodicWork {
     @Inject
     Jenkins jenkins;
 
-    final FileListCap logs = new FileListCap(new File(Jenkins.getInstance().getRootDir(),"slow-requests"), 50);
+    final FileListCap logs = new FileListCap(new File(Jenkins.get().getRootDir(),"slow-requests"), 50);
 
     final SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd-HHmmss.SSS");
     {
@@ -103,7 +104,7 @@ public class SlowRequestChecker extends PeriodicWork {
                         w = new PrintWriter(req.record,"UTF-8");
                         req.writeHeader(w, contentFilter);
                     } else {
-                        w = new PrintWriter(new OutputStreamWriter(new FileOutputStream(req.record,true),"UTF-8"));
+                        w = new PrintWriter(new OutputStreamWriter(new FileOutputStream(req.record,true), StandardCharsets.UTF_8));
                         logs.touch(req.record);
                     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/slowrequest/SlowRequestChecker.java
+++ b/src/main/java/com/cloudbees/jenkins/support/slowrequest/SlowRequestChecker.java
@@ -4,6 +4,7 @@ import com.cloudbees.jenkins.support.SupportPlugin;
 import com.cloudbees.jenkins.support.filter.ContentFilter;
 import com.cloudbees.jenkins.support.timer.FileListCap;
 import com.cloudbees.jenkins.support.timer.FileListCapComponent;
+import com.cloudbees.jenkins.support.util.StreamUtils;
 import com.google.inject.Inject;
 import hudson.Extension;
 import hudson.model.PeriodicWork;
@@ -126,9 +127,7 @@ public class SlowRequestChecker extends PeriodicWork {
                         }
                     }
                 } finally {
-                    if (w != null) {
-                        w.close();
-                    }
+                    StreamUtils.closeQuietly(w);
                 }
             }
         }

--- a/src/main/java/com/cloudbees/jenkins/support/slowrequest/SlowRequestChecker.java
+++ b/src/main/java/com/cloudbees/jenkins/support/slowrequest/SlowRequestChecker.java
@@ -7,7 +7,6 @@ import com.cloudbees.jenkins.support.timer.FileListCapComponent;
 import com.google.inject.Inject;
 import hudson.Extension;
 import hudson.model.PeriodicWork;
-import hudson.util.IOUtils;
 import jenkins.model.Jenkins;
 
 import java.io.File;
@@ -127,7 +126,9 @@ public class SlowRequestChecker extends PeriodicWork {
                         }
                     }
                 } finally {
-                    IOUtils.closeQuietly(w);
+                    if (w != null) {
+                        w.close();
+                    }
                 }
             }
         }

--- a/src/main/java/com/cloudbees/jenkins/support/slowrequest/SlowRequestFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/slowrequest/SlowRequestFilter.java
@@ -50,7 +50,7 @@ public class SlowRequestFilter implements Filter {
 
     @Initializer
     public static void init() throws ServletException {
-        Injector inj = Jenkins.getInstance().getInjector();
+        Injector inj = Jenkins.get().getInjector();
         if (inj == null) {
             return;
         }

--- a/src/main/java/com/cloudbees/jenkins/support/threaddump/HighLoadCpuChecker.java
+++ b/src/main/java/com/cloudbees/jenkins/support/threaddump/HighLoadCpuChecker.java
@@ -82,7 +82,7 @@ public class HighLoadCpuChecker extends PeriodicWork {
     /**
      * Thread dumps generated on high CPU load are stored in $JENKINS_HOME/high-load/cpu
      **/
-    protected final FileListCap logs = new FileListCap(new File(Jenkins.getInstance().getRootDir(),"high-load/cpu"), HIGH_CPU_THREAD_DUMPS_TO_RETAIN);
+    protected final FileListCap logs = new FileListCap(new File(Jenkins.get().getRootDir(),"high-load/cpu"), HIGH_CPU_THREAD_DUMPS_TO_RETAIN);
 
     private final SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd-HHmmss.SSS");
     {

--- a/src/main/java/com/cloudbees/jenkins/support/timer/DeadlockTrackChecker.java
+++ b/src/main/java/com/cloudbees/jenkins/support/timer/DeadlockTrackChecker.java
@@ -28,7 +28,7 @@ public class DeadlockTrackChecker extends PeriodicWork {
     {
         format.setTimeZone(TimeZone.getTimeZone("UTC"));
     }
-    final FileListCap logs = new FileListCap(new File(Jenkins.getInstance().getRootDir(),"deadlocks"), 50);
+    final FileListCap logs = new FileListCap(new File(Jenkins.get().getRootDir(),"deadlocks"), 50);
 
     @Override
     public long getRecurrencePeriod() {

--- a/src/main/java/com/cloudbees/jenkins/support/util/StreamUtils.java
+++ b/src/main/java/com/cloudbees/jenkins/support/util/StreamUtils.java
@@ -28,7 +28,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.logging.Logger;
 
 /**
  * Utility methods for handling files.
@@ -73,5 +76,19 @@ public final class StreamUtils {
     private static boolean isNonWhitespaceControlCharacter(byte b) {
         char c = (char) (b & 0xff);
         return Character.isISOControl(c) && c != '\t' && c != '\n' && c != '\r' && c != '\0';
+    }
+
+    /**
+     * Close resources quietly.
+     * 
+     * @param closeable the {@link Closeable}
+     */
+    public static void closeQuietly(Closeable closeable) {
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (IOException ignored) {
+            }
+        }
     }
 }

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -1,0 +1,7 @@
+<FindBugsFilter>
+    
+    <Match>
+        <Class name="~.*\.Messages"/>
+    </Match>
+    
+</FindBugsFilter>

--- a/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
@@ -321,7 +321,7 @@ public class SupportActionTest {
         j.createSlave("agent1","test",null).getComputer().connect(false).get();
         j.createSlave("agent2","test",null).getComputer().connect(false).get();
 
-        RingBufferLogHandler checker = new RingBufferLogHandler();
+        RingBufferLogHandler checker = new RingBufferLogHandler(256);
         Logger logger = Logger.getLogger(SupportPlugin.class.getPackage().getName());
 
         logger.addHandler(checker);

--- a/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
@@ -25,7 +25,6 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -63,6 +62,7 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -72,9 +72,6 @@ import static org.junit.Assert.fail;
 public class SupportActionTest {
     @Rule
     public JenkinsRule j = new JenkinsRule();
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Rule
     public TemporaryFolder temp = new TemporaryFolder();
@@ -285,9 +282,9 @@ public class SupportActionTest {
     }
 
     @Test
-    public void generateBundleFailsWhenNoParameter() throws IOException, SAXException {
-        exceptionRule.expectMessage(startsWith("Server returned HTTP response code: 400 for URL:"));
-        downloadBundle("/generateBundle");
+    public void generateBundleFailsWhenNoParameter() {
+        Exception exception = assertThrows(IOException.class, () -> downloadBundle("/generateBundle"));
+        assertThat(exception.getMessage(), startsWith("Server returned HTTP response code: 400 for URL:"));
     }
 
     @Test

--- a/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
@@ -55,6 +55,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.ZipFile;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
@@ -62,7 +63,6 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/src/test/java/com/cloudbees/jenkins/support/api/FileContentTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/api/FileContentTest.java
@@ -30,6 +30,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.nio.charset.Charset;
 
 import static org.junit.Assert.assertEquals;
 
@@ -39,7 +40,7 @@ public class FileContentTest {
 
     @Test public void truncation() throws Exception {
         File f = tmp.newFile();
-        FileUtils.writeStringToFile(f, "hello world\n");
+        FileUtils.writeStringToFile(f, "hello world\n", Charset.defaultCharset());
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         new FileContent("-", f).writeTo(baos);

--- a/src/test/java/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponentTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponentTest.java
@@ -4,6 +4,13 @@ import com.cloudbees.jenkins.support.api.Container;
 import com.cloudbees.jenkins.support.api.Content;
 import com.cloudbees.plugins.credentials.SecretBytes;
 import hudson.util.Secret;
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.nio.file.Files;
@@ -12,15 +19,14 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
-import org.apache.commons.io.FileUtils;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.LoggerRule;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class OtherConfigFilesComponentTest {
 

--- a/src/test/java/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponentTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponentTest.java
@@ -13,6 +13,7 @@ import org.jvnet.hudson.test.LoggerRule;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.text.MessageFormat;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class OtherConfigFilesComponentTest {
     @Test
     public void shouldPutAPlaceHolderInsteadOfSecret() throws Exception {
         File file = File.createTempFile("test", ".xml");
-        FileUtils.writeStringToFile(file, xml);
+        FileUtils.writeStringToFile(file, xml, Charset.defaultCharset());
         String patchedXml = SecretHandler.findSecrets(file);
         assertThat(patchedXml, equalToCompressingWhiteSpace(expectedXml));
     }
@@ -110,7 +111,7 @@ public class OtherConfigFilesComponentTest {
     @Test
     public void missingFile() throws Exception {
         File file = new File(j.jenkins.root, "x.xml");
-        FileUtils.writeStringToFile(file, xml);
+        FileUtils.writeStringToFile(file, xml, Charset.defaultCharset());
         Map<String, Content> contents = new HashMap<>();
         new OtherConfigFilesComponent().addContents(new Container() {
             @Override

--- a/src/test/java/com/cloudbees/jenkins/support/configfiles/SecretHandlerTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/configfiles/SecretHandlerTest.java
@@ -10,6 +10,7 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.File;
+import java.nio.charset.Charset;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
@@ -62,7 +63,7 @@ public class SecretHandlerTest {
     @Test
     public void shouldPutAPlaceHolderInsteadOfSecret() throws Exception {
         File file = File.createTempFile("test", ".xml");
-        FileUtils.writeStringToFile(file, xml);
+        FileUtils.writeStringToFile(file, xml, Charset.defaultCharset());
         String patchedXml = SecretHandler.findSecrets(file);
         String expectedXml = "<com.cloudbees.plugins.credentials.SystemCredentialsProvider plugin=\"credentials@1.18\">\n" +
                 "    <domainCredentialsMap class=\"hudson.util.CopyOnWriteMap$Hash\">\n" +
@@ -101,7 +102,7 @@ public class SecretHandlerTest {
                 "]>\n" +
                 "<xxx>&xxeattack;</xxx>";
         File file = File.createTempFile("test", ".xml");
-        FileUtils.writeStringToFile(file, xxeXml);
+        FileUtils.writeStringToFile(file, xxeXml, Charset.defaultCharset());
         String redactedXxeXml = SecretHandler.findSecrets(file);
         // Either the XML library understands the XXE disabling features, and removes XXEs completely,
         // or our custom EntityResolver is used which replaces them with a placeholder.

--- a/src/test/java/com/cloudbees/jenkins/support/configfiles/SecretHandlerTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/configfiles/SecretHandlerTest.java
@@ -11,10 +11,10 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.File;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 public class SecretHandlerTest {
 

--- a/src/test/java/com/cloudbees/jenkins/support/filter/ContentMappingsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/filter/ContentMappingsTest.java
@@ -42,13 +42,13 @@ import java.util.Set;
 import java.util.stream.StreamSupport;
 
 import static java.util.stream.Collectors.toList;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInRelativeOrder;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class ContentMappingsTest {

--- a/src/test/java/com/cloudbees/jenkins/support/impl/AbstractItemComponentTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/AbstractItemComponentTest.java
@@ -14,8 +14,10 @@ import org.jvnet.hudson.test.MockFolder;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class AbstractItemComponentTest {
 

--- a/src/test/java/com/cloudbees/jenkins/support/impl/BuildQueueTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/BuildQueueTest.java
@@ -42,9 +42,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItems;
-import static org.junit.Assert.assertThat;
 
 /**
  * @author schristou88

--- a/src/test/java/com/cloudbees/jenkins/support/impl/CustomLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/CustomLogsTest.java
@@ -23,8 +23,8 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class CustomLogsTest {

--- a/src/test/java/com/cloudbees/jenkins/support/impl/DumpExportTableTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/DumpExportTableTest.java
@@ -13,11 +13,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 
 public class DumpExportTableTest {
 

--- a/src/test/java/com/cloudbees/jenkins/support/impl/NetworkInterfacesTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/NetworkInterfacesTest.java
@@ -12,8 +12,8 @@ import java.io.IOException;
 import java.net.NetworkInterface;
 import java.util.Enumeration;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertThat;
 
 public class NetworkInterfacesTest {
 

--- a/src/test/java/com/cloudbees/jenkins/support/impl/RootCAsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/RootCAsTest.java
@@ -4,8 +4,8 @@ import org.junit.Test;
 
 import java.io.StringWriter;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertThat;
 
 public class RootCAsTest {
 

--- a/src/test/java/com/cloudbees/jenkins/support/impl/RunDirectoryComponentTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/RunDirectoryComponentTest.java
@@ -15,7 +15,9 @@ import org.jvnet.hudson.test.JenkinsRule;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class RunDirectoryComponentTest {
 

--- a/src/test/java/com/cloudbees/jenkins/support/impl/RunningBuildsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/RunningBuildsTest.java
@@ -25,9 +25,9 @@ import org.jvnet.hudson.test.TestBuilder;
 
 import java.util.Optional;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
 
 public class RunningBuildsTest {
 

--- a/src/test/java/com/cloudbees/jenkins/support/impl/SlaveCommandStatisticsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/SlaveCommandStatisticsTest.java
@@ -32,19 +32,23 @@ import hudson.model.FreeStyleProject;
 import hudson.remoting.VirtualChannel;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.SlaveComputer;
-import java.io.File;
-import java.io.IOException;
-import java.util.logging.Level;
 import jenkins.MasterToSlaveFileCallable;
-import org.junit.Test;
 import org.junit.Rule;
+import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.TestBuilder;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import java.io.File;
+import java.io.IOException;
+import java.util.logging.Level;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 
 public class SlaveCommandStatisticsTest {
 

--- a/src/test/java/com/cloudbees/jenkins/support/impl/TaskLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/TaskLogsTest.java
@@ -19,8 +19,8 @@ import java.nio.file.Files;
 import java.util.Collections;
 import java.util.Objects;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class TaskLogsTest {

--- a/src/test/java/com/cloudbees/jenkins/support/timer/DeadlockTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/timer/DeadlockTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.File;
+import java.nio.charset.Charset;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -104,7 +105,7 @@ public class DeadlockTest {
                 files = new File(j.getInstance().getRootDir(), "/deadlocks").listFiles();
                 assertNotNull("There should be at least one deadlock file", files);
                 assertThat("A deadlock was detected and a new deadlock file created", files.length, greaterThan(initialCount));
-                String text = FileUtils.readFileToString(files[initialCount]);
+                String text = FileUtils.readFileToString(files[initialCount], Charset.defaultCharset());
                 assertThat(text, containsString("secondMethod"));
                 assertThat(text, containsString("firstMethod"));
             } finally {

--- a/src/test/java/com/cloudbees/jenkins/support/timer/DeadlockTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/timer/DeadlockTest.java
@@ -109,10 +109,10 @@ public class DeadlockTest {
                 assertThat(text, containsString("secondMethod"));
                 assertThat(text, containsString("firstMethod"));
             } finally {
-                t2.stop();
+                t2.interrupt();
             }
         } finally {
-            t1.stop();
+            t1.interrupt();
         }
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/support/timer/DeadlockTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/timer/DeadlockTest.java
@@ -30,10 +30,10 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.File;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 
 /**
  * @author schristou88


### PR DESCRIPTION
Addresses most of the current API deprecated usages:

main:

* `Jenkins.getInstance()` -> `Jenkins.get()`
* `IOUtils.closeQuitely()` -> Try with resources or explicit `close()`
* `LogRecorder.includes` -> `LogRecorder.matches`
* Pass default charset in `FileUtils.readFileToString` / `FileUtils.writeFileToString`
* `Plugin.logger` -> uses own logger in `SupportPlugin`

tests:

* `org.junit.Assert.assertThat` -> `org.hamcrest.MatcherAssert.assertThat`
* `Thread.stop` -> `Thread.interrupt` (used in tests)
* `ExpectedException.none()` -> `assertThrows` with lambda
* Pass a size to `RingBufferLogHandler` constructor


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue