### PR TITLE
Jenkins logs should be colocated

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
@@ -164,7 +164,7 @@ public class SupportAction implements RootAction, StaplerProxy {
     public List<String> getBundles() {
         List<String> res = new ArrayList<>();
         File rootDirectory = SupportPlugin.getRootDirectory();
-        File[] bundlesFiles = rootDirectory.listFiles((dir, name) -> name.endsWith(".zip") || name.endsWith(".log"));
+        File[] bundlesFiles = rootDirectory.listFiles((dir, name) -> name.endsWith(".zip"));
         if (bundlesFiles != null) {
             for (File bundleFile : bundlesFiles) {
                 res.add(bundleFile.getName());

--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -67,6 +67,7 @@ import hudson.security.Permission;
 import hudson.security.PermissionGroup;
 import hudson.security.PermissionScope;
 import hudson.slaves.ComputerListener;
+import hudson.triggers.SafeTimerTask;
 import jenkins.metrics.impl.JenkinsMetricProviderImpl;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
@@ -171,7 +172,7 @@ public class SupportPlugin extends Plugin {
     public SupportPlugin() {
         super();
         handler.setLevel(getLogLevel());
-        handler.setDirectory(getRootDirectory(), "all");
+        handler.setDirectory(getLogsDirectory(), "all");
     }
 
     public SupportProvider getSupportProvider() {
@@ -193,12 +194,20 @@ public class SupportPlugin extends Plugin {
     /**
      * Working directory that the support-core plugin uses to write out files.
      *
-     * @return the wrking directory that the support-core plugin uses to write out files.
+     * @return the working directory that the support-core plugin uses to write out files.
      */
     public static File getRootDirectory() {
         return new File(Jenkins.get().getRootDir(), SUPPORT_DIRECTORY_NAME);
     }
 
+    /**
+     * Working directory that the support-core plugin uses to write out log files.
+     *
+     * @return the working directory that the support-core plugin uses to write out log files.
+     */
+    public static File getLogsDirectory() {
+        return new File(SafeTimerTask.getLogsRoot(), SUPPORT_DIRECTORY_NAME);
+    }
 
     public static Authentication getRequesterAuthentication() {
         return requesterAuthentication.get();

--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -181,7 +181,7 @@ public class SupportPlugin extends Plugin {
     public static void migrateExistingLogs() {
         File rootDirectory = getRootDirectory();
         File[] files = rootDirectory.listFiles();
-        if (rootDirectory != null) {
+        if (files != null) {
             for (File f : files) {
                 if (f.isFile() && f.getName().endsWith(".log")) {
                     Path p = f.toPath();

--- a/src/main/java/com/cloudbees/jenkins/support/impl/JenkinsLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/JenkinsLogs.java
@@ -90,7 +90,7 @@ public class JenkinsLogs extends Component {
             }
         });
 
-        final File[] julLogFiles = SupportPlugin.getRootDirectory().listFiles(new LogFilenameFilter());
+        final File[] julLogFiles = SupportPlugin.getLogsDirectory().listFiles(new LogFilenameFilter());
         if (julLogFiles == null) {
             LOGGER.log(Level.WARNING, "Cannot add controller java.util.logging logs to the bundle. Cannot access log files");
             return;

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SmartLogCleaner.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SmartLogCleaner.java
@@ -33,7 +33,7 @@ class SmartLogCleaner {
      *      Used to generate the cache keys to match within the target directory.
      */
     SmartLogCleaner(final String id, final Set<String> cackeKeys) {
-        this.rootCacheDir = new File(SupportPlugin.getRootDirectory(), id);
+        this.rootCacheDir = new File(SupportPlugin.getLogsDirectory(), id);
         this.cacheKeys = cackeKeys;
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SmartLogFetcher.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SmartLogFetcher.java
@@ -49,7 +49,7 @@ class SmartLogFetcher {
      *      Used to match log files within the target directory.
      */
     public SmartLogFetcher(String id, FilenameFilter filter) {
-        this.rootCacheDir = new File(SupportPlugin.getRootDirectory(), id);
+        this.rootCacheDir = new File(SupportPlugin.getLogsDirectory(), id);
         this.filter = filter;
         assert filter instanceof Serializable;
     }

--- a/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
@@ -225,7 +225,8 @@ public class SupportActionTest {
     }
 
     private Path createFakeSupportBundle() throws IOException {
-        return Files.createTempFile(SupportPlugin.getRootDirectory().toPath(), "fake-bundle-", ".zip");
+        Path parent = Files.createDirectories(SupportPlugin.getRootDirectory().toPath());
+        return Files.createTempFile(parent, "fake-bundle-", ".zip");
     }
 
     /**

--- a/src/test/java/com/cloudbees/jenkins/support/impl/SmartLogCleanerTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/SmartLogCleanerTest.java
@@ -31,8 +31,7 @@ public class SmartLogCleanerTest {
 
     @Test
     public void cleanUp() throws Exception {
-        File supportDir = new File(j.getInstance().getRootDir(), "support");
-        File cacheDir = new File(supportDir, "winsw");
+        File cacheDir = new File(SupportPlugin.getLogsDirectory(), "winsw");
 
         DumbSlave agent1 = j.createOnlineSlave();
         DumbSlave agent2 = j.createOnlineSlave();


### PR DESCRIPTION
Part of log files generated by support-core plugin are located under `$JENKINS_HOME/logs`. Another part is located under `$JENKINS_HOME/support`. All Jenkins log files should be located under `$JENKINS_HOME/logs`.

`support/all_*.log` are being moved to `logs/support/all_*.log`

This also honors any log root directory override specified by system property via Jenkins core mecanism.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
