### PR TITLE
Use `SafeTimerTask.getLogsRoot`

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/CustomLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/CustomLogs.java
@@ -12,6 +12,7 @@ import hudson.init.Terminator;
 import hudson.logging.LogRecorder;
 import hudson.model.PeriodicWork;
 import hudson.security.Permission;
+import hudson.triggers.SafeTimerTask;
 import hudson.util.CopyOnWriteList;
 import hudson.util.io.RewindableFileOutputStream;
 import hudson.util.io.RewindableRotatingFileOutputStream;
@@ -44,7 +45,7 @@ public class CustomLogs extends Component {
 
     private static final Logger LOGGER = Logger.getLogger(CustomLogs.class.getName());
     private static final int MAX_ROTATE_LOGS = Integer.getInteger(CustomLogs.class.getName() + ".MAX_ROTATE_LOGS", 9);
-    private static final File customLogs = new File(TaskLogs.getLogsRoot(), "custom");
+    private static final File customLogs = new File(SafeTimerTask.getLogsRoot(), "custom");
     private final List<LogRecorder> logRecorders = Jenkins.get().getLog().getRecorders();
 
     @NonNull

--- a/src/main/java/com/cloudbees/jenkins/support/impl/TaskLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/TaskLogs.java
@@ -7,6 +7,7 @@ import com.cloudbees.jenkins.support.timer.FileListCapComponent;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.security.Permission;
+import hudson.triggers.SafeTimerTask;
 import jenkins.model.Jenkins;
 
 import java.io.File;
@@ -59,7 +60,7 @@ public class TaskLogs extends Component {
     private void addControllerTasksLogs(Container result) {
         Jenkins jenkins = Jenkins.getInstanceOrNull();
         if (jenkins != null) {
-            File logsRoot = getLogsRoot();
+            File logsRoot = SafeTimerTask.getLogsRoot();
             for (File logs : new File[] {logsRoot, new File(logsRoot, "tasks")}) {
                 File[] files = logs.listFiles(ROTATED_LOGFILE_FILTER);
                 if (files != null) {
@@ -75,19 +76,4 @@ public class TaskLogs extends Component {
         }
     }
 
-    /**
-     * Returns the root directory for logs (historically always found under <code>$JENKINS_HOME/logs</code>.
-     * Configurable since Jenkins 2.114.
-     *
-     * @see hudson.triggers.SafeTimerTask#LOGS_ROOT_PATH_PROPERTY
-     * @return the root directory for logs.
-     */
-    protected static File getLogsRoot() {
-        final String overriddenLogsRoot = System.getProperty("hudson.triggers.SafeTimerTask.logsTargetDir");
-        if (overriddenLogsRoot == null) {
-            return new File(Jenkins.get().getRootDir(), "logs");
-        } else {
-            return new File(overriddenLogsRoot);
-        }
-    }
 }


### PR DESCRIPTION
Cleanup from https://github.com/jenkinsci/support-core-plugin/pull/140#discussion_r177712220.