### PR TITLE
[JENKINS-67940] Fix retrieval of rotated JDK 9+ GC logs

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
@@ -31,11 +31,13 @@ import java.util.regex.Pattern;
 @Extension(ordinal = 90.0) // probably big too, see JenkinsLogs
 public class GCLogs extends Component {
 
+    //TODO: Remove the JDK 8 part after the June 2022 LTS that drop support for JDK 8
     static final String GCLOGS_JRE_SWITCH = "-Xloggc:";
     static final String GCLOGS_JRE9_SWITCH = "-Xlog:gc";
     // We need (?:[a-zA-Z]\:\\)? to handle Windows disk drive 
     static final String GCLOGS_JRE9_LOCATION = ".*:file=[\"]?(?<location>(?:[a-zA-Z]:\\\\)?[^\":]*).*";
     static final String GCLOGS_ROTATION_SWITCH = "-XX:+UseGCLogFileRotation";
+    static final String GCLOGS_JRE9_ROTATION_SWITCH = ".*filecount=0.*";
 
     private static final String GCLOGS_RETENTION_PROPERTY = GCLogs.class.getName() + ".retention";
 
@@ -112,7 +114,7 @@ public class GCLogs extends Component {
      * <li>or that feature is not used, then we simply match by "starts with"</li>
      * </ul>
      *
-     * @param gcLogFileLocation the specified value after <code>-Xloggc:</code>
+     * @param gcLogFileLocation the specified value within <code>-Xlog:gc.*:file=[filename]:.*</code> for JDK 9+ or after <code>-Xloggc:[filename]</code> for JDK 8 
      * @param result            the container where to add the found logs, if any.
      * @see https://bugs.openjdk.java.net/browse/JDK-7164841
      */
@@ -184,7 +186,7 @@ public class GCLogs extends Component {
      * Returns if the file passed in should be considered following the retention  @{link GCLOGS_RETENTION_DAYS}
      * configured.
      * @param gcLog the file
-     * @return true if the the file should be considered
+     * @return true if the file should be considered
      */
     private boolean shouldConsiderFile(File gcLog) {
         return GCLOGS_RETENTION_DAYS <= 0 || 
@@ -192,7 +194,13 @@ public class GCLogs extends Component {
     }
 
     public boolean isGcLogRotationConfigured() {
-        return isJava8OrBelow() && vmArgumentFinder.findVmArgument(GCLOGS_ROTATION_SWITCH) != null;
+        if (isJava8OrBelow()) {
+            return vmArgumentFinder.findVmArgument(GCLOGS_ROTATION_SWITCH) != null;
+        } else {
+            // JDK 9 and -Xlog:gc rotation is defaulted to 5 files and only disabled if filecount=0 is set
+            String gcLogSwitch = vmArgumentFinder.findVmArgument(GCLOGS_JRE9_SWITCH);
+            return gcLogSwitch != null && !Pattern.compile(GCLOGS_JRE9_ROTATION_SWITCH).matcher(gcLogSwitch).find();
+        }
     }
 
     /**
@@ -211,12 +219,8 @@ public class GCLogs extends Component {
     protected static class VmArgumentFinder {
         @CheckForNull
         public String findVmArgument(String argName) {
-            for (String argument : ManagementFactory.getRuntimeMXBean().getInputArguments()) {
-                if (argument.startsWith(argName)) {
-                    return argument;
-                }
-            }
-            return null;
+            return ManagementFactory.getRuntimeMXBean().getInputArguments().stream()
+                .filter(arg -> arg.startsWith(argName)).findFirst().orElse(null);
         }
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/support/impl/GCLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/GCLogsTest.java
@@ -57,12 +57,12 @@ public class GCLogsTest {
         } else {
 
             when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file="
-                + tempDir.getAbsolutePath() + File.separator + "gc.log.%p" + ":filecount=10,filesize=50m");
+                + tempDir.getAbsolutePath() + File.separator + "gc.log" + ":filecount=10,filesize=50m");
             assertContentWithFinderContainsFiles(finder, 5);
             
             // The file locations may be wrapped with quotes
             when(finder.findVmArgument(GCLogs.GCLOGS_JRE9_SWITCH)).thenReturn(GCLogs.GCLOGS_JRE9_SWITCH + "*:file=\""
-                + tempDir.getAbsolutePath() + File.separator + "gc.log.%p\":filecount=10,filesize=50m");
+                + tempDir.getAbsolutePath() + File.separator + "gc.log\":filecount=10,filesize=50m");
         }
         assertContentWithFinderContainsFiles(finder, 5);
     }
@@ -71,10 +71,10 @@ public class GCLogsTest {
     public void parameterizedFiles() throws Exception {
         File tempDir = Files.createTempDir();
         for (int count = 0; count < 5; count++) {
-            Files.touch(new File(tempDir, "gc." + System.currentTimeMillis() + ".1423.log." + count));
+            Files.touch(new File(tempDir, "gc." + System.nanoTime() + ".1423.log"));
         }
         for (int count = 0; count < 3; count++) {
-            Files.touch(new File(tempDir, "gc." + System.currentTimeMillis() + ".2534.log." + count));
+            Files.touch(new File(tempDir, "gc." + System.nanoTime() + ".2534.log"));
         }
         GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
 
@@ -96,10 +96,10 @@ public class GCLogsTest {
     public void parameterizedAndRotatedFiles() throws Exception {
         File tempDir = Files.createTempDir();
         for (int count = 0; count < 10; count++) {
-            Files.touch(new File(tempDir, "gc5625.log." + count));
+            Files.touch(new File(tempDir, "gc." + System.nanoTime() + ".5625.log." + count));
         }
         for (int count = 0; count < 5; count++) {
-            Files.touch(new File(tempDir, "gc3421.log." + count));
+            Files.touch(new File(tempDir, "gc." + System.nanoTime() + ".3421.log." + count));
         }
         GCLogs.VmArgumentFinder finder = mock(GCLogs.VmArgumentFinder.class);
 


### PR DESCRIPTION
[JENKINS-67940](https://issues.jenkins.io/browse/JENKINS-67940)

Log rotation in JDK9+ with Xlog:gc is enabled by default and only disabled if `filecount=0` is set. The GCLogs component was missing that point and did not collect rotated gc logs. Only parameterized ones.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue