### PR TITLE
[JENKINS-68417] Revert `LogRecord` tricks

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportLogHandler.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportLogHandler.java
@@ -25,7 +25,6 @@
 package com.cloudbees.jenkins.support;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.remoting.ProxyException;
 import hudson.util.IOUtils;
 import io.jenkins.lib.support_log_formatter.SupportLogFormatter;
 import net.jcip.annotations.GuardedBy;
@@ -48,10 +47,8 @@ import java.util.List;
 import java.util.TimeZone;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.logging.Formatter;
 import java.util.logging.Handler;
 import java.util.logging.LogRecord;
-import java.util.logging.SimpleFormatter;
 
 /**
  * A log handler that rotates files.
@@ -59,11 +56,6 @@ import java.util.logging.SimpleFormatter;
  * @author Stephen Connolly
  */
 public class SupportLogHandler extends Handler {
-
-    /**
-     * Just to access {@link Formatter#formatMessage} which is not {@code static} though it could have been.
-     */
-    private static final Formatter dummyFormatter = new SimpleFormatter();
 
     private final Lock outputLock = new ReentrantLock();
     private final int fileSize;
@@ -104,24 +96,6 @@ public class SupportLogHandler extends Handler {
 
     @Override
     public void publish(LogRecord record) {
-        if (record.getParameters() != null) {
-            try {
-                LogRecord clone = new LogRecord(record.getLevel(), dummyFormatter.formatMessage(record));
-                clone.setLoggerName(record.getLoggerName());
-                clone.setMillis(record.getMillis());
-                clone.setSequenceNumber(record.getSequenceNumber());
-                clone.setSourceClassName(record.getSourceClassName());
-                clone.setSourceMethodName(record.getSourceMethodName());
-                clone.setThreadID(record.getThreadID());
-                Throwable t = record.getThrown();
-                if (t != null) {
-                    clone.setThrown(new ProxyException(t));
-                }
-                record = clone;
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
         outputLock.lock();
         try {
             int maxCount = records.length;


### PR DESCRIPTION
Essentially reverting #324 (slight simpification to timing of `format` in the process). Essentially the same fix as https://github.com/jenkinsci/jenkins/pull/6643. ~Here the calculus is simpler since any log records appearing in the handler _will_ need to be formatted (we write them to disk files) so there is no justification for deferring the message format expansion.~

Testing in `pipeline-groovy-lib-plugin`:
<details>

```diff
diff --git pom.xml pom.xml
index 9ee4e40..98f9e92 100644
--- pom.xml
+++ pom.xml
@@ -63,15 +63,15 @@
     </pluginRepositories>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.289.1</jenkins.version>
+        <jenkins.version>2.355-SNAPSHOT</jenkins.version> <!-- TODO https://github.com/jenkinsci/jenkins/pull/6643 -->
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.289.x</artifactId>
-                <version>1008.vb9e22885c9cf</version>
+                <artifactId>bom-2.332.x</artifactId>
+                <version>1342.v729ca_3818e88</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -203,5 +203,11 @@
             <version>1.10.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>support-core</artifactId>
+            <version>999999-SNAPSHOT</version> <!-- TODO https://github.com/jenkinsci/support-core-plugin/pull/376 -->
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>
diff --git src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryMemoryTest.java src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryMemoryTest.java
index 59c9d05..dad9e09 100644
--- src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryMemoryTest.java
+++ src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryMemoryTest.java
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.workflow.libs;
 
 import groovy.lang.MetaClass;
 import hudson.PluginManager;
+import hudson.WebAppMain;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -65,6 +66,9 @@ public class LibraryMemoryTest {
     }
     @Issue("JENKINS-50223")
     @Test public void loaderReleased() throws Exception {
+        Method installLogger = WebAppMain.class.getDeclaredMethod("installLogger");
+        installLogger.setAccessible(true);
+        installLogger.invoke(new WebAppMain());
         sampleRepo.init();
         sampleRepo.write("src/p/C.groovy", "package p; class C {}");
         sampleRepo.write("vars/leak.groovy", "def call() {def c = node {new p.C()}; [this, c].each {" + LibraryMemoryTest.class.getName() + ".register(it)}}");
```

</details>