### PR TITLE
Update plugin parent POM and plugin BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>metrics</artifactId>
-      <version>4.1.6.2-rc355.fa_fe367a_f14c</version> <!-- TODO https://github.com/jenkinsci/metrics-plugin/pull/153 -->
+      <version>4.1.6.2</version>
     </dependency>
     <dependency>
       <groupId>org.kohsuke</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
  ~ The MIT License
  ~
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.39</version>
+    <version>4.40</version>
     <relativePath />
   </parent>
 
@@ -62,7 +62,7 @@
   </developers>
 
   <scm>
-    <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
     <tag>${scmTag}</tag>
     <url>https://github.com/${gitHubRepo}</url>
@@ -71,7 +71,6 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <jenkins.version>2.332.1</jenkins.version>
-    <java.level>8</java.level>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 
@@ -93,7 +92,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.332.x</artifactId>
-        <version>1210.vcd41f6657f03</version>
+        <version>1280.vd669827e38cd</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -116,7 +115,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>metrics</artifactId>
-      <version>4.1.6.1</version>
+      <version>4.1.6.2-rc355.fa_fe367a_f14c</version> <!-- TODO https://github.com/jenkinsci/metrics-plugin/pull/153 -->
     </dependency>
     <dependency>
       <groupId>org.kohsuke</groupId>


### PR DESCRIPTION
Supersedes #358. Downstream of https://github.com/jenkinsci/metrics-plugin/pull/153. Getting this released will help us cross the recent `jackson2-api` flag day and restore `support-core` to jenkinsci/bom as described in https://github.com/jenkinsci/bom/pull/1011, https://github.com/jenkinsci/metrics-plugin/pull/153, and https://github.com/jenkinsci/bom/pull/1016.

CC @jetersen @Dohbedoh