### PR TITLE
[JENKINS-64558] Sort existing bundles in `/support/`

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
@@ -59,6 +59,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -141,7 +142,7 @@ public class SupportAction implements RootAction, StaplerProxy {
                 res.add(bundleFile.getName());
             }
         }
-
+        Collections.sort(res);
         return res;
     }
 


### PR DESCRIPTION
Currently this page can list dozens of existing support bundles, in totally random order, making it very hard to find (for example) the most recent one, or one taken just before some known outage.
