### PR TITLE
`SupportLogHandler.records` could leak memory

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportLogHandler.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportLogHandler.java
@@ -211,7 +211,7 @@ public class SupportLogHandler extends Handler {
             for (int i = 0; i < count; i++) {
                 LogRecord lr = records[(position + i) % records.length].get();
                 if (lr != null) {
-                    result.add(i, lr);
+                    result.add(lr);
                 }
             }
             return result;


### PR DESCRIPTION
As discovered in https://github.com/jenkinsci/bom/pull/644#issuecomment-985156639 it seems that the ring buffer could hold a strong ref to `LogRecord.parameters` for recently logged messages, including things like

```
FINER	o.j.p.w.cps.CpsFlowExecution#cleanUpLoader: ignoring org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxResolvingClassLoader@…
```

which really ought to have been collected.

Eagerly formatting the records is not a good option for these sub-`INFO` messages which might otherwise never be formatted, so the most straightforward fix seems to be to use `SoftReference` to offer these records most of the time to https://github.com/jenkinsci/support-core-plugin/blob/bb61a87442c7d5ea391214bd97cd71edb422e8d7/src/main/java/com/cloudbees/jenkins/support/SupportLogHandler.java#L199 callers, if any, without forcing them to be held.