### PR TITLE
Update plugin BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.332.x</artifactId>
-        <version>1280.vd669827e38cd</version>
+        <version>1289.v5c4b_1c43511b_</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -115,7 +115,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>metrics</artifactId>
-      <version>4.1.6.2</version>
     </dependency>
     <dependency>
       <groupId>org.kohsuke</groupId>


### PR DESCRIPTION
Cleaning up after #360. Now that jenkinsci/bom#1016 has been merged and released, we don't need to specify a custom version for `metrics` anymore. Instead we can take it from the BOM.

This is just a cleanup; there is no urgent need for this to be released.