### PR TITLE
[JENKINS-71466] Fix MalformedInputException on non-UTF-8 characters when Anonymization is on

### DIFF
--- a/src/test/java/com/cloudbees/jenkins/support/api/FileContentTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/api/FileContentTest.java
@@ -27,18 +27,22 @@ import org.apache.commons.io.FileUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.Issue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.nio.charset.Charset;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class FileContentTest {
 
-    @Rule public TemporaryFolder tmp = new TemporaryFolder();
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
 
-    @Test public void truncation() throws Exception {
+    @Test
+    public void truncation() throws Exception {
         File f = tmp.newFile();
         FileUtils.writeStringToFile(f, "hello world\n", Charset.defaultCharset());
 
@@ -53,5 +57,17 @@ public class FileContentTest {
         baos.reset();
         new FileContent("-", f, 20).writeTo(baos);
         assertEquals("hello world\n", baos.toString());
+    }
+
+    @Test
+    @Issue("JENKINS-71466")
+    public void encoding() throws Exception {
+        File f = new File(getClass().getResource("non-utf8.txt").getFile());
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        new FileContent("-", f).writeTo(baos);
+        assertTrue(baos.toString().contains("Checking folder"));
+        baos.reset();
+        new FileContent("-", f).writeTo(baos, input -> input);
+        assertTrue(baos.toString().contains("Checking folder"));
     }
 }

--- a/src/test/resources/com/cloudbees/jenkins/support/api/non-utf8.txt
+++ b/src/test/resources/com/cloudbees/jenkins/support/api/non-utf8.txt
@@ -1,0 +1,1 @@
+Checking folder » job


### PR DESCRIPTION
[JENKINS-71466](https://issues.jenkins.io/browse/JENKINS-71466) Fix issues encoding exception originating from `Files.readAllLines`.

### Testing done


```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```