### PR TITLE
[JENKINS-68743] Report if a node is marked offline

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
@@ -64,6 +64,7 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TimeZone;
@@ -616,7 +617,7 @@ public class AboutJenkins extends Component {
             return Markdown.prettyNone(n.getLabelString());
         }
         @Override protected void printTo(PrintWriter out,  ContentFilter filter) throws IOException {
-            final Jenkins jenkins = Jenkins.getInstance();
+            final Jenkins jenkins = Jenkins.get();
             SupportPlugin supportPlugin = SupportPlugin.getInstance();
             if (supportPlugin != null) {
                 out.println("Node statistics");
@@ -643,6 +644,13 @@ public class AboutJenkins extends Component {
                     Markdown.escapeBacktick(ContentFilter.filter(filter, jenkins.getRootDir().getAbsolutePath())) + "`");
             out.println("      - Labels:         " + ContentFilter.filter(filter, getLabelString(jenkins)));
             out.println("      - Usage:          `" + jenkins.getMode() + "`");
+            Optional.ofNullable(jenkins.toComputer()).ifPresent(computer ->
+                out.println("      - Marked Offline: " + computer.isTemporarilyOffline()));
+            if(jenkins.getChannel() == null) {
+                out.println("      - Status:         offline");
+            } else {
+                out.println("      - Status:         on-line");
+            }
             out.println("      - Slave Version:  " + Launcher.VERSION);
             out.print(new GetJavaInfo("      -", "          +").getInfo(filter));
             out.println();
@@ -669,6 +677,8 @@ public class AboutJenkins extends Component {
                     }
                     out.println("      - Availability:   " + getDescriptorName(agent.getRetentionStrategy()));
                 }
+                Optional.ofNullable(node.toComputer()).ifPresent(computer ->
+                    out.println("      - Marked Offline: " + computer.isTemporarilyOffline()));
                 VirtualChannel channel = node.getChannel();
                 if (channel == null) {
                     out.println("      - Status:         off-line");


### PR DESCRIPTION
[JENKINS-68743](https://issues.jenkins.io/browse/JENKINS-68743) Report if a node is marked offline. 

Note [Computer.java#isTemporarilyOffline](https://github.com/jenkinsci/jenkins/blob/jenkins-2.332.3/core/src/main/java/hudson/model/Computer.java#L667-L684) is marked as deprecated to warn people that they should use `Computer#isOffline` to truly know about a node status. What we want to know here is if that `temporarilyOffline` attribute is set to `true` for troubleshooting purposes.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
