### PR TITLE
Diagnostics for flake in `FileDescriptorLimitTest.agentContentFilter`

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/AsyncResultCache.java
+++ b/src/main/java/com/cloudbees/jenkins/support/AsyncResultCache.java
@@ -38,7 +38,10 @@ public class AsyncResultCache<T> implements Runnable {
 
             throws IOException {
         
-        if (node == null) return null;
+        if (node == null) {
+            LOGGER.fine("no node");
+            return null;
+        }
         Future<V> future;
         // If launching execution on the built-in node, no need to use the CallAsyncWrapper
         if (node instanceof Jenkins) {
@@ -52,6 +55,7 @@ public class AsyncResultCache<T> implements Runnable {
         } else {
             VirtualChannel channel = node.getChannel();
             if (channel == null) {
+                LOGGER.fine("no channel for " + getNodeName(node));
                 synchronized (cache) {
                     return cache.get(node);
                 }
@@ -63,6 +67,7 @@ public class AsyncResultCache<T> implements Runnable {
             synchronized (cache) {
                 cache.put(node, result);
             }
+            LOGGER.finer(() -> operation + " on " + getNodeName(node) + " succeeded");
             return result;
         } catch (InterruptedException | ExecutionException e) {
             final LogRecord lr = new LogRecord(Level.FINE, "Could not retrieve {0} from {1}");

--- a/src/test/java/com/cloudbees/jenkins/support/impl/FileDescriptorLimitTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/FileDescriptorLimitTest.java
@@ -1,5 +1,6 @@
 package com.cloudbees.jenkins.support.impl;
 
+import com.cloudbees.jenkins.support.AsyncResultCache;
 import com.cloudbees.jenkins.support.SupportPlugin;
 import com.cloudbees.jenkins.support.SupportTestUtils;
 import com.cloudbees.jenkins.support.filter.ContentFilter;
@@ -21,11 +22,13 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.zip.ZipFile;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
+import org.jvnet.hudson.test.LoggerRule;
 
 public class FileDescriptorLimitTest {
 
@@ -37,6 +40,9 @@ public class FileDescriptorLimitTest {
 
     @Rule
     public TemporaryFolder tmp = new TemporaryFolder();
+
+    @Rule
+    public LoggerRule logging = new LoggerRule();
 
     @Test
     public void addContents() throws Exception {
@@ -78,6 +84,7 @@ public class FileDescriptorLimitTest {
     public void agentContentFilter() throws Exception {
         Assume.assumeTrue(!Functions.isWindows());
         Assume.assumeTrue(SystemPlatform.LINUX == SystemPlatform.current());
+        logging.record(AsyncResultCache.class, Level.FINER);
         ContentFilters.get().setEnabled(true);
         j.createOnlineSlave();
         File bundle = tmp.newFile("bundle.zip");


### PR DESCRIPTION
The test added in #474 has been observed to flake

```
java.lang.AssertionError: 
worked on agent
Expected: a string containing "All open files"
     but: was "slave0
======

N/A: Either no connection to node or no cached result
"
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at com.cloudbees.jenkins.support.impl.FileDescriptorLimitTest.agentContentFilter(FileDescriptorLimitTest.java:92)
```

with nothing obviously wrong in stdout/stderr: the agent does come online.
