### PR TITLE
Adapt to jenkinsci/jenkins#6982

### DIFF
--- a/src/test/java/com/cloudbees/jenkins/support/impl/AbstractItemComponentTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/AbstractItemComponentTest.java
@@ -163,7 +163,7 @@ public class AbstractItemComponentTest {
         assertTrue(output.containsKey(prefix + "/builds/1/build.xml"));
         assertTrue(output.containsKey(prefix + "/builds/1/log"));
         assertTrue(output.containsKey(prefix + "/builds/1/workflow/2.xml"));
-        assertThat(output.get(prefix + "/config.xml"), containsString("<flow-definition>"));
+        assertThat(output.get(prefix + "/config.xml"), containsString("<flow-definition"));
         assertThat(output.get(prefix + "/nextBuildNumber"), containsString("2"));
     }
 

--- a/src/test/java/com/cloudbees/jenkins/support/impl/RunDirectoryComponentTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/RunDirectoryComponentTest.java
@@ -58,7 +58,7 @@ public class RunDirectoryComponentTest {
         assertTrue(output.containsKey(prefix + "/build.xml"));
         assertTrue(output.containsKey(prefix + "/log"));
         assertTrue(output.containsKey(prefix + "/workflow/2.xml"));
-        assertThat(output.get(prefix + "/build.xml"), Matchers.containsString("<flow-build>"));
+        assertThat(output.get(prefix + "/build.xml"), Matchers.containsString("<flow-build"));
         assertThat(output.get(prefix + "/log"), Matchers.containsString("[Pipeline] node"));
     }
 


### PR DESCRIPTION
Observed in https://github.com/jenkinsci/bom/pull/1407: `com.cloudbees.jenkins.support.impl.AbstractItemComponentTest.addContentsFromPipeline` and `com.cloudbees.jenkins.support.impl.RunDirectoryComponentTest.addContentsFromPipeline` started failing with:

- https://ci.jenkins.io/job/Tools/job/bom/view/change-requests/job/PR-1407/1/testReport/junit/com.cloudbees.jenkins.support.impl/AbstractItemComponentTest/pct_support_core_weekly___addContentsFromPipeline/
- https://ci.jenkins.io/job/Tools/job/bom/view/change-requests/job/PR-1407/1/testReport/junit/com.cloudbees.jenkins.support.impl/RunDirectoryComponentTest/pct_support_core_weekly___addContentsFromPipeline/

The failure starts occurring after https://github.com/jenkinsci/jenkins/pull/6982, which improves the test framework by making `PluginManager#whichPlugin` behave more realistically in some cases, as it does in production. That in turn means that …

```
whichPlugin:1352, PluginManager (hudson)
ownerOf:572, XStream2$PluginClassOwnership (hudson.util)
marshal:163, RobustReflectionConverter (hudson.util)
convert:68, AbstractReferenceMarshaller (com.thoughtworks.xstream.core)
convertAnother:59, TreeMarshaller (com.thoughtworks.xstream.core)
convertAnother:44, TreeMarshaller (com.thoughtworks.xstream.core)
start:83, TreeMarshaller (com.thoughtworks.xstream.core)
marshal:37, AbstractTreeMarshallingStrategy (com.thoughtworks.xstream.core)
marshal:1266, XStream (com.thoughtworks.xstream)
marshal:1255, XStream (com.thoughtworks.xstream)
toXML:1228, XStream (com.thoughtworks.xstream)
write:213, XmlFile (hudson)
writeByXStream:30, PipelineIOUtils (org.jenkinsci.plugins.workflow.support)
save:1228, WorkflowRun (org.jenkinsci.plugins.workflow.job)
run:321, WorkflowRun (org.jenkinsci.plugins.workflow.job)
execute:107, ResourceController (hudson.model)
run:449, Executor (hudson.model)
```

… now finds `workflow-job` and as a result serializes `<flow-definition plugin="workflow-job@1232.v5a_4c994312f1">` and `<flow-build plugin="workflow-job@1232.v5a_4c994312f1">` (like production!) rather than just `<flow-definition>` and `<flow-build>`. The test asserts the latter and now fails.

Since the core PR is making the code more like production, I believe the test should be adjusted. Here I have loosened the test to work in both environments.

CC @dohbedoh A release of this would be appreciated for BOM/PCT purposes.