### PR TITLE
Fix LogRecorder usage for newer core versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,17 +204,6 @@
       <artifactId>cloudbees-folder</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>io.jenkins.plugins</groupId>
-      <artifactId>javax-mail-api</artifactId>
-      <version>1.6.2-5</version>
-    </dependency>
-    <dependency>
-      <groupId>io.jenkins.plugins</groupId>
-      <artifactId>javax-activation-api</artifactId>
-      <version>1.2.0-2</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.31</version>
+    <version>4.36</version>
     <relativePath />
   </parent>
 
@@ -71,7 +71,7 @@
   <properties>
     <revision>2.81</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.222.4</jenkins.version>
+    <jenkins.version>2.332</jenkins.version>
     <java.level>8</java.level>
   </properties>
 
@@ -92,8 +92,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.222.x</artifactId>
-        <version>887.vae9c8ac09ff7</version>
+        <artifactId>bom-2.332.x</artifactId>
+        <version>1155.v77b_fd92a_26fc</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -203,6 +203,17 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>cloudbees-folder</artifactId>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>javax-mail-api</artifactId>
+      <version>1.6.2-5</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>javax-activation-api</artifactId>
+      <version>1.2.0-2</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
   <properties>
     <revision>2.81</revision>
     <changelist>-SNAPSHOT</changelist>
+    <!-- TODO use the 2.332.1 LTS once released -->
     <jenkins.version>2.332</jenkins.version>
     <java.level>8</java.level>
   </properties>

--- a/src/test/java/com/cloudbees/jenkins/support/impl/CustomLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/CustomLogsTest.java
@@ -10,6 +10,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ExtensionList;
 import hudson.logging.LogRecorder;
 import hudson.security.Permission;
+import java.io.IOException;
 import jenkins.model.Jenkins;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
@@ -39,12 +40,13 @@ public class CustomLogsTest {
     }
 
     @Test
-    public void testCustomLogsContent() {
+    public void testCustomLogsContent() throws InterruptedException, IOException {
         LogRecorder testLogRecorder = new LogRecorder("test");
         LogRecorder.Target testTarget = new LogRecorder.Target(CustomLogsTest.class.getName(), Level.FINER);
-        testLogRecorder.targets.add(testTarget);
-        j.getInstance().getLog().logRecorders.put("test", testLogRecorder);
+        testLogRecorder.getLoggers().add(testTarget);
+        j.getInstance().getLog().getRecorders().add(testLogRecorder);
         testTarget.enable();
+        testLogRecorder.save();
         SupportTestUtils.invokeComponentToString(new Component() {
 
             @NonNull
@@ -64,8 +66,7 @@ public class CustomLogsTest {
                 Logger.getLogger(CustomLogsTest.class.getName()).fine("Testing custom log recorders");
             }
         });
-        String customLogs = SupportTestUtils.invokeComponentToString(
-                Objects.requireNonNull(ExtensionList.lookup(Component.class).get(CustomLogs.class)));
+        String customLogs = SupportTestUtils.invokeComponentToString(Objects.requireNonNull(ExtensionList.lookup(Component.class).get(CustomLogs.class)));
         assertFalse("Should write CustomLogsTest FINE logs", customLogs.isEmpty());
         assertThat(customLogs , Matchers.containsString("Testing custom log recorders"));
     }

--- a/src/test/java/com/cloudbees/jenkins/support/impl/CustomLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/CustomLogsTest.java
@@ -40,7 +40,7 @@ public class CustomLogsTest {
     }
 
     @Test
-    public void testCustomLogsContent() throws InterruptedException, IOException {
+    public void testCustomLogsContent() throws IOException {
         LogRecorder testLogRecorder = new LogRecorder("test");
         LogRecorder.Target testTarget = new LogRecorder.Target(CustomLogsTest.class.getName(), Level.FINER);
         testLogRecorder.getLoggers().add(testTarget);

--- a/src/test/java/com/cloudbees/jenkins/support/impl/CustomLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/CustomLogsTest.java
@@ -66,7 +66,8 @@ public class CustomLogsTest {
                 Logger.getLogger(CustomLogsTest.class.getName()).fine("Testing custom log recorders");
             }
         });
-        String customLogs = SupportTestUtils.invokeComponentToString(Objects.requireNonNull(ExtensionList.lookup(Component.class).get(CustomLogs.class)));
+        String customLogs = SupportTestUtils.invokeComponentToString(
+                Objects.requireNonNull(ExtensionList.lookup(Component.class).get(CustomLogs.class)));
         assertFalse("Should write CustomLogsTest FINE logs", customLogs.isEmpty());
         assertThat(customLogs , Matchers.containsString("Testing custom log recorders"));
     }


### PR DESCRIPTION
There is some issues on migration code from https://github.com/jenkinsci/jenkins/pull/4538 see https://github.com/jenkinsci/github-branch-source-plugin/pull/485 for full details.

This PR updates the plugin usages of affected code to make it work again and updates the baseline. Issues can be demonstrated by `mvn test -Djenkins.version=2.332.1-cb-3 -Dtest=CustomLogsTest#testCustomLogsContent -Denforcer.skip -Daccess-modifier-checker.skip` 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
