### PR TITLE
Improve initialization of some extensions

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/filter/ContentFilters.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/ContentFilters.java
@@ -25,6 +25,7 @@
 package com.cloudbees.jenkins.support.filter;
 
 import hudson.Extension;
+import hudson.ExtensionList;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.GlobalConfigurationCategory;
 import org.jenkinsci.Symbol;
@@ -46,7 +47,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public class ContentFilters extends GlobalConfiguration {
 
     public static ContentFilters get() {
-        return GlobalConfiguration.all().get(ContentFilters.class);
+        return ExtensionList.lookupSingleton(ContentFilters.class);
     }
 
     private boolean enabled;

--- a/src/main/java/com/cloudbees/jenkins/support/filter/ContentMappings.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/ContentMappings.java
@@ -27,6 +27,7 @@ package com.cloudbees.jenkins.support.filter;
 import com.cloudbees.jenkins.support.SupportPlugin;
 import com.cloudbees.jenkins.support.util.Persistence;
 import hudson.Extension;
+import hudson.ExtensionList;
 import hudson.model.AbstractItem;
 import hudson.model.ManagementLink;
 import hudson.model.Saveable;
@@ -83,7 +84,7 @@ public class ContentMappings extends ManagementLink implements Saveable, Iterabl
      * @return the singleton instance
      */
     public static ContentMappings get() {
-        return all().get(ContentMappings.class);
+        return ExtensionList.lookupSingleton(ContentMappings.class);
     }
 
     /**


### PR DESCRIPTION
It came to my attention when looking at some initialization issues recently (such as https://github.com/jenkinsci/job-config-history-plugin/pull/279/files) that we should be using `ExtensionList.[lookup|lookupSingleton]` if we can, for example in the `get()` methods of singleton extensions, instead of the `GlobalConfiguration.all()` | `ManagementLink.all()`.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue