### PR TITLE
Update Site Id is added to Update Center component

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/UpdateCenter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/UpdateCenter.java
@@ -42,9 +42,10 @@ public class UpdateCenter extends Component {
                     @Override
                     public void printTo(PrintWriter out, ContentFilter filter) {
                         try {
-                            hudson.model.UpdateCenter updateCenter = Jenkins.getInstance().getUpdateCenter();
+                            hudson.model.UpdateCenter updateCenter = Jenkins.get().getUpdateCenter();
                             out.println("=== Sites ===");
                             for (UpdateSite c : updateCenter.getSiteList()) {
+                                out.printf(" - Id: %s%n", c.getId());
                                 out.println(" - Url: " + ContentFilter.filter(filter, c.getUrl()));
                                 out.println(" - Connection Url: " + ContentFilter.filter(filter, c.getConnectionCheckUrl()));
                                 out.println(" - Implementation Type: " + c.getClass().getName());
@@ -55,7 +56,7 @@ public class UpdateCenter extends Component {
                             out.println("Last updated: " + updateCenter.getLastUpdatedString());
 
                             // Only do this part of the async-http-client plugin is installed.
-                            if (Jenkins.getInstance().getPlugin("async-http-client") != null) {
+                            if (Jenkins.get().getPlugin("async-http-client") != null) {
                                 addProxyInformation(out, filter);
                             } else {
                                 out.println("Proxy: 'async-http-client' not installed, so no proxy info available.");


### PR DESCRIPTION
A few deprecated API usages are updated.
Id of every update site is printed alongside the information that is already available. It should make it easier to correlate logs that mention update site id to the URL of the site.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- ~[ ] Link to relevant issues in GitHub or Jira~
- ~[ ] Link to relevant pull requests, esp. upstream and downstream changes~
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
