### PR TITLE
Forward compatibility with Apache Commons IO 2.13.0

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/api/BaseFileContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/BaseFileContent.java
@@ -101,7 +101,7 @@ class BaseFileContent {
                     IOUtils.copy(new TruncatedInputStream(is, maxSize), os);
                 }
             }
-        } catch (FileNotFoundException e) { // TODO FilePathContent.isFileNotFound?
+        } catch (FileNotFoundException | NoSuchFileException e) { // TODO FilePathContent.isFileNotFound?
             OutputStreamWriter osw = new OutputStreamWriter(os, ENCODING);
             try {
                 PrintWriter pw = new PrintWriter(osw, true);

--- a/src/test/java/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponentTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponentTest.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
@@ -129,6 +130,10 @@ public class OtherConfigFilesComponentTest {
                 filter(lr -> lr.getLevel().intValue() >= Level.WARNING.intValue()). // TODO .record(…, WARNING) does not accomplish this
                 map(lr -> lr.getSourceClassName() + "." + lr.getSourceMethodName() + ": " + lr.getMessage()).collect(Collectors.toList()), // LogRecord does not override toString
             emptyIterable());
-        assertThat(baos.toString(), allOf(containsString("FileNotFoundException"), containsString(file.getAbsolutePath())));
+        assertThat(
+                baos.toString(),
+                allOf(
+                        anyOf(containsString("FileNotFoundException"), containsString("NoSuchFileException")),
+                        containsString(file.getAbsolutePath())));
     }
 }


### PR DESCRIPTION
Without dropping support for Commons IO 2.11.0, add support for Commons IO 2.12.0 and 2.13.0, which throw `NoSuchFileException` in places where the previous version threw `FileNotFoundException`.

### Testing done

Tested in `jenkinsci/bom` with an incremental build of core with Commons 2.13.0.

### Submitter checklist

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
