### PR TITLE
Pin jackson2-api temporarily

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
-  
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -117,6 +117,12 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>metrics</artifactId>
       <version>4.1.6.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jackson2-api</artifactId>
+      <!-- TODO https://github.com/jenkinsci/bom/pull/1011 -->
+      <version>2.13.2.20220328-273.v11d70a_b_a_1a_52</version>
     </dependency>
     <dependency>
       <groupId>org.kohsuke</groupId>


### PR DESCRIPTION
Pinned jackson2-api to avoid cyclic dependency

We need to pin this to unblock https://github.com/jenkinsci/bom/pull/1011#issuecomment-1100675121

Can be removed once BOM and metrics plugin is updated to using that BOM