### PR TITLE
Fix test on Java 17

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -125,7 +125,7 @@ public class SupportPlugin extends Plugin {
      * How long remote operations can block support bundle generation for.
      */
     public static final int REMOTE_OPERATION_TIMEOUT_MS =
-            Integer.getInteger(SupportPlugin.class.getName() + ".REMOTE_OPERATION_TIMEOUT_MS", 500);
+            Integer.getInteger(SupportPlugin.class.getName() + ".REMOTE_OPERATION_TIMEOUT_MS", 1000);
 
     /**
      * How long remote operations fallback caching can wait for


### PR DESCRIPTION
While running PCT on Java 17 I noticed [this test failure](https://ci.jenkins.io/job/Tools/job/bom/job/PR-935/36/testReport/junit/com.cloudbees.jenkins.support.impl/FileDescriptorLimitTest/pct_support_core_weekly___addContentsFiltered/), which I could also reproduce locally:

```
java.lang.AssertionError: 

Expected: a string containing "core file size"
     but: was "Jenkins
======

N/A: Either no connection to node or no cached result
"
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
	at com.cloudbees.jenkins.support.impl.FileDescriptorLimitTest.addContentsFiltered(FileDescriptorLimitTest.java:66)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:606)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

Debugging the test locally, I saw that the code was working correctly but we were timing out before we ever got the result. It seems this code path has gotten a few cycles slower in Java 17, but by increasing the timeout the test is fully functional on Java 17.