### PR TITLE
Improve support bundle generation page

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/api/Component.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/Component.java
@@ -24,6 +24,7 @@
 
 package com.cloudbees.jenkins.support.api;
 
+import com.cloudbees.jenkins.support.Messages;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ExtensionPoint;
 import hudson.model.AbstractModelObject;
@@ -31,6 +32,7 @@ import hudson.security.ACL;
 import hudson.security.Permission;
 import jenkins.model.Jenkins;
 import org.acegisecurity.Authentication;
+import org.jvnet.localizer.Localizable;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
@@ -140,6 +142,32 @@ public abstract class Component implements ExtensionPoint {
     }
 
     public void start(@NonNull SupportContext context) {
+    }
 
+    /**
+     * Specify in which {@see ComponentCategory} the current component is related.
+     *
+     * @return the component category. Cannot be null. By default, returns {@see ComponentCategory.Misc}.
+     */
+    @Exported
+    @NonNull
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Misc;
+    }
+
+    public static enum ComponentCategory {
+        Controller(Messages._SupportPlugin_Category_Controller()),
+        Agent(Messages._SupportPlugin_Category_Agent()),
+        Misc(Messages._SupportPlugin_Category_Misc());
+
+        private final Localizable label;
+
+        ComponentCategory(Localizable label) {
+            this.label = label;
+        }
+
+        public @NonNull String getLabel() {
+            return label.toString();
+        }
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/api/Component.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/Component.java
@@ -155,10 +155,12 @@ public abstract class Component implements ExtensionPoint {
         return ComponentCategory.Misc;
     }
 
-    public static enum ComponentCategory {
-        Controller(Messages._SupportPlugin_Category_Controller()),
+    public enum ComponentCategory {
         Agent(Messages._SupportPlugin_Category_Agent()),
-        Misc(Messages._SupportPlugin_Category_Misc());
+        Controller(Messages._SupportPlugin_Category_Controller()),
+        Logs(Messages._SupportPlugin_Category_Logs()),
+        Misc(Messages._SupportPlugin_Category_Misc()),
+        Platform(Messages._SupportPlugin_Category_Platform());
 
         private final Localizable label;
 

--- a/src/main/java/com/cloudbees/jenkins/support/api/Component.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/Component.java
@@ -152,15 +152,34 @@ public abstract class Component implements ExtensionPoint {
     @Exported
     @NonNull
     public ComponentCategory getCategory() {
-        return ComponentCategory.Misc;
+        return ComponentCategory.UNCATEGORIZED;
     }
 
     public enum ComponentCategory {
-        Agent(Messages._SupportPlugin_Category_Agent()),
-        Controller(Messages._SupportPlugin_Category_Controller()),
-        Logs(Messages._SupportPlugin_Category_Logs()),
-        Misc(Messages._SupportPlugin_Category_Misc()),
-        Platform(Messages._SupportPlugin_Category_Platform());
+        /**
+         * For components related to the agents, their configuration and other bits.
+         */
+        AGENT(Messages._SupportPlugin_Category_Agent()),
+        /**
+         * For components related to the controller, its configuration and other bits.
+         */
+        CONTROLLER(Messages._SupportPlugin_Category_Controller()),
+        /**
+         * For components related to the logging system or the logs themself.
+         */
+        LOGS(Messages._SupportPlugin_Category_Logs()),
+        /**
+         * Anything that doesn't fit any other categories.
+         */
+        MISC(Messages._SupportPlugin_Category_Misc()),
+        /**
+         * For components related to how the controller is running, how it is running, where it is running.
+         */
+        PLATFORM(Messages._SupportPlugin_Category_Platform()),
+        /**
+         * The default category. This shouldn't be explicitly used.
+         */
+        UNCATEGORIZED(Messages._SupportPlugin_Category_Uncategorized());
 
         private final Localizable label;
 

--- a/src/main/java/com/cloudbees/jenkins/support/api/Component.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/Component.java
@@ -145,9 +145,10 @@ public abstract class Component implements ExtensionPoint {
     }
 
     /**
-     * Specify in which {@see ComponentCategory} the current component is related.
+     * Specify in which {@link ComponentCategory} the current component is related.
      *
-     * @return the component category. Cannot be null. By default, returns {@see ComponentCategory.Misc}.
+     * @return An enum value of {@link ComponentCategory}.
+     * @since TODO
      */
     @Exported
     @NonNull
@@ -155,6 +156,11 @@ public abstract class Component implements ExtensionPoint {
         return ComponentCategory.UNCATEGORIZED;
     }
 
+    /**
+     * Categories supported by this version of support-core
+     *
+     * @since TODO
+     */
     public enum ComponentCategory {
         /**
          * For components related to the agents, their configuration and other bits.

--- a/src/main/java/com/cloudbees/jenkins/support/api/Component.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/Component.java
@@ -179,7 +179,7 @@ public abstract class Component implements ExtensionPoint {
          */
         MISC(Messages._SupportPlugin_Category_Misc()),
         /**
-         * For components related to how the controller is running, how it is running, where it is running.
+         * For components related to how the controller is running and where it is running.
          */
         PLATFORM(Messages._SupportPlugin_Category_Platform()),
         /**

--- a/src/main/java/com/cloudbees/jenkins/support/configfiles/AgentsConfigFile.java
+++ b/src/main/java/com/cloudbees/jenkins/support/configfiles/AgentsConfigFile.java
@@ -74,7 +74,7 @@ public class AgentsConfigFile extends ObjectComponent<Computer> {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Agent;
+        return ComponentCategory.AGENT;
     }
 
     @NonNull

--- a/src/main/java/com/cloudbees/jenkins/support/configfiles/AgentsConfigFile.java
+++ b/src/main/java/com/cloudbees/jenkins/support/configfiles/AgentsConfigFile.java
@@ -73,6 +73,12 @@ public class AgentsConfigFile extends ObjectComponent<Computer> {
 
     @NonNull
     @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Agent;
+    }
+
+    @NonNull
+    @Override
     public String getDisplayName() {
         return "Agent Configuration File";
     }

--- a/src/main/java/com/cloudbees/jenkins/support/configfiles/ConfigFileComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/configfiles/ConfigFileComponent.java
@@ -50,5 +50,11 @@ public class ConfigFileComponent extends Component {
         return false;
     }
 
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Controller;
+    }
+
     private static final Logger LOGGER = Logger.getLogger(ConfigFileComponent.class.getName());
 }

--- a/src/main/java/com/cloudbees/jenkins/support/configfiles/ConfigFileComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/configfiles/ConfigFileComponent.java
@@ -53,7 +53,7 @@ public class ConfigFileComponent extends Component {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Controller;
+        return ComponentCategory.CONTROLLER;
     }
 
     private static final Logger LOGGER = Logger.getLogger(ConfigFileComponent.class.getName());

--- a/src/main/java/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponent.java
@@ -93,7 +93,7 @@ public class OtherConfigFilesComponent extends Component {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Controller;
+        return ComponentCategory.CONTROLLER;
     }
 
     private static final Logger LOGGER = Logger.getLogger(OtherConfigFilesComponent.class.getName());

--- a/src/main/java/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponent.java
@@ -90,6 +90,12 @@ public class OtherConfigFilesComponent extends Component {
         return false;
     }
 
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Controller;
+    }
+
     private static final Logger LOGGER = Logger.getLogger(OtherConfigFilesComponent.class.getName());
 
 }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutBrowser.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutBrowser.java
@@ -80,4 +80,10 @@ public class AboutBrowser extends Component {
             });
         }
     }
+
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return super.getCategory();
+    }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutBrowser.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutBrowser.java
@@ -84,6 +84,6 @@ public class AboutBrowser extends Component {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return super.getCategory();
+        return ComponentCategory.MISC;
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
@@ -107,7 +107,7 @@ public class AboutJenkins extends Component {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Controller;
+        return ComponentCategory.CONTROLLER;
     }
 
     @Override

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
@@ -104,6 +104,12 @@ public class AboutJenkins extends Component {
         return "About Jenkins";
     }
 
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Controller;
+    }
+
     @Override
     public void addContents(@NonNull Container container) {
         List<PluginWrapper> activePlugins = new ArrayList<PluginWrapper>();

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutUser.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutUser.java
@@ -63,4 +63,10 @@ public class AboutUser extends Component {
             });
         }
     }
+
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.MISC;
+    }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AdministrativeMonitors.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AdministrativeMonitors.java
@@ -101,6 +101,6 @@ import java.util.Set;
     }
 
     @NonNull @Override public ComponentCategory getCategory() {
-        return ComponentCategory.Controller;
+        return ComponentCategory.CONTROLLER;
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AdministrativeMonitors.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AdministrativeMonitors.java
@@ -27,6 +27,7 @@ package com.cloudbees.jenkins.support.impl;
 import com.cloudbees.jenkins.support.api.Component;
 import com.cloudbees.jenkins.support.api.Container;
 import com.cloudbees.jenkins.support.api.PrintedContent;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.diagnosis.OldDataMonitor;
 import hudson.diagnosis.ReverseProxySetupMonitor;
@@ -97,5 +98,9 @@ import java.util.Set;
                 return false;
             }
         });
+    }
+
+    @NonNull @Override public ComponentCategory getCategory() {
+        return ComponentCategory.Controller;
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AdvancedProcFilesRetriever.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AdvancedProcFilesRetriever.java
@@ -77,6 +77,12 @@ public abstract class AdvancedProcFilesRetriever extends ProcFilesRetriever {
         afterAddUnixContents(container, node, name);
     }
 
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Platform;
+    }
+
     /**
      * A class to define a file with a name in the bundle and also whether its content should be filtered.
      */

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AdvancedProcFilesRetriever.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AdvancedProcFilesRetriever.java
@@ -11,7 +11,6 @@ import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -80,7 +79,7 @@ public abstract class AdvancedProcFilesRetriever extends ProcFilesRetriever {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Platform;
+        return ComponentCategory.PLATFORM;
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AgentProtocols.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AgentProtocols.java
@@ -75,6 +75,6 @@ public class AgentProtocols extends Component {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Agent;
+        return ComponentCategory.AGENT;
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AgentProtocols.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AgentProtocols.java
@@ -71,4 +71,10 @@ public class AgentProtocols extends Component {
             }
         });
     }
+
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Agent;
+    }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/BuildQueue.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/BuildQueue.java
@@ -105,4 +105,10 @@ public class BuildQueue extends Component {
       }
     );
   }
+
+  @NonNull
+  @Override
+  public ComponentCategory getCategory() {
+    return ComponentCategory.Controller;
+  }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/BuildQueue.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/BuildQueue.java
@@ -40,7 +40,6 @@ import jenkins.model.Jenkins;
 
 import java.io.PrintWriter;
 import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -109,6 +108,6 @@ public class BuildQueue extends Component {
   @NonNull
   @Override
   public ComponentCategory getCategory() {
-    return ComponentCategory.Controller;
+    return ComponentCategory.CONTROLLER;
   }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/CustomLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/CustomLogs.java
@@ -66,6 +66,12 @@ public class CustomLogs extends Component {
         addLogRecorders(result);
     }
 
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Logs;
+    }
+
     /**
      * Dumps the content of {@link LogRecorder}, which is the groups of loggers configured
      * by the user. The contents are also ring buffer and only remembers recent 256 or so entries.

--- a/src/main/java/com/cloudbees/jenkins/support/impl/CustomLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/CustomLogs.java
@@ -69,7 +69,7 @@ public class CustomLogs extends Component {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Logs;
+        return ComponentCategory.LOGS;
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/support/impl/DumpExportTable.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/DumpExportTable.java
@@ -92,6 +92,12 @@ public class DumpExportTable extends ObjectComponent<Computer> {
         );
     }
 
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Agent;
+    }
+
     @Override
     public <C extends AbstractModelObject> boolean isApplicable(Class<C> clazz) {
         return Jenkins.class.isAssignableFrom(clazz) || Computer.class.isAssignableFrom(clazz);

--- a/src/main/java/com/cloudbees/jenkins/support/impl/DumpExportTable.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/DumpExportTable.java
@@ -95,7 +95,7 @@ public class DumpExportTable extends ObjectComponent<Computer> {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Agent;
+        return ComponentCategory.AGENT;
     }
 
     @Override

--- a/src/main/java/com/cloudbees/jenkins/support/impl/EnvironmentVariables.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/EnvironmentVariables.java
@@ -87,6 +87,12 @@ public class EnvironmentVariables extends Component {
         }
     }
 
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Platform;
+    }
+
     public Map<String,String> getEnvironmentVariables(Node node) throws IOException {
         return AsyncResultCache.get(node, environmentVariableCache, new GetEnvironmentVariables(), "environment",
                 UNAVAILABLE);

--- a/src/main/java/com/cloudbees/jenkins/support/impl/EnvironmentVariables.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/EnvironmentVariables.java
@@ -90,7 +90,7 @@ public class EnvironmentVariables extends Component {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Platform;
+        return ComponentCategory.PLATFORM;
     }
 
     public Map<String,String> getEnvironmentVariables(Node node) throws IOException {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/FileDescriptorLimit.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/FileDescriptorLimit.java
@@ -65,6 +65,12 @@ public class FileDescriptorLimit extends Component {
         }
     }
 
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Platform;
+    }
+
     private void addContents(@NonNull Container container, final @NonNull Node node) {
         Computer c = node.toComputer();
         if (c == null) {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/FileDescriptorLimit.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/FileDescriptorLimit.java
@@ -68,7 +68,7 @@ public class FileDescriptorLimit extends Component {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Platform;
+        return ComponentCategory.PLATFORM;
     }
 
     private void addContents(@NonNull Container container, final @NonNull Node node) {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
@@ -105,6 +105,12 @@ public class GCLogs extends Component {
         return false;
     }
 
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Logs;
+    }
+
     /**
      * Two cases:
      * <ul>

--- a/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
@@ -9,7 +9,7 @@ import hudson.security.Permission;
 import jenkins.model.Jenkins;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-import edu.umd.cs.findbugs.annotations.NonNull;
+
 import java.io.File;
 import java.lang.management.ManagementFactory;
 import java.util.Collections;
@@ -108,7 +108,7 @@ public class GCLogs extends Component {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Logs;
+        return ComponentCategory.LOGS;
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/support/impl/HeapUsageHistogram.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/HeapUsageHistogram.java
@@ -77,7 +77,7 @@ public class HeapUsageHistogram extends Component {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Platform;
+        return ComponentCategory.PLATFORM;
     }
 
     private String getLiveHistogram() throws IOException {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/HeapUsageHistogram.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/HeapUsageHistogram.java
@@ -56,7 +56,6 @@ public class HeapUsageHistogram extends Component {
         return false;
     }
 
-
     @Override
     public void addContents(@NonNull Container result) {
         result.add(
@@ -73,6 +72,12 @@ public class HeapUsageHistogram extends Component {
                 }
             }
         );
+    }
+
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Platform;
     }
 
     private String getLiveHistogram() throws IOException {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/ItemsContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/ItemsContent.java
@@ -180,6 +180,12 @@ public class ItemsContent extends Component {
         });
     }
 
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Controller;
+    }
+
     private static class Stats {
         private int count = 0;
         private long sumOfValues = 0;

--- a/src/main/java/com/cloudbees/jenkins/support/impl/ItemsContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/ItemsContent.java
@@ -183,7 +183,7 @@ public class ItemsContent extends Component {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Controller;
+        return ComponentCategory.CONTROLLER;
     }
 
     private static class Stats {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/JVMProcessSystemMetricsContents.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/JVMProcessSystemMetricsContents.java
@@ -94,7 +94,7 @@ public abstract class JVMProcessSystemMetricsContents extends AdvancedProcFilesR
         @NonNull
         @Override
         public ComponentCategory getCategory() {
-            return ComponentCategory.Agent;
+            return ComponentCategory.AGENT;
         }
 
         @Override

--- a/src/main/java/com/cloudbees/jenkins/support/impl/JVMProcessSystemMetricsContents.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/JVMProcessSystemMetricsContents.java
@@ -91,6 +91,12 @@ public abstract class JVMProcessSystemMetricsContents extends AdvancedProcFilesR
             return "Agent JVM process system metrics (Linux only)";
         }
 
+        @NonNull
+        @Override
+        public ComponentCategory getCategory() {
+            return ComponentCategory.Agent;
+        }
+
         @Override
         public boolean isSelectedByDefault() {
             return false;

--- a/src/main/java/com/cloudbees/jenkins/support/impl/JenkinsLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/JenkinsLogs.java
@@ -47,6 +47,12 @@ public class JenkinsLogs extends Component {
         addControllerJulLogRecords(result);
     }
 
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Logs;
+    }
+
     /**
      * Adds {@link Jenkins#logRecords} (from core) into the support bundle.
      *

--- a/src/main/java/com/cloudbees/jenkins/support/impl/JenkinsLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/JenkinsLogs.java
@@ -50,7 +50,7 @@ public class JenkinsLogs extends Component {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Logs;
+        return ComponentCategory.LOGS;
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/support/impl/LoadStats.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/LoadStats.java
@@ -102,6 +102,12 @@ public class LoadStats extends Component {
         }
     }
 
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Controller;
+    }
+
     private void add(@NonNull Container container, String name, LoadStatistics stats) {
         // A headless environment may be missing the fonts required for these graphs, so even though
         // we should be able to generate graphs from a headless environment we will skip the graphs

--- a/src/main/java/com/cloudbees/jenkins/support/impl/LoadStats.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/LoadStats.java
@@ -105,7 +105,7 @@ public class LoadStats extends Component {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Controller;
+        return ComponentCategory.CONTROLLER;
     }
 
     private void add(@NonNull Container container, String name, LoadStatistics stats) {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/LoggerManager.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/LoggerManager.java
@@ -60,4 +60,10 @@ public class LoggerManager extends Component {
             }
         });
     }
+
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Logs;
+    }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/LoggerManager.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/LoggerManager.java
@@ -64,6 +64,6 @@ public class LoggerManager extends Component {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Logs;
+        return ComponentCategory.LOGS;
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/Metrics.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/Metrics.java
@@ -50,6 +50,6 @@ public class Metrics extends Component {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Controller;
+        return ComponentCategory.CONTROLLER;
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/Metrics.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/Metrics.java
@@ -47,37 +47,9 @@ public class Metrics extends Component {
         */
     }
 
-    /*
-    private static class RemoteMetricsContent extends Content {
-
-        private final Node node;
-        private final WeakHashMap<Node, byte[]> metricsCache;
-
-        public RemoteMetricsContent(String name, Node node, WeakHashMap<Node, byte[]> metricsCache) {
-            super(name);
-            this.node = node;
-            this.metricsCache = metricsCache;
-        }
-
-        @Override
-        public void writeTo(OutputStream os) throws IOException {
-            os.write(AsyncResultCache.get(node, metricsCache, new GetMetricsResult(), "metrics data",
-                    UNAVAILABLE.getBytes("utf-8")));
-        }
-
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Controller;
     }
-
-    private static class GetMetricsResult extends MasterToSlaveCallable<byte[], RuntimeException> {
-        public byte[] call() throws RuntimeException {
-            ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            try {
-                new MetricsContent("", somethingHere).writeTo(bos);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-            return bos.toByteArray();
-        }
-    }
-    */
-
 }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/NetworkInterfaces.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/NetworkInterfaces.java
@@ -94,7 +94,7 @@ public class NetworkInterfaces extends Component {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Platform;
+        return ComponentCategory.PLATFORM;
     }
 
     public String getNetworkInterface(Node node) throws IOException {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/NetworkInterfaces.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/NetworkInterfaces.java
@@ -91,6 +91,12 @@ public class NetworkInterfaces extends Component {
         }
     }
 
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Platform;
+    }
+
     public String getNetworkInterface(Node node) throws IOException {
         return AsyncResultCache.get(node,
                 networkInterfaceCache,

--- a/src/main/java/com/cloudbees/jenkins/support/impl/NodeMonitors.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/NodeMonitors.java
@@ -61,4 +61,10 @@ public class NodeMonitors extends Component{
             }
         });
     }
+
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Controller;
+    }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/NodeMonitors.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/NodeMonitors.java
@@ -65,6 +65,6 @@ public class NodeMonitors extends Component{
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Controller;
+        return ComponentCategory.CONTROLLER;
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/NodeRemoteDirectoryComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/NodeRemoteDirectoryComponent.java
@@ -75,6 +75,12 @@ public class NodeRemoteDirectoryComponent extends DirectoryComponent<Computer> i
 
     @NonNull
     @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Agent;
+    }
+
+    @NonNull
+    @Override
     public String getDisplayName() {
         return Messages.NodeRemoteDirectoryComponent_DisplayName();
     }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/NodeRemoteDirectoryComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/NodeRemoteDirectoryComponent.java
@@ -76,7 +76,7 @@ public class NodeRemoteDirectoryComponent extends DirectoryComponent<Computer> i
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Agent;
+        return ComponentCategory.AGENT;
     }
 
     @NonNull

--- a/src/main/java/com/cloudbees/jenkins/support/impl/OtherLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/OtherLogs.java
@@ -49,6 +49,12 @@ public class OtherLogs extends Component {
         addOtherControllerLogs(result);
     }
 
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Logs;
+    }
+
     /**
      * Grabs any files that look like log files directly under {@code $JENKINS_HOME}, just in case
      * any of them are useful.

--- a/src/main/java/com/cloudbees/jenkins/support/impl/OtherLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/OtherLogs.java
@@ -52,7 +52,7 @@ public class OtherLogs extends Component {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Logs;
+        return ComponentCategory.LOGS;
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/support/impl/ProcFilesRetriever.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/ProcFilesRetriever.java
@@ -79,7 +79,7 @@ public abstract class ProcFilesRetriever extends ObjectComponent<Computer> {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Platform;
+        return ComponentCategory.PLATFORM;
     }
 
     protected void addUnixContents(@NonNull Container container, final @NonNull Node node) {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/ProcFilesRetriever.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/ProcFilesRetriever.java
@@ -76,6 +76,12 @@ public abstract class ProcFilesRetriever extends ObjectComponent<Computer> {
         Optional.ofNullable(item.getNode()).ifPresent(node -> addUnixContents(container, node));
     }
 
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Platform;
+    }
+
     protected void addUnixContents(@NonNull Container container, final @NonNull Node node) {
         Computer c = node.toComputer();
         if (c == null || c.isOffline()) {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/RemotingDiagnostics.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/RemotingDiagnostics.java
@@ -55,4 +55,9 @@ public class RemotingDiagnostics extends Component {
             }
         });
     }
+
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Agent;
+    }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/RemotingDiagnostics.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/RemotingDiagnostics.java
@@ -56,8 +56,9 @@ public class RemotingDiagnostics extends Component {
         });
     }
 
+    @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Agent;
+        return ComponentCategory.AGENT;
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/ReverseProxy.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/ReverseProxy.java
@@ -69,6 +69,11 @@ public class ReverseProxy extends Component {
     });
   }
 
+  @Override
+  public ComponentCategory getCategory() {
+    return ComponentCategory.Platform;
+  }
+
   private Trilean isForwardedHeaderDetected(StaplerRequest req, String header) {
     if (req == null) {
       return Trilean.UNKNOWN;

--- a/src/main/java/com/cloudbees/jenkins/support/impl/ReverseProxy.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/ReverseProxy.java
@@ -69,9 +69,10 @@ public class ReverseProxy extends Component {
     });
   }
 
+  @NonNull
   @Override
   public ComponentCategory getCategory() {
-    return ComponentCategory.Platform;
+    return ComponentCategory.PLATFORM;
   }
 
   private Trilean isForwardedHeaderDetected(StaplerRequest req, String header) {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/RootCAs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/RootCAs.java
@@ -81,6 +81,12 @@ public class RootCAs extends Component {
     }
   }
 
+  @NonNull
+  @Override
+  public ComponentCategory getCategory() {
+    return ComponentCategory.Platform;
+  }
+
   private void addContents(@NonNull Container container, final @NonNull Node node) {
     Computer c = node.toComputer();
     if (c == null) {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/RootCAs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/RootCAs.java
@@ -84,7 +84,7 @@ public class RootCAs extends Component {
   @NonNull
   @Override
   public ComponentCategory getCategory() {
-    return ComponentCategory.Platform;
+    return ComponentCategory.PLATFORM;
   }
 
   private void addContents(@NonNull Container container, final @NonNull Node node) {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/RunDirectoryComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/RunDirectoryComponent.java
@@ -88,7 +88,7 @@ public class RunDirectoryComponent extends DirectoryComponent<Run> {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Platform;
+        return ComponentCategory.PLATFORM;
     }
 
     @NonNull

--- a/src/main/java/com/cloudbees/jenkins/support/impl/RunDirectoryComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/RunDirectoryComponent.java
@@ -87,6 +87,12 @@ public class RunDirectoryComponent extends DirectoryComponent<Run> {
 
     @NonNull
     @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Platform;
+    }
+
+    @NonNull
+    @Override
     public String getDisplayName() {
         return Messages.RunDirectoryComponent_DisplayName();
     }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/RunningBuilds.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/RunningBuilds.java
@@ -47,4 +47,10 @@ public class RunningBuilds extends Component {
                 }
             });
     }
+
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Controller;
+    }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/RunningBuilds.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/RunningBuilds.java
@@ -51,6 +51,6 @@ public class RunningBuilds extends Component {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Controller;
+        return ComponentCategory.CONTROLLER;
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SlaveCommandStatistics.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SlaveCommandStatistics.java
@@ -100,6 +100,12 @@ public final class SlaveCommandStatistics extends Component {
         }));
     }
 
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Agent;
+    }
+
     @VisibleForTesting
     /*package*/ Map<String, Statistics> getStatistics() {
         synchronized (statLock) {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SlaveCommandStatistics.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SlaveCommandStatistics.java
@@ -103,7 +103,7 @@ public final class SlaveCommandStatistics extends Component {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Agent;
+        return ComponentCategory.AGENT;
     }
 
     @VisibleForTesting

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLaunchLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLaunchLogs.java
@@ -77,6 +77,12 @@ public class SlaveLaunchLogs extends ObjectComponent<Computer> {
         addAgentsLaunchLogs(container);
     }
 
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Agent;
+    }
+
     @Override
     public void addContents(@NonNull Container container, Computer item) {
         if (item.getNode() == null) {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLaunchLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLaunchLogs.java
@@ -80,7 +80,7 @@ public class SlaveLaunchLogs extends ObjectComponent<Computer> {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Agent;
+        return ComponentCategory.AGENT;
     }
 
     @Override

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLogs.java
@@ -84,8 +84,6 @@ public class SlaveLogs extends Component {
         return false;
     }
 
-
-
     @Override
     public void addContents(@NonNull Container container) {
         // expensive remote computation are pooled together and executed later concurrently across all the agents
@@ -150,6 +148,11 @@ public class SlaveLogs extends Component {
 
     }
 
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Logs;
+    }
 
     /**
      * Captures a "recent" (but still fairly large number of) j.u.l entries written on this agent.

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLogs.java
@@ -151,7 +151,7 @@ public class SlaveLogs extends Component {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Logs;
+        return ComponentCategory.LOGS;
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SystemConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SystemConfiguration.java
@@ -135,7 +135,7 @@ public abstract class SystemConfiguration extends AdvancedProcFilesRetriever {
         @NonNull
         @Override
         public ComponentCategory getCategory() {
-            return ComponentCategory.Agent;
+            return ComponentCategory.AGENT;
         }
 
         @Override

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SystemConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SystemConfiguration.java
@@ -132,6 +132,12 @@ public abstract class SystemConfiguration extends AdvancedProcFilesRetriever {
             return false;
         }
 
+        @NonNull
+        @Override
+        public ComponentCategory getCategory() {
+            return ComponentCategory.Agent;
+        }
+
         @Override
         protected List<Node> getNodes() {
             return Jenkins.get().getNodes();

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SystemProperties.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SystemProperties.java
@@ -94,6 +94,12 @@ public class SystemProperties extends Component {
         }
     }
 
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Platform;
+    }
+
     public Map<Object, Object> getSystemProperties(Node node) throws IOException  {
         return AsyncResultCache.get(node, systemPropertyCache, new GetSystemProperties(), "system properties", UNAVAILABLE);
     }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SystemProperties.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SystemProperties.java
@@ -97,7 +97,7 @@ public class SystemProperties extends Component {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Platform;
+        return ComponentCategory.PLATFORM;
     }
 
     public Map<Object, Object> getSystemProperties(Node node) throws IOException  {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/TaskLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/TaskLogs.java
@@ -47,7 +47,7 @@ public class TaskLogs extends Component {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Logs;
+        return ComponentCategory.LOGS;
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/support/impl/TaskLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/TaskLogs.java
@@ -43,7 +43,13 @@ public class TaskLogs extends Component {
     public void addContents(@NonNull Container result) {
         addControllerTasksLogs(result);
     }
-    
+
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Logs;
+    }
+
     /**
      * Grabs any files that look like log files directly under <code>$JENKINS_HOME/logs</code>, just in case
      * any of them are useful.

--- a/src/main/java/com/cloudbees/jenkins/support/impl/ThreadDumps.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/ThreadDumps.java
@@ -187,6 +187,12 @@ public class ThreadDumps extends ObjectComponent<Computer> {
         }
     }
 
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Platform;
+    }
+
     public Future<String> getThreadDump(Node node) throws IOException {
         VirtualChannel channel = node.getChannel();
         if (channel == null) {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/ThreadDumps.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/ThreadDumps.java
@@ -190,7 +190,7 @@ public class ThreadDumps extends ObjectComponent<Computer> {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Platform;
+        return ComponentCategory.PLATFORM;
     }
 
     public Future<String> getThreadDump(Node node) throws IOException {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/UpdateCenter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/UpdateCenter.java
@@ -64,6 +64,12 @@ public class UpdateCenter extends Component {
         );
     }
 
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Controller;
+    }
+
     private void addProxyInformation(PrintWriter out, ContentFilter filter) {
         out.println("=== Proxy ===");
         ProxyConfiguration proxy = Jenkins.get().getProxy();

--- a/src/main/java/com/cloudbees/jenkins/support/impl/UpdateCenter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/UpdateCenter.java
@@ -67,7 +67,7 @@ public class UpdateCenter extends Component {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Controller;
+        return ComponentCategory.CONTROLLER;
     }
 
     private void addProxyInformation(PrintWriter out, ContentFilter filter) {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/UserCount.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/UserCount.java
@@ -87,4 +87,10 @@ public class UserCount extends UnfilteredFileListCapComponent {
     public boolean isSelectedByDefault() {
         return true;
     }
+
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Misc;
+    }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/UserCount.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/UserCount.java
@@ -91,6 +91,6 @@ public class UserCount extends UnfilteredFileListCapComponent {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Misc;
+        return ComponentCategory.MISC;
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/slowrequest/SlowRequestComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/slowrequest/SlowRequestComponent.java
@@ -26,4 +26,10 @@ public class SlowRequestComponent extends UnfilteredFileListCapComponent {
     public void addContents(@NonNull Container container) {
         super.addContents(container, checker.logs);
     }
+
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Controller;
+    }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/slowrequest/SlowRequestComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/slowrequest/SlowRequestComponent.java
@@ -30,6 +30,6 @@ public class SlowRequestComponent extends UnfilteredFileListCapComponent {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Controller;
+        return ComponentCategory.CONTROLLER;
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/threaddump/HighLoadComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/threaddump/HighLoadComponent.java
@@ -51,6 +51,6 @@ public class HighLoadComponent extends UnfilteredFileListCapComponent {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Platform;
+        return ComponentCategory.PLATFORM;
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/threaddump/HighLoadComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/threaddump/HighLoadComponent.java
@@ -47,4 +47,10 @@ public class HighLoadComponent extends UnfilteredFileListCapComponent {
             super.addContents(container, checker.logs);
         }
     }
+
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Platform;
+    }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/timer/DeadlockRequestComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/timer/DeadlockRequestComponent.java
@@ -25,4 +25,10 @@ public class DeadlockRequestComponent extends UnfilteredFileListCapComponent {
     public void addContents(@NonNull Container container) {
         super.addContents(container, checker.logs);
     }
+
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Platform;
+    }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/timer/DeadlockRequestComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/timer/DeadlockRequestComponent.java
@@ -29,6 +29,6 @@ public class DeadlockRequestComponent extends UnfilteredFileListCapComponent {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Platform;
+        return ComponentCategory.PLATFORM;
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/timer/FileListCapComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/timer/FileListCapComponent.java
@@ -36,6 +36,12 @@ public abstract class FileListCapComponent extends Component {
         return Collections.singleton(Jenkins.ADMINISTER);
     }
 
+    @NonNull
+    @Override
+    public ComponentCategory getCategory() {
+        return ComponentCategory.Platform;
+    }
+
     public void addContents(@NonNull Container container, FileListCap fileListCap) {
         synchronized (fileListCap) {
             // while we read and put the reports into the support bundle, we don't want

--- a/src/main/java/com/cloudbees/jenkins/support/timer/FileListCapComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/timer/FileListCapComponent.java
@@ -39,7 +39,7 @@ public abstract class FileListCapComponent extends Component {
     @NonNull
     @Override
     public ComponentCategory getCategory() {
-        return ComponentCategory.Platform;
+        return ComponentCategory.PLATFORM;
     }
 
     public void addContents(@NonNull Container container, FileListCap fileListCap) {

--- a/src/main/java/com/cloudbees/jenkins/support/timer/UnfilteredFileListCapComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/timer/UnfilteredFileListCapComponent.java
@@ -44,5 +44,4 @@ public abstract class UnfilteredFileListCapComponent extends Component {
             }
         }
     }
-
 }

--- a/src/main/resources/com/cloudbees/jenkins/support/Messages.properties
+++ b/src/main/resources/com/cloudbees/jenkins/support/Messages.properties
@@ -43,3 +43,4 @@ SupportPlugin_DownloadBundle=Download bundle
 SupportPlugin_ListBundle=Existing support bundles
 SupportPlugin_loadConfig=Read support plugin configuration
 
+SupportPlugin_Category_Misc=Miscellaneous

--- a/src/main/resources/com/cloudbees/jenkins/support/Messages.properties
+++ b/src/main/resources/com/cloudbees/jenkins/support/Messages.properties
@@ -48,3 +48,4 @@ SupportPlugin_Category_Controller=Controller
 SupportPlugin_Category_Logs=Logs
 SupportPlugin_Category_Misc=Miscellaneous
 SupportPlugin_Category_Platform=Platform
+SupportPlugin_Category_Uncategorized=Uncategorized

--- a/src/main/resources/com/cloudbees/jenkins/support/Messages.properties
+++ b/src/main/resources/com/cloudbees/jenkins/support/Messages.properties
@@ -43,4 +43,8 @@ SupportPlugin_DownloadBundle=Download bundle
 SupportPlugin_ListBundle=Existing support bundles
 SupportPlugin_loadConfig=Read support plugin configuration
 
+SupportPlugin_Category_Agent=Agents
+SupportPlugin_Category_Controller=Controller
+SupportPlugin_Category_Logs=Logs
 SupportPlugin_Category_Misc=Miscellaneous
+SupportPlugin_Category_Platform=Platform

--- a/src/main/resources/com/cloudbees/jenkins/support/SupportAction/index.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/support/SupportAction/index.jelly
@@ -69,6 +69,26 @@
             </div>
           </section>
         </j:forEach>
+        <!--<j:forEach var="component" items="${it.components}">
+          <f:entry field="component">
+            <div name="components">
+              <j:if test="${component.enabled}">
+                <f:checkbox name="selected" checked="${it.selectedByDefault(component)}"
+                            title="${component.displayName}"/>
+              </j:if>
+              <j:if test="${!component.enabled}">
+                <input type="checkbox"
+                       name="selected"
+                       value="false"
+                       disabled="disabled"/>
+                <label class="attach-previous" style="text-decoration: line-through;"
+                       title="${%permissionPreReqs(component.displayPermissions)}">${component.displayName}
+                </label>
+              </j:if>
+              <input style="display:none" name="name" value="${component.id}"/>
+            </div>
+          </f:entry>
+        </j:forEach>-->
         <f:entry>
           <f:submit value="${%Generate Bundle}"/>
         </f:entry>

--- a/src/main/resources/com/cloudbees/jenkins/support/SupportAction/index.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/support/SupportAction/index.jelly
@@ -51,25 +51,19 @@
         </p>
       </j:if>
       <f:form name="bundle-contents" method="POST" action="generateAllBundles">
-        <j:forEach var="component" items="${it.components}">
-          <f:entry field="component">
-            <div name="components">
-              <j:if test="${component.enabled}">
-                <f:checkbox name="selected" checked="${it.selectedByDefault(component)}"
-                            title="${component.displayName}"/>
-              </j:if>
-              <j:if test="${!component.enabled}">
-                <input type="checkbox"
-                       name="selected"
-                       value="false"
-                       disabled="disabled"/>
-                <label class="attach-previous" style="text-decoration: line-through;"
-                       title="${%permissionPreReqs(component.displayPermissions)}">${component.displayName}
-                </label>
-              </j:if>
-              <input style="display:none" name="name" value="${component.id}"/>
+        <j:forEach var="category" items="${it.categorizedComponents.entrySet()}">
+          <section class="jenkins-section jenkins-section__bottom-padding">
+            <h2 class="jenkins-section__title">${category.key.label}</h2>
+            <div class="jenkins-section__items">
+              <j:forEach var="component" items="${category.value}">
+                <div name="components" class="jenkins-section__item">
+                  <f:checkbox title="${component.displayName}" name="selected"
+                              checked="${it.selectedByDefault(component)}"/>
+                  <input type="hidden" name="name" value="${component.id}"/>
+                </div>
+              </j:forEach>
             </div>
-          </f:entry>
+          </section>
         </j:forEach>
         <f:entry>
           <f:submit value="${%Generate Bundle}"/>

--- a/src/main/resources/com/cloudbees/jenkins/support/SupportAction/index.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/support/SupportAction/index.jelly
@@ -69,26 +69,6 @@
             </div>
           </section>
         </j:forEach>
-        <!--<j:forEach var="component" items="${it.components}">
-          <f:entry field="component">
-            <div name="components">
-              <j:if test="${component.enabled}">
-                <f:checkbox name="selected" checked="${it.selectedByDefault(component)}"
-                            title="${component.displayName}"/>
-              </j:if>
-              <j:if test="${!component.enabled}">
-                <input type="checkbox"
-                       name="selected"
-                       value="false"
-                       disabled="disabled"/>
-                <label class="attach-previous" style="text-decoration: line-through;"
-                       title="${%permissionPreReqs(component.displayPermissions)}">${component.displayName}
-                </label>
-              </j:if>
-              <input style="display:none" name="name" value="${component.id}"/>
-            </div>
-          </f:entry>
-        </j:forEach>-->
         <f:entry>
           <f:submit value="${%Generate Bundle}"/>
         </f:entry>

--- a/src/main/resources/com/cloudbees/jenkins/support/SupportAction/index.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/support/SupportAction/index.jelly
@@ -57,8 +57,12 @@
             <div class="jenkins-section__items">
               <j:forEach var="component" items="${category.value}">
                 <div name="components" class="jenkins-section__item">
-                  <f:checkbox title="${component.displayName}" name="selected"
-                              checked="${it.selectedByDefault(component)}"/>
+                  <j:if test="${component.enabled}">
+                    <f:checkbox title="${component.displayName}" name="selected" checked="${it.selectedByDefault(component)}"/>
+                  </j:if>
+                  <j:if test="${!component.enabled}">
+                    <f:checkbox title="${%permissionPreReqs(component.displayPermissions)}" name="selected" checked="false" readOnlyMode="true"/>
+                  </j:if>
                   <input type="hidden" name="name" value="${component.id}"/>
                 </div>
               </j:forEach>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
I'm trying to see how we can improve the UX of the plugin. 
First in my list is the huge page to select what to include in the bundle to be generated.

<details>
<summary>
Here the current display with <code>2.346.1</code>
</summary>

![Screenshot 2022-06-23 at 17-18-32 Support Jenkins](https://user-images.githubusercontent.com/985955/175334974-b39dd170-76c2-4c69-86c2-06f9495761d2.png)

</details>


Do you think this is worth the effort to continue? 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
