### PR TITLE
Skip old log files

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/TaskLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/TaskLogs.java
@@ -3,6 +3,7 @@ package com.cloudbees.jenkins.support.impl;
 import com.cloudbees.jenkins.support.api.Component;
 import com.cloudbees.jenkins.support.api.Container;
 import com.cloudbees.jenkins.support.api.FileContent;
+import com.cloudbees.jenkins.support.timer.FileListCapComponent;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.security.Permission;
@@ -12,7 +13,6 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 import static com.cloudbees.jenkins.support.impl.JenkinsLogs.ROTATED_LOGFILE_FILTER;
 
@@ -58,7 +58,7 @@ public class TaskLogs extends Component {
                 File[] files = logs.listFiles(ROTATED_LOGFILE_FILTER);
                 if (files != null) {
                     Arrays.sort(files);
-                    long recently = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(90);
+                    long recently = System.currentTimeMillis() - FileListCapComponent.MAX_LOG_FILE_AGE_MS;
                     for (File f : files) {
                         if (f.lastModified() > recently) {
                             result.add(new FileContent("task-logs/{0}", new String[] {f.getName()}, f));

--- a/src/main/java/com/cloudbees/jenkins/support/impl/TaskLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/TaskLogs.java
@@ -9,8 +9,10 @@ import hudson.security.Permission;
 import jenkins.model.Jenkins;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static com.cloudbees.jenkins.support.impl.JenkinsLogs.ROTATED_LOGFILE_FILTER;
 
@@ -51,19 +53,17 @@ public class TaskLogs extends Component {
     private void addControllerTasksLogs(Container result) {
         Jenkins jenkins = Jenkins.getInstanceOrNull();
         if (jenkins != null) {
-            File logs = getLogsRoot();
-            File[] files = logs.listFiles(ROTATED_LOGFILE_FILTER);
-            if (files != null) {
-                for (File f : files) {
-                    result.add(new FileContent("task-logs/{0}", new String[]{f.getName()}, f));
-                }
-            }
-
-            File taskLogs = new File(logs, "tasks");
-            files = taskLogs.listFiles(ROTATED_LOGFILE_FILTER);
-            if (files != null) {
-                for (File f : files) {
-                    result.add(new FileContent("task-logs/{0}", new String[]{f.getName()}, f));
+            File logsRoot = getLogsRoot();
+            for (File logs : new File[] {logsRoot, new File(logsRoot, "tasks")}) {
+                File[] files = logs.listFiles(ROTATED_LOGFILE_FILTER);
+                if (files != null) {
+                    Arrays.sort(files);
+                    long recently = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(90);
+                    for (File f : files) {
+                        if (f.lastModified() > recently) {
+                            result.add(new FileContent("task-logs/{0}", new String[] {f.getName()}, f));
+                        }
+                    }
                 }
             }
         }

--- a/src/main/java/com/cloudbees/jenkins/support/timer/FileListCapComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/timer/FileListCapComponent.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 /**
  * {@link Component} that attaches files inside {@link FileListCap} into a support bundle.
@@ -22,6 +23,12 @@ public abstract class FileListCapComponent extends Component {
 
     /** Maximum file size to pack is 2Mb. */
     public static final int MAX_FILE_SIZE = 2 * 1000000;
+
+    /**
+     * Maximum age (in milliseconds) of log files we would bother including in a bundle.
+     * Anything older is likely no longer relevant.
+     */
+    public static final long MAX_LOG_FILE_AGE_MS = TimeUnit.DAYS.toMillis(90);
 
     @NonNull
     @Override
@@ -36,8 +43,11 @@ public abstract class FileListCapComponent extends Component {
 
             final Collection<File> files = FileUtils.listFiles(
                     fileListCap.getFolder(), new String[] {"txt"}, false);
+            long recently = System.currentTimeMillis() - MAX_LOG_FILE_AGE_MS;
             for (File f : files) {
-                container.add(new FileContent("{0}/{1}", new String[]{fileListCap.getFolder().getName(), f.getName()}, f, MAX_FILE_SIZE));
+                if (f.lastModified() > recently) {
+                    container.add(new FileContent("{0}/{1}", new String[]{fileListCap.getFolder().getName(), f.getName()}, f, MAX_FILE_SIZE));
+                }
             }
         }
     }

--- a/src/main/java/com/cloudbees/jenkins/support/timer/UnfilteredFileListCapComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/timer/UnfilteredFileListCapComponent.java
@@ -9,9 +9,11 @@ import jenkins.model.Jenkins;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
-import java.util.Collection;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 /**
  * {@link Component} that attaches files inside {@link FileListCap} into a support bundle without filtering the
@@ -35,10 +37,14 @@ public abstract class UnfilteredFileListCapComponent extends Component {
             // while we read and put the reports into the support bundle, we don't want
             // the FileListCap to delete files. So we lock it.
 
-            final Collection<File> files = FileUtils.listFiles(
-                    fileListCap.getFolder(), new String[] {"txt"}, false);
+            final List<File> files = new ArrayList<>(FileUtils.listFiles(
+                    fileListCap.getFolder(), new String[] {"txt"}, false));
+            Collections.sort(files);
+            long recently = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(90);
             for (File f : files) {
-                container.add(new UnfilteredFileContent("{0}/{1}", new String[]{fileListCap.getFolder().getName(), f.getName()}, f, MAX_FILE_SIZE));
+                if (f.lastModified() > recently) {
+                    container.add(new UnfilteredFileContent("{0}/{1}", new String[]{fileListCap.getFolder().getName(), f.getName()}, f, MAX_FILE_SIZE));
+                }
             }
         }
     }

--- a/src/main/java/com/cloudbees/jenkins/support/timer/UnfilteredFileListCapComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/timer/UnfilteredFileListCapComponent.java
@@ -13,7 +13,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 /**
  * {@link Component} that attaches files inside {@link FileListCap} into a support bundle without filtering the
@@ -22,9 +21,6 @@ import java.util.concurrent.TimeUnit;
  * @author stevenchristou
  */
 public abstract class UnfilteredFileListCapComponent extends Component {
-
-    /** Maximum file size to pack is 2Mb. */
-    public static final int MAX_FILE_SIZE = 2 * 1000000;
 
     @NonNull
     @Override
@@ -40,10 +36,10 @@ public abstract class UnfilteredFileListCapComponent extends Component {
             final List<File> files = new ArrayList<>(FileUtils.listFiles(
                     fileListCap.getFolder(), new String[] {"txt"}, false));
             Collections.sort(files);
-            long recently = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(90);
+            long recently = System.currentTimeMillis() - FileListCapComponent.MAX_LOG_FILE_AGE_MS;
             for (File f : files) {
                 if (f.lastModified() > recently) {
-                    container.add(new UnfilteredFileContent("{0}/{1}", new String[]{fileListCap.getFolder().getName(), f.getName()}, f, MAX_FILE_SIZE));
+                    container.add(new UnfilteredFileContent("{0}/{1}", new String[]{fileListCap.getFolder().getName(), f.getName()}, f, FileListCapComponent.MAX_FILE_SIZE));
                 }
             }
         }


### PR DESCRIPTION
Was frustrated to look through a support bundle containing lots of file entries dating as far back as 2018:

* `deadlocks/DeadlockDetected-20181128-124111.txt`
* `task-logs/cloudbees-devoptics-deliver-authentication.log`

Also sorting these files for legibility.

**Untested.**
