### PR TITLE
Upgrade plugin parent POM to 4.60

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.55</version>
+    <version>4.60</version>
     <relativePath />
   </parent>
 
@@ -163,7 +163,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Adapts to https://github.com/mockito/mockito/pull/2945 by switching our dependency from `mockito-inline` to `mockito-core`.