### PR TITLE
More gracefully handle empty `bundlesToDownload`

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
@@ -29,6 +29,7 @@ import com.cloudbees.jenkins.support.api.SupportProvider;
 import com.cloudbees.jenkins.support.filter.ContentFilters;
 import hudson.Extension;
 import hudson.model.Api;
+import hudson.model.Failure;
 import hudson.model.RootAction;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
@@ -223,6 +224,8 @@ public class SupportAction implements RootAction, StaplerProxy {
         if (bundlesToDownload.size() > 1) {
             // more than one bundles were selected, create a zip file
             fileToDownload = createZipFile(bundlesToDownload);
+        } else if (bundlesToDownload.isEmpty()) {
+            throw new Failure("No matching bundles");
         } else {
             fileToDownload = new File(SupportPlugin.getRootDirectory(), bundlesToDownload.iterator().next());
         }


### PR DESCRIPTION
In a support bundle (ironically enough) I noticed a stack trace

```
java.util.NoSuchElementException
	at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1513)
	at java.base/java.util.HashMap$KeyIterator.next(HashMap.java:1534)
	at com.cloudbees.jenkins.support.SupportAction.doDownloadBundles(SupportAction.java:227)
```

which looks like it could come from an attempt to download no bundles. Should be handled more clearly.
