### PR TITLE
[JENKINS-68339] Skip remoting stack on built-in node and improve IPv6 Regex

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
-buildPlugin(configurations: [
-    [ platform: "linux", jdk: "8", jenkins: null],
-    [ platform: "linux", jdk: "11", jenkins: null],
-    [ platform: "windows", jdk: "8", jenkins: null],
+buildPlugin(useContainerAgent: true, configurations: [
+    [ platform: "linux", jdk: "11"],
+    [ platform: "linux", jdk: "17", jenkins: '2.342'],
+    [ platform: "windows", jdk: "11"]
 ])

--- a/src/main/java/com/cloudbees/jenkins/support/AsyncResultCache.java
+++ b/src/main/java/com/cloudbees/jenkins/support/AsyncResultCache.java
@@ -40,8 +40,7 @@ public class AsyncResultCache<T> implements Runnable {
         
         if (node == null) return null;
         Future<V> future;
-        // If running in on the built-in node, no need to use the CallAsyncWrapper or be subjected 
-        // to the REMOTE_OPERATION_TIMEOUT_MS
+        // If launching execution on the built-in node, no need to use the CallAsyncWrapper
         if (node instanceof Jenkins) {
             future = Computer.threadPoolForRemoting.submit(() -> {
                 try {

--- a/src/main/java/com/cloudbees/jenkins/support/AsyncResultCache.java
+++ b/src/main/java/com/cloudbees/jenkins/support/AsyncResultCache.java
@@ -4,13 +4,13 @@ import com.cloudbees.jenkins.support.util.CallAsyncWrapper;
 import hudson.model.Computer;
 import hudson.model.Node;
 import hudson.remoting.Callable;
-import hudson.remoting.Future;
 import hudson.remoting.VirtualChannel;
 import jenkins.model.Jenkins;
 
 import java.io.IOException;
 import java.util.WeakHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
@@ -37,29 +37,35 @@ public class AsyncResultCache<T> implements Runnable {
     public static <V, T extends java.lang.Throwable> V get(Node node, WeakHashMap<Node, V> cache, /*MasterToSlave*/Callable<V,T> operation, String name)
 
             throws IOException {
+        
         if (node == null) return null;
-        VirtualChannel channel = node.getChannel();
-        if (channel == null) {
-            synchronized (cache) {
-                return cache.get(node);
+        Future<V> future;
+        // If running in on the built-in node, no need to use the CallAsyncWrapper or be subjected 
+        // to the REMOTE_OPERATION_TIMEOUT_MS
+        if (node instanceof Jenkins) {
+            future = Computer.threadPoolForRemoting.submit(() -> {
+                try {
+                    return operation.call();
+                } catch (Throwable e) {
+                    throw new IOException(e);
+                }
+            });
+        } else {
+            VirtualChannel channel = node.getChannel();
+            if (channel == null) {
+                synchronized (cache) {
+                    return cache.get(node);
+                }
             }
+            future = CallAsyncWrapper.callAsync(channel, operation);
         }
-        Future<V> future = CallAsyncWrapper.callAsync(channel, operation);
         try {
             final V result = future.get(SupportPlugin.REMOTE_OPERATION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
             synchronized (cache) {
                 cache.put(node, result);
             }
             return result;
-        } catch (InterruptedException e) {
-            final LogRecord lr = new LogRecord(Level.FINE, "Could not retrieve {0} from {1}");
-            lr.setParameters(new Object[]{name, getNodeName(node)});
-            lr.setThrown(e);
-            LOGGER.log(lr);
-            synchronized (cache) {
-                return cache.get(node);
-            }
-        } catch (ExecutionException e) {
+        } catch (InterruptedException | ExecutionException e) {
             final LogRecord lr = new LogRecord(Level.FINE, "Could not retrieve {0} from {1}");
             lr.setParameters(new Object[]{name, getNodeName(node)});
             lr.setThrown(e);
@@ -72,7 +78,7 @@ public class AsyncResultCache<T> implements Runnable {
             lr.setParameters(new Object[]{name, getNodeName(node)});
             lr.setThrown(e);
             LOGGER.log(lr);
-            Computer.threadPoolForRemoting.submit(new AsyncResultCache<V>(node, cache, future, name));
+            Computer.threadPoolForRemoting.submit(new AsyncResultCache<>(node, cache, future, name));
             synchronized (cache) {
                 return cache.get(node);
             }
@@ -90,6 +96,7 @@ public class AsyncResultCache<T> implements Runnable {
         this.name = name;
     }
 
+    @Override
     public void run() {
         T result;
         try {
@@ -97,12 +104,7 @@ public class AsyncResultCache<T> implements Runnable {
             synchronized (cache) {
                 cache.put(node, result);
             }
-        } catch (InterruptedException e1) {
-            final LogRecord lr = new LogRecord(Level.FINE, "Could not retrieve {0} from {1} for caching");
-            lr.setParameters(new Object[]{name, getNodeName(node)});
-            lr.setThrown(e1);
-            LOGGER.log(lr);
-        } catch (ExecutionException e1) {
+        } catch (InterruptedException | ExecutionException e1) {
             final LogRecord lr = new LogRecord(Level.FINE, "Could not retrieve {0} from {1} for caching");
             lr.setParameters(new Object[]{name, getNodeName(node)});
             lr.setThrown(e1);

--- a/src/main/java/com/cloudbees/jenkins/support/filter/InetAddressContentFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/InetAddressContentFilter.java
@@ -53,13 +53,13 @@ public class InetAddressContentFilter implements ContentFilter {
         return ExtensionList.lookupSingleton(InetAddressContentFilter.class);
     }
 
-    // https://blogs.msdn.microsoft.com/oldnewthing/20060522-08/?p=31113
-    private static final String IPv4 =
-            "([1-9]?\\d|1\\d\\d|2[0-4]\\d|25[0-5])\\.([1-9]?\\d|1\\d\\d|2[0-4]\\d|25[0-5])\\.([1-9]?\\d|1\\d\\d|2[0-4]\\d|25[0-5])\\.([1-9]?\\d|1\\d\\d|2[0-4]\\d|25[0-5])";
-    // https://stackoverflow.com/a/17871737
-    private static final String IPv6 =
-            "(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]+|::(ffff(:0{1,4})?:)?((25[0-5]|(2[0-4]|1?[0-9])?[0-9])\\.){3}(25[0-5]|(2[0-4]|1?[0-9])?[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1?[0-9])?[0-9])\\.){3}(25[0-5]|(2[0-4]|1?[0-9])?[0-9]))";
-    private static final Pattern IP_ADDRESS = Pattern.compile("\\b(" + IPv4 + '|' + IPv6 + ")\\b");
+    // http://www.java2s.com/example/java/java.util.regex/is-ipv4-address-by-regex.html
+    private static final String IPv4 = "(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(\\.(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}";
+    // Following is based http://www.java2s.com/example/java/java.util.regex/is-ipv6-address-by-regex.html to which 
+    // we add the mix notation (last 2 octet is IPv4)
+    private static final String IPv6_STANDARD_AND_MIX = "(?i)(?:[0-9a-f]{1,4}:){6}(?:([0-9a-f]{1,4}):[0-9a-f]{1,4}|" + IPv4 + ")";
+    private static final String IPv6_COMPRESSED_AND_MIX = "(?i)((?:[0-9a-f]{1,4}(?::[0-9a-f]{1,4})*)?)::(((?:[0-9a-f]{1,4}:){1,5})?(" + IPv4 + ")|((?:[0-9a-f]{1,4}(?::[0-9a-f]{1,4})*)?))";
+    private static final Pattern IP_ADDRESS = Pattern.compile("(?<![:.\\w])(" + IPv4 + '|' + IPv6_STANDARD_AND_MIX + '|' + IPv6_COMPRESSED_AND_MIX + ")(?![:.\\w])");
 
     @Override
     public @NonNull String filter(@NonNull String input) {

--- a/src/test/java/com/cloudbees/jenkins/support/impl/FileDescriptorLimitTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/FileDescriptorLimitTest.java
@@ -50,7 +50,6 @@ public class FileDescriptorLimitTest {
         MatcherAssert.assertThat(output, containsString(SENSITIVE_JOB_NAME));
     }
 
-    @Ignore("TODO flaky test")
     @Test
     public void addContentsFiltered() throws Exception {
         Assume.assumeTrue(!Functions.isWindows());


### PR DESCRIPTION
[JENKINS-68339](https://issues.jenkins.io/browse/JENKINS-68339)

* Only use `channel.callAsync` (through the `CallAsyncWrapper`) if retrieving data on remote node. When retrieving data on the built-in node, just execute the callable.
* updated CI to build use containers, and build on JDK 11 and JDK 17.

I am hoping that this fix the flakyness with JDK 17 as we remove the remoting overhead for this use case. See the following for reference:

* https://github.com/jenkinsci/support-core-plugin/pull/363
* https://github.com/jenkinsci/support-core-plugin/pull/362

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

