### PR TITLE
`InflightRequest` should only parse `userAgent` if and when `SlowRequestChecker` needs it

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/slowrequest/InflightRequest.java
+++ b/src/main/java/com/cloudbees/jenkins/support/slowrequest/InflightRequest.java
@@ -2,7 +2,6 @@ package com.cloudbees.jenkins.support.slowrequest;
 
 import com.cloudbees.jenkins.support.filter.ContentFilter;
 import jenkins.model.Jenkins;
-import net.sf.uadetector.ReadableUserAgent;
 import net.sf.uadetector.service.UADetectorServiceFactory;
 
 import javax.servlet.http.HttpServletRequest;
@@ -55,7 +54,7 @@ final class InflightRequest {
     /**
      * User Agent that invoked the slow request.
      */
-    final ReadableUserAgent userAgent;
+    private final String userAgent;
 
     /**
      * Locale of slow request
@@ -68,8 +67,7 @@ final class InflightRequest {
         startTime = System.currentTimeMillis();
         userName = Jenkins.getAuthentication().getName();
         referer = req.getHeader("Referer");
-        String agentHeader = req.getHeader("User-Agent");
-        userAgent = agentHeader != null ? UADetectorServiceFactory.getResourceModuleParser().parse(agentHeader) : null;
+        userAgent = req.getHeader("User-Agent");
         locale = req.getLocale().toString();
     }
 
@@ -80,7 +78,7 @@ final class InflightRequest {
     void writeHeader(PrintWriter w, Optional<ContentFilter> filter) {
         w.println("Username: " + filter.map(contentFilter -> contentFilter.filter(userName)).orElse(userName));
         w.println("Referer: " + filter.map(contentFilter -> contentFilter.filter(referer)).orElse(referer));
-        w.println("User Agent: " + userAgent);
+        w.println("User Agent: " + (userAgent != null ? UADetectorServiceFactory.getResourceModuleParser().parse(userAgent) : null));
         w.println("Date: " + new Date());
         w.println("URL: " + filter.map(contentFilter -> contentFilter.filter(url)).orElse(url));
         w.println("Locale: " + locale);


### PR DESCRIPTION
Noticed in a thread dump:

```
"Handling POST /…/ajaxExecutors from … : Jetty (winstone)-…" Id=… Group=main RUNNABLE
	at java.util.regex.Pattern$CharProperty.match(Pattern.java:3791)
	at java.util.regex.Pattern$Curly.match0(Pattern.java:4274)
	at java.util.regex.Pattern$Curly.match(Pattern.java:4248)
	at java.util.regex.Pattern$Start.match(Pattern.java:3475)
	at java.util.regex.Matcher.search(Matcher.java:1248)
	at java.util.regex.Matcher.find(Matcher.java:637)
	at net.sf.uadetector.parser.AbstractUserAgentStringParser.examineOperatingSystem(AbstractUserAgentStringParser.java:167)
	at net.sf.uadetector.parser.AbstractUserAgentStringParser.parse(AbstractUserAgentStringParser.java:205)
	at net.sf.uadetector.parser.AbstractUserAgentStringParser.parse(AbstractUserAgentStringParser.java:39)
	at com.cloudbees.jenkins.support.slowrequest.InflightRequest.<init>(InflightRequest.java:72)
	at com.cloudbees.jenkins.support.slowrequest.SlowRequestFilter.doFilter(SlowRequestFilter.java:34)
```

This is absurd when you look at it: the servlet filter responsible for checking _if_ a request is slow is making it slower!

This parsing is not needed unless and until a slow request record is actually written to a support bundle. (Perhaps it is not needed at all; I do not see why we would need to have this header parsed for purposes of this support bundle entry. Really I do not see why we would care about the user agent at all in this context: it is the _server_ that is slow.)
