### PR TITLE
[JENKINS-71529] Fix sensitive word boundaries matching

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilter.java
@@ -114,7 +114,7 @@ public class SensitiveContentFilter implements ContentFilter {
                         trie.add(lowerCaseOriginal);
                     }
                 }));
-        this.mappingsPattern.set(Pattern.compile("\\b" + trie.getRegex() + "\\b", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE));
+        this.mappingsPattern.set(Pattern.compile("(?<!\\w)" + trie.getRegex() + "(?!\\w)", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE));
         this.replacementsMap.set(replacementsMap);
         LOGGER.log(Level.FINE, "Took " + (System.currentTimeMillis()-startTime) + "ms to reload");
     }

--- a/src/test/java/com/cloudbees/jenkins/support/util/WordReplacerTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/util/WordReplacerTest.java
@@ -6,6 +6,7 @@ import com.cloudbees.jenkins.support.filter.WordsTrie;
 import hudson.Functions;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.recipes.WithTimeout;
 
 import java.util.ArrayList;
@@ -326,6 +327,22 @@ public class WordReplacerTest {
         assertEquals(result, WordReplacer.replaceWords(input, triePattern(words), replacementsMap(words, replaces)));
     }
 
+    @Test
+    @Issue("JENKINS-71529")
+    public void testBoundaries() {
+        String specialChars = "~`!@#$%^&*()_+-={}[]|\\:\";'<>?,./";
+        String[] words = new String[specialChars.length()];
+        String[] replaces = new String[specialChars.length()];
+        for(int i=0; i< specialChars.length(); i++) {
+            words[i] = specialChars.charAt(i) + "word" + specialChars.charAt(i);
+            replaces[i] = "**" + words[i] + "**";
+        }
+        String result = String.join(" ", replaces);
+
+        assertEquals(result, WordReplacer.replaceWords(String.join(" ", words), words, replaces));
+        assertEquals(result, WordReplacer.replaceWords(String.join(" ", words), triePattern(words), replacementsMap(words, replaces)));
+    }
+
     private List<String> generateFakeListString(int lines) {
         assertTrue(lines < 1001);
         return Stream.generate(() -> FilteredOutputStreamTest.FAKE_TEXT).limit(lines).collect(Collectors.toList());
@@ -434,6 +451,6 @@ public class WordReplacerTest {
             buf.deleteCharAt(buf.length() - 1);
             buf.append(')');
         }
-        return Pattern.compile("\\b" + buf.toString() + "\\b", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+        return Pattern.compile("\\b" + buf + "\\b", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/support/util/WordReplacerTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/util/WordReplacerTest.java
@@ -399,7 +399,7 @@ public class WordReplacerTest {
         for (String search : originals) {
             trie.add(lowercase ? search.toLowerCase(Locale.ENGLISH): search);
         }
-        return Pattern.compile("\\b" + trie.getRegex() + "\\b", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+        return Pattern.compile("(?<!\\w)" + trie.getRegex() + "(?!\\w)", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
     }
 
 
@@ -451,6 +451,6 @@ public class WordReplacerTest {
             buf.deleteCharAt(buf.length() - 1);
             buf.append(')');
         }
-        return Pattern.compile("\\b" + buf + "\\b", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+        return Pattern.compile("(?<!\\w)" + buf + "(?!\\w)", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
     }
 }


### PR DESCRIPTION
[JENKINS-71529](https://issues.jenkins.io/browse/JENKINS-71529): `\b` causes a change of behavior and prevent the matching of words that are bound with a non word character. To fix this (as it was working with the previous bahevior of the WordReplacer) we can use negative lookahead and negative lookbehind.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```