### PR TITLE
[chore] Remove unnecessary flaky test

### DIFF
--- a/src/test/java/com/cloudbees/jenkins/support/impl/TaskLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/TaskLogsTest.java
@@ -29,13 +29,6 @@ public class TaskLogsTest {
     public JenkinsRule j = new JenkinsRule();
 
     @Test
-    public void testTaskLogsContentEmpty() {
-        String otherLogs = SupportTestUtils.invokeComponentToString(
-                Objects.requireNonNull(ExtensionList.lookup(Component.class).get(TaskLogs.class)));
-        assertTrue("Should not write anything", otherLogs.isEmpty());
-    }
-
-    @Test
     public void testTaskRootSafeTimerLogs() throws IOException {
         File safeTimerTasksDir = SafeTimerTask.getLogsRoot();
         safeTimerTasksDir.mkdir();


### PR DESCRIPTION
This test is not necessary and may break if a timer tasks has already done something before the component is actually invoked..

```
java.lang.AssertionError: Should not write anything
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at com.cloudbees.jenkins.support.impl.TaskLogsTest.testTaskLogsContentEmpty(TaskLogsTest.java:35)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:603)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:750)
```

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
