### PR TITLE
[JENKINS-70351] Fix initialization and deprecate obsolete SupportContext

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportContextImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportContextImpl.java
@@ -33,9 +33,12 @@ import jenkins.metrics.api.Metrics;
  * The implementation of {@link SupportContext}
  *
  * @author Stephen Connolly
+ * @deprecated usage removed
  */
+@Deprecated
 public class SupportContextImpl implements SupportContext {
 
+    @Deprecated
     public SupportContextImpl() {
     }
 
@@ -57,6 +60,7 @@ public class SupportContextImpl implements SupportContext {
         return Metrics.healthCheckRegistry();
     }
 
+    @Deprecated
     public void shutdown() {
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -53,7 +53,6 @@ import hudson.Main;
 import hudson.Plugin;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
-import hudson.model.AbstractCIBase;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
 import hudson.model.Node;
@@ -645,29 +644,14 @@ public class SupportPlugin extends Plugin {
         context = new SupportContextImpl();
     }
 
+    /**
+     * @return the {@link com.cloudbees.jenkins.support.api.SupportContext}
+     * @deprecated usage removed
+     */
     @NonNull
+    @Deprecated
     public synchronized SupportContextImpl getContext() {
         return context;
-    }
-
-    @Override
-    public void postInitialize() throws Exception {
-        super.postInitialize();
-        for (Component component : getComponents()) {
-            try {
-                long initializerStart = System.currentTimeMillis();
-                component.start(getContext());
-                if (AbstractCIBase.LOG_STARTUP_PERFORMANCE) {
-                    long delta = System.currentTimeMillis() - initializerStart;
-                    logger.info(String.format("Took %dms for support component %s startup", delta, component.getId()));
-                }
-            } catch (Throwable t) {
-                LogRecord logRecord = new LogRecord(Level.WARNING, "Exception propagated from component: {0}");
-                logRecord.setThrown(t);
-                logRecord.setParameters(new Object[]{component.getDisplayName()});
-                logger.log(logRecord);
-            }
-        }
     }
 
     @Override

--- a/src/main/java/com/cloudbees/jenkins/support/api/Component.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/Component.java
@@ -138,6 +138,7 @@ public abstract class Component implements ExtensionPoint {
         return getClass().getSimpleName();
     }
 
+    @Deprecated
     public void start(@NonNull SupportContext context) {
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/api/SupportContext.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/SupportContext.java
@@ -32,7 +32,9 @@ import com.codahale.metrics.health.HealthCheckRegistry;
  * The context that a {@link Component} is being instantiated in.
  *
  * @author Stephen Connolly
+ * @deprecated usage removed
  */
+@Deprecated
 public interface SupportContext {
     /**
      * Returns the {@link MetricRegistry} for the current Jenkins.

--- a/src/main/java/com/cloudbees/jenkins/support/impl/CustomLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/CustomLogs.java
@@ -3,10 +3,11 @@ package com.cloudbees.jenkins.support.impl;
 import com.cloudbees.jenkins.support.api.Component;
 import com.cloudbees.jenkins.support.api.Container;
 import com.cloudbees.jenkins.support.api.FileContent;
-import com.cloudbees.jenkins.support.api.SupportContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
 import hudson.init.Terminator;
 import hudson.logging.LogRecorder;
 import hudson.model.PeriodicWork;
@@ -17,6 +18,8 @@ import hudson.util.io.RewindableRotatingFileOutputStream;
 import io.jenkins.lib.support_log_formatter.SupportLogFormatter;
 import java.util.List;
 import jenkins.model.Jenkins;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.io.File;
 import java.io.IOException;
@@ -54,11 +57,6 @@ public class CustomLogs extends Component {
     @Override
     public String getDisplayName() {
         return "Controller Custom Log Recorders";
-    }
-
-    @Override
-    public void start(@NonNull SupportContext context) {
-        Logger.getLogger("").addHandler(new CustomHandler());
     }
 
     @Override
@@ -123,6 +121,12 @@ public class CustomLogs extends Component {
             handler.publish(record);
             LogFlusher.scheduleFlush(handler);
         }
+    }
+
+    @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED, before = InitMilestone.SYSTEM_CONFIG_LOADED)
+    @Restricted(NoExternalUse.class)
+    public void startCustomHandler() {
+        Logger.getLogger("").addHandler(new CustomHandler());
     }
 
     private final class CustomHandler extends Handler {


### PR DESCRIPTION
[JENKINS-70351](https://issues.jenkins.io/browse/JENKINS-70351)

* Removed the `SupportPlugin#postInitialize` that happens on plugin startup
* Deprecate the `SupportContext` that the `SupportPlugin#postInitialize` is setting as it is obsolete / unused since https://github.com/jenkinsci/support-core-plugin/commit/5905c4f2ba026302de91ce629d72c74cd05a8051.
* Add an `@Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED, before = InitMilestone.SYSTEM_CONFIG_LOADED)` to the `CustomLogs.CustomLogHandler`. For some reason, this was done via `Component#start(SupportContext)` though not related to the `SupportContext`.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue