### PR TITLE
[JENKINS-68008] Remove unnecessary usage of AHCUtils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,12 +119,6 @@
       <version>4.1.6.1</version>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>async-http-client</artifactId>
-      <version>1.7.24.3</version>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>wordnet-random-name</artifactId>
       <version>1.5</version>

--- a/src/test/java/com/cloudbees/jenkins/support/impl/UpdateCenterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/UpdateCenterTest.java
@@ -1,0 +1,42 @@
+package com.cloudbees.jenkins.support.impl;
+
+import com.cloudbees.jenkins.support.SupportTestUtils;
+import com.cloudbees.jenkins.support.api.Component;
+import hudson.ExtensionList;
+import hudson.ProxyConfiguration;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class UpdateCenterTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    @Issue("JENKINS-68008")
+    public void testUpdateCenterProxyContent() {
+
+        List<String> noProxyHosts = Arrays.asList(".server.com", "*.example.com"); 
+        j.jenkins.get().setProxy(new ProxyConfiguration("proxy.server.com", 1234, "proxyUser", "proxyPass", 
+            String.join("\n", noProxyHosts), "http://localhost:8080"));
+
+        String ucMdToString = SupportTestUtils.invokeComponentToString(Objects.requireNonNull(ExtensionList.lookup(Component.class).get(UpdateCenter.class)));
+        assertThat(ucMdToString, containsString(" - Host: proxy.server.com"));
+        assertThat(ucMdToString, containsString(" - Port: 1234"));
+        assertThat(ucMdToString, not(containsString("proxyUser")));
+        assertThat(ucMdToString, not(containsString("proxyPass")));
+        for (String noProxyHost : noProxyHosts) {
+            assertThat(ucMdToString, containsString(" * " + noProxyHost));
+        }
+    }
+}


### PR DESCRIPTION
[JENKINS-68008](https://issues.jenkins.io/browse/JENKINS-68008) The AyncHttpClient plugin is not necessary and can be removed.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue