### PR TITLE
Avoid NPE when `Computer.getNode` returns null

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -808,7 +808,7 @@ public class SupportPlugin extends Plugin {
         @Override
         public void onOnline(Computer c, TaskListener listener) throws IOException, InterruptedException {
             final Node node = c.getNode();
-            if (node instanceof Jenkins) {
+            if (node == null || node instanceof Jenkins) {
                 return;
             }
             try {


### PR DESCRIPTION
Observed an NPE caught and reported as _Could not install root log handler…_ which from the stack trace looks like the computer went offline immediately after coming online, perhaps.