### PR TITLE
[JENKINS-71732] Add component to collect executors information

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/NodeExecutors.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/NodeExecutors.java
@@ -142,7 +142,7 @@ public class NodeExecutors extends ObjectComponent<Computer> {
         }
         Queue.Executable executable = executor.getCurrentExecutable();
         if (executable != null) {
-          out.println("          - executable: " + ContentFilter.filter(filter, executable.getParent().toString()));
+          out.println("          - executable: " + ContentFilter.filter(filter, executable.toString()));
           out.println("          - elapsedTime: " + executor.getTimestampString());
         }
       });

--- a/src/main/java/com/cloudbees/jenkins/support/impl/NodeExecutors.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/NodeExecutors.java
@@ -76,7 +76,7 @@ public class NodeExecutors extends ObjectComponent<Computer> {
         @Override
         public void printTo(PrintWriter out, ContentFilter filter) {
           try {
-            out.println("Nodes Executors");
+            out.println("Node Executors");
             out.println("===========");
             out.println();
 

--- a/src/main/java/com/cloudbees/jenkins/support/impl/NodeExecutors.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/NodeExecutors.java
@@ -34,7 +34,6 @@ import hudson.Extension;
 import hudson.Util;
 import hudson.model.AbstractModelObject;
 import hudson.model.Computer;
-import hudson.model.Node;
 import hudson.model.Queue;
 import hudson.model.queue.WorkUnit;
 import hudson.security.Permission;
@@ -44,6 +43,7 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.PrintWriter;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -81,12 +81,8 @@ public class NodeExecutors extends ObjectComponent<Computer> {
             out.println("===========");
             out.println();
 
-            out.println("  * built-in (Jenkins)");
-            dumpExecutorInfo(Jenkins.get().toComputer(), out, filter);
-
-            Jenkins.get().getNodes().forEach(node -> {
-              out.println("  * " + ContentFilter.filter(filter, node.getDisplayName()));
-              dumpExecutorInfo(node.toComputer(), out, filter);
+            Arrays.stream(Jenkins.get().getComputers()).forEach(computer -> {
+              dumpExecutorInfo(computer, out, filter);
             });
 
           } finally {
@@ -107,11 +103,7 @@ public class NodeExecutors extends ObjectComponent<Computer> {
           out.println("===========");
           out.println();
 
-          Node node = computer.getNode();
-          if (node != null) {
-            out.println("  * " + ContentFilter.filter(filter, node.getDisplayName()));
-            dumpExecutorInfo(node.toComputer(), out, filter);
-          }
+          dumpExecutorInfo(computer, out, filter);
 
         } finally {
           out.flush();
@@ -122,6 +114,7 @@ public class NodeExecutors extends ObjectComponent<Computer> {
 
   private void dumpExecutorInfo(@CheckForNull Computer computer, PrintWriter out, ContentFilter filter) {
     if (computer != null) {
+      out.println("  * " + ContentFilter.filter(filter, computer.getDisplayName()));
       computer.getAllExecutors().forEach(executor -> {
         out.println("      - " + ContentFilter.filter(filter, executor.getDisplayName()));
         out.println("          - active: " + executor.isActive());

--- a/src/main/java/com/cloudbees/jenkins/support/impl/NodeExecutors.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/NodeExecutors.java
@@ -31,6 +31,7 @@ import com.cloudbees.jenkins.support.filter.ContentFilter;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import hudson.Util;
 import hudson.model.AbstractModelObject;
 import hudson.model.Computer;
 import hudson.model.Node;
@@ -129,19 +130,21 @@ public class NodeExecutors extends ObjectComponent<Computer> {
             executor.getCausesOfInterruption().stream()
                 .map(CauseOfInterruption::getShortDescription)
                 .collect(Collectors.joining(","))) + "]");
+        out.println("          - idle: " + executor.isIdle());
+        long idleStartMilliseconds = executor.getIdleStartMilliseconds();
+        out.println("          - idleStartMilliseconds: " + idleStartMilliseconds
+            + "(" + Util.XS_DATETIME_FORMATTER.format(idleStartMilliseconds) + ")");
+        out.println("          - progress: " + executor.getProgress());
+        out.println("          - state: " + executor.getState());
         WorkUnit workUnit = executor.getCurrentWorkUnit();
         if (workUnit != null) {
           out.println("          - currentWorkUnit: " + ContentFilter.filter(filter, workUnit.toString()));
         }
-        out.println("          - elapsedTime: " + executor.getElapsedTime());
         Queue.Executable executable = executor.getCurrentExecutable();
         if (executable != null) {
           out.println("          - executable: " + ContentFilter.filter(filter, executable.getParent().toString()));
+          out.println("          - elapsedTime: " + executor.getTimestampString());
         }
-        out.println("          - idle: " + executor.isIdle());
-        out.println("          - idleStartMilliseconds: " + executor.getIdleStartMilliseconds());
-        out.println("          - progress: " + executor.getProgress());
-        out.println("          - state: " + executor.getState());
       });
     }
   }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/NodeExecutors.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/NodeExecutors.java
@@ -126,7 +126,7 @@ public class NodeExecutors extends ObjectComponent<Computer> {
         out.println("          - idle: " + executor.isIdle());
         long idleStartMilliseconds = executor.getIdleStartMilliseconds();
         out.println("          - idleStartMilliseconds: " + idleStartMilliseconds
-            + "(" + Util.XS_DATETIME_FORMATTER.format(idleStartMilliseconds) + ")");
+            + " (" + Util.XS_DATETIME_FORMATTER.format(idleStartMilliseconds) + ")");
         out.println("          - progress: " + executor.getProgress());
         out.println("          - state: " + executor.getState());
         WorkUnit workUnit = executor.getCurrentWorkUnit();

--- a/src/main/java/com/cloudbees/jenkins/support/impl/NodeExecutors.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/NodeExecutors.java
@@ -1,0 +1,189 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 schristou88
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.support.impl;
+
+import com.cloudbees.jenkins.support.api.Container;
+import com.cloudbees.jenkins.support.api.ObjectComponent;
+import com.cloudbees.jenkins.support.api.ObjectComponentDescriptor;
+import com.cloudbees.jenkins.support.api.PrefilteredPrintedContent;
+import com.cloudbees.jenkins.support.filter.ContentFilter;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.AbstractModelObject;
+import hudson.model.Computer;
+import hudson.model.Node;
+import hudson.model.Queue;
+import hudson.model.queue.WorkUnit;
+import hudson.security.Permission;
+import jenkins.model.CauseOfInterruption;
+import jenkins.model.Jenkins;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.PrintWriter;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Gather information about the node executors.
+ */
+@Extension
+public class NodeExecutors extends ObjectComponent<Computer> {
+
+  @DataBoundConstructor
+  public NodeExecutors() {
+    super();
+  }
+
+  @NonNull
+  @Override
+  public Set<Permission> getRequiredPermissions() {
+    return Collections.singleton(Jenkins.ADMINISTER);
+  }
+
+  @NonNull
+  @Override
+  public String getDisplayName() {
+    return "Node Executors";
+  }
+
+  @Override
+  public void addContents(@NonNull Container container) {
+    container.add(new PrefilteredPrintedContent("executors.md") {
+        @Override
+        public void printTo(PrintWriter out, ContentFilter filter) {
+          try {
+            out.println("Nodes Executors");
+            out.println("===========");
+            out.println();
+
+            out.println("  * built-in (Jenkins)");
+            dumpExecutorInfo(Jenkins.get().toComputer(), out, filter);
+
+            Jenkins.get().getNodes().forEach(node -> {
+              out.println("  * " + ContentFilter.filter(filter, node.getDisplayName()));
+              dumpExecutorInfo(node.toComputer(), out, filter);
+            });
+
+          } finally {
+            out.flush();
+          }
+        }
+      }
+    );
+  }
+
+  @Override
+  public void addContents(@NonNull Container container, @NonNull Computer computer) {
+    container.add(new PrefilteredPrintedContent("executors.md") {
+      @Override
+      public void printTo(PrintWriter out, ContentFilter filter) {
+        try {
+          out.println("Node Executors");
+          out.println("===========");
+          out.println();
+
+          Node node = computer.getNode();
+          if (node != null) {
+            out.println("  * " + ContentFilter.filter(filter, node.getDisplayName()));
+            dumpExecutorInfo(node.toComputer(), out, filter);
+          }
+
+        } finally {
+          out.flush();
+        }
+      }
+    });
+  }
+
+  private void dumpExecutorInfo(@CheckForNull Computer computer, PrintWriter out, ContentFilter filter) {
+    if (computer != null) {
+      computer.getAllExecutors().forEach(executor -> {
+        out.println("      - " + ContentFilter.filter(filter, executor.getDisplayName()));
+        out.println("          - active: " + executor.isActive());
+        out.println("          - busy: " + executor.isBusy());
+        out.println("          - causesOfInterruption: [" + ContentFilter.filter(filter,
+            executor.getCausesOfInterruption().stream()
+                .map(CauseOfInterruption::getShortDescription)
+                .collect(Collectors.joining(","))) + "]");
+        WorkUnit workUnit = executor.getCurrentWorkUnit();
+        if (workUnit != null) {
+          out.println("          - currentWorkUnit: " + ContentFilter.filter(filter, workUnit.toString()));
+        }
+        out.println("          - elapsedTime: " + executor.getElapsedTime());
+        Queue.Executable executable = executor.getCurrentExecutable();
+        if (executable != null) {
+          out.println("          - executable: " + ContentFilter.filter(filter, executable.getParent().toString()));
+        }
+        out.println("          - idle: " + executor.isIdle());
+        out.println("          - idleStartMilliseconds: " + executor.getIdleStartMilliseconds());
+        out.println("          - progress: " + executor.getProgress());
+        out.println("          - state: " + executor.getState());
+      });
+    }
+  }
+
+  @NonNull
+  @Override
+  public ComponentCategory getCategory() {
+    return ComponentCategory.CONTROLLER;
+  }
+
+  @Override
+  public boolean isSelectedByDefault() {
+    return false;
+  }
+
+  @Override
+  public <C extends AbstractModelObject> boolean isApplicable(Class<C> clazz) {
+    return Jenkins.class.isAssignableFrom(clazz) || Computer.class.isAssignableFrom(clazz);
+  }
+
+  @Override
+  public boolean isApplicable(Computer item) {
+    return item != Jenkins.get().toComputer();
+  }
+
+  @Override
+  public DescriptorImpl getDescriptor() {
+    return Jenkins.get().getDescriptorByType(DescriptorImpl.class);
+  }
+
+  @Extension
+  @Symbol("nodeExecutors")
+  public static class DescriptorImpl extends ObjectComponentDescriptor<Computer> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public String getDisplayName() {
+      return "Node Executors";
+    }
+
+  }
+}

--- a/src/test/java/com/cloudbees/jenkins/support/impl/NodeExecutorsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/NodeExecutorsTest.java
@@ -1,0 +1,31 @@
+package com.cloudbees.jenkins.support.impl;
+
+import com.cloudbees.jenkins.support.SupportTestUtils;
+import hudson.model.Label;
+import hudson.slaves.DumbSlave;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the {@link NodeExecutors}
+ */
+public class NodeExecutorsTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void addContents() throws Exception {
+        DumbSlave agent = j.createOnlineSlave(Label.parseExpression("test"), null);
+
+        Map<String, String> output = SupportTestUtils.invokeComponentToMap(new NodeExecutors(), agent.toComputer());
+
+        assertTrue(output.keySet().stream().anyMatch(key -> key.matches("executors.md")));
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/support/impl/NodeExecutorsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/NodeExecutorsTest.java
@@ -18,8 +18,10 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Scanner;
 import java.util.regex.Pattern;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -38,33 +40,40 @@ public class NodeExecutorsTest {
 
         String executorMd = SupportTestUtils.invokeComponentToString(new NodeExecutors());
         assertNotNull(executorMd);
-        assertTrue(Pattern.compile(
-            " {2}\\* " + Objects.requireNonNull(j.jenkins.toComputer()).getDisplayName()+ "" + System.lineSeparator() +
-            " {6}- Executor #0" + System.lineSeparator() +
-            " {10}- active: true" + System.lineSeparator() +
-            " {10}- busy: false" + System.lineSeparator() +
-            " {10}- causesOfInterruption: \\[]" + System.lineSeparator() +
-            " {10}- idle: true" + System.lineSeparator() +
-            " {10}- idleStartMilliseconds: [0-9]* \\(.*\\)" + System.lineSeparator() +
-            " {10}- progress: -1" + System.lineSeparator() +
-            " {10}- state: NEW" + System.lineSeparator() +
-            " {6}- Executor #1" + System.lineSeparator() +
-            " {10}- active: true" + System.lineSeparator() +
-            " {10}- busy: false" + System.lineSeparator() +
-            " {10}- causesOfInterruption: \\[]" + System.lineSeparator() +
-            " {10}- idle: true" + System.lineSeparator() +
-            " {10}- idleStartMilliseconds: [0-9]* \\(.*\\)" + System.lineSeparator() +
-            " {10}- progress: -1" + System.lineSeparator() +
-            " {10}- state: NEW\n").matcher(executorMd).find());
-        assertTrue(Pattern.compile(" {2}\\* " + Objects.requireNonNull(agent.toComputer()).getDisplayName()+ "" + System.lineSeparator() +
-            " {6}- Executor #0" + System.lineSeparator() +
-            " {10}- active: true" + System.lineSeparator() +
-            " {10}- busy: false" + System.lineSeparator() +
-            " {10}- causesOfInterruption: \\[]" + System.lineSeparator() +
-            " {10}- idle: true" + System.lineSeparator() +
-            " {10}- idleStartMilliseconds: [0-9]* \\(.*\\)" + System.lineSeparator() +
-            " {10}- progress: -1" + System.lineSeparator() +
-            " {10}- state: NEW\n").matcher(executorMd).find());
+        String [] agentSnippets = executorMd.split(" {2}\\* ");
+        // headers, built-in node and permanent agent
+        assertEquals(3, agentSnippets.length);
+        Scanner scanner = new Scanner(agentSnippets[1]);
+        assertTrue(scanner.nextLine().contains(Objects.requireNonNull(j.jenkins.toComputer()).getDisplayName()));
+        assertTrue(scanner.nextLine().contains("- Executor #0"));
+        assertTrue(scanner.nextLine().contains("- active: true"));
+        assertTrue(scanner.nextLine().contains("- busy: false"));
+        assertTrue(scanner.nextLine().contains("- causesOfInterruption: []"));
+        assertTrue(scanner.nextLine().contains("- idle: true"));
+        assertTrue(scanner.nextLine().contains("- idleStartMilliseconds:"));
+        assertTrue(scanner.nextLine().contains("- progress: -1"));
+        assertTrue(scanner.nextLine().contains("- state: NEW"));
+        assertTrue(scanner.nextLine().contains("- Executor #1"));
+        assertTrue(scanner.nextLine().contains("- active: true"));
+        assertTrue(scanner.nextLine().contains("- busy: false"));
+        assertTrue(scanner.nextLine().contains("- causesOfInterruption: []"));
+        assertTrue(scanner.nextLine().contains("- idle: true"));
+        assertTrue(scanner.nextLine().contains("- idleStartMilliseconds:"));
+        assertTrue(scanner.nextLine().contains("- progress: -1"));
+        assertTrue(scanner.nextLine().contains("- state: NEW"));
+        assertFalse(scanner.hasNextLine());
+        scanner = new Scanner(agentSnippets[2]);
+        assertTrue(scanner.nextLine().contains(Objects.requireNonNull(agent.toComputer()).getDisplayName()));
+        assertTrue(scanner.nextLine().contains("- Executor #0"));
+        assertTrue(scanner.nextLine().contains("- active: true"));
+        assertTrue(scanner.nextLine().contains("- busy: false"));
+        assertTrue(scanner.nextLine().contains("- causesOfInterruption: []"));
+        assertTrue(scanner.nextLine().contains("- idle: true"));
+        assertTrue(scanner.nextLine().contains("- idleStartMilliseconds:"));
+        assertTrue(scanner.nextLine().contains("- progress: -1"));
+        assertTrue(scanner.nextLine().contains("- state: NEW"));
+        assertFalse(scanner.hasNextLine());
+        scanner.close();
 
         // No running task
         assertFalse(executorMd.contains("- currentWorkUnit:"));
@@ -87,19 +96,25 @@ public class NodeExecutorsTest {
         assertNotNull(executorMd);
         assertFalse(executorMd.contains("  * " + Objects.requireNonNull(j.jenkins.toComputer()).getDisplayName()));
         assertTrue(executorMd.contains("  * " + agent.getDisplayName()));
-        assertTrue(Pattern.compile(
-            " {2}\\* slave0" + System.lineSeparator() +
-                " {6}- Executor #0" + System.lineSeparator() +
-                " {10}- active: true" + System.lineSeparator() +
-                " {10}- busy: true" + System.lineSeparator() +
-                " {10}- causesOfInterruption: \\[]" + System.lineSeparator() +
-                " {10}- idle: false" + System.lineSeparator() +
-                " {10}- idleStartMilliseconds: [0-9]* \\(.*\\)" + System.lineSeparator() +
-                " {10}- progress: -1" + System.lineSeparator() +
-                " {10}- state: (?!NEW).*" + System.lineSeparator() +
-                " {10}- currentWorkUnit:.*" + workflowRun.getFullDisplayName() + ".*" + System.lineSeparator() +
-                " {10}- executable:.*" + workflowRun.getFullDisplayName() + ".*" + System.lineSeparator() +
-                " {10}- elapsedTime:.*").matcher(executorMd).find());
+
+        String [] agentSnippets = executorMd.split(" {2}\\* ");
+        // headers and the agent
+        assertEquals(2, agentSnippets.length);
+        Scanner scanner = new Scanner(agentSnippets[1]);
+        assertTrue(scanner.nextLine().contains(Objects.requireNonNull(agent.toComputer()).getDisplayName()));
+        assertTrue(scanner.nextLine().contains("- Executor #0"));
+        assertTrue(scanner.nextLine().contains("- active: true"));
+        assertTrue(scanner.nextLine().contains("- busy: true"));
+        assertTrue(scanner.nextLine().contains("- causesOfInterruption: []"));
+        assertTrue(scanner.nextLine().contains("- idle: false"));
+        assertTrue(scanner.nextLine().contains("- idleStartMilliseconds:"));
+        assertTrue(scanner.nextLine().contains("- progress: -1"));
+        assertTrue(Pattern.compile("- state: (?!NEW).*").matcher(scanner.nextLine()).find());
+        assertTrue(Pattern.compile("- currentWorkUnit:.*" + workflowRun.getFullDisplayName() + ".*").matcher(scanner.nextLine()).find());
+        assertTrue(Pattern.compile("- executable:.*" + workflowRun.getFullDisplayName() + ".*").matcher(scanner.nextLine()).find());
+        assertTrue(scanner.nextLine().contains("- elapsedTime: "));
+        assertFalse(scanner.hasNextLine());
+        scanner.close();
 
         SemaphoreStep.success("wait/1", null);
         j.waitForCompletion(workflowRun);
@@ -108,16 +123,21 @@ public class NodeExecutorsTest {
         assertNotNull(executorMd);
         assertFalse(executorMd.contains("  * " + Objects.requireNonNull(j.jenkins.toComputer()).getDisplayName()));
         assertTrue(executorMd.contains("  * " + agent.getDisplayName()));
-        assertTrue(Pattern.compile(
-            " {2}\\* slave0" + System.lineSeparator() +
-            " {6}- Executor #0" + System.lineSeparator() +
-            " {10}- active: true" + System.lineSeparator() +
-            " {10}- busy: false" + System.lineSeparator() +
-            " {10}- causesOfInterruption: \\[]" + System.lineSeparator() +
-            " {10}- idle: true" + System.lineSeparator() +
-            " {10}- idleStartMilliseconds: [0-9]* \\(.*\\)" + System.lineSeparator() +
-            " {10}- progress: -1" + System.lineSeparator() +
-            " {10}- state: NEW\n").matcher(executorMd).find());
+
+        agentSnippets = executorMd.split(" {2}\\* ");
+        // headers and the agent
+        assertEquals(2, agentSnippets.length);
+        scanner = new Scanner(agentSnippets[1]);
+        assertTrue(scanner.nextLine().contains(Objects.requireNonNull(agent.toComputer()).getDisplayName()));
+        assertTrue(scanner.nextLine().contains("- Executor #0"));
+        assertTrue(scanner.nextLine().contains("- active: true"));
+        assertTrue(scanner.nextLine().contains("- busy: false"));
+        assertTrue(scanner.nextLine().contains("- causesOfInterruption: []"));
+        assertTrue(scanner.nextLine().contains("- idle: true"));
+        assertTrue(scanner.nextLine().contains("- idleStartMilliseconds:"));
+        assertTrue(scanner.nextLine().contains("- progress: -1"));
+        assertTrue(scanner.nextLine().contains("- state: NEW"));
+        assertFalse(scanner.hasNextLine());
 
         // No running task
         assertFalse(executorMd.contains("- currentWorkUnit:"));

--- a/src/test/java/com/cloudbees/jenkins/support/impl/NodeExecutorsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/NodeExecutorsTest.java
@@ -39,31 +39,31 @@ public class NodeExecutorsTest {
         String executorMd = SupportTestUtils.invokeComponentToString(new NodeExecutors());
         assertNotNull(executorMd);
         assertTrue(Pattern.compile(
-            " {2}\\* " + Objects.requireNonNull(j.jenkins.toComputer()).getDisplayName()+ "\n" +
-            " {6}- Executor #0\n" +
-            " {10}- active: true\n" +
-            " {10}- busy: false\n" +
-            " {10}- causesOfInterruption: \\[]\n" +
-            " {10}- idle: true\n" +
-            " {10}- idleStartMilliseconds: [0-9]* \\(.*\\)\n" +
-            " {10}- progress: -1\n" +
-            " {10}- state: NEW\n" +
-            " {6}- Executor #1\n" +
-            " {10}- active: true\n" +
-            " {10}- busy: false\n" +
-            " {10}- causesOfInterruption: \\[]\n" +
-            " {10}- idle: true\n" +
-            " {10}- idleStartMilliseconds: [0-9]* \\(.*\\)\n" +
-            " {10}- progress: -1\n" +
+            " {2}\\* " + Objects.requireNonNull(j.jenkins.toComputer()).getDisplayName()+ "" + System.lineSeparator() +
+            " {6}- Executor #0" + System.lineSeparator() +
+            " {10}- active: true" + System.lineSeparator() +
+            " {10}- busy: false" + System.lineSeparator() +
+            " {10}- causesOfInterruption: \\[]" + System.lineSeparator() +
+            " {10}- idle: true" + System.lineSeparator() +
+            " {10}- idleStartMilliseconds: [0-9]* \\(.*\\)" + System.lineSeparator() +
+            " {10}- progress: -1" + System.lineSeparator() +
+            " {10}- state: NEW" + System.lineSeparator() +
+            " {6}- Executor #1" + System.lineSeparator() +
+            " {10}- active: true" + System.lineSeparator() +
+            " {10}- busy: false" + System.lineSeparator() +
+            " {10}- causesOfInterruption: \\[]" + System.lineSeparator() +
+            " {10}- idle: true" + System.lineSeparator() +
+            " {10}- idleStartMilliseconds: [0-9]* \\(.*\\)" + System.lineSeparator() +
+            " {10}- progress: -1" + System.lineSeparator() +
             " {10}- state: NEW\n").matcher(executorMd).find());
-        assertTrue(Pattern.compile(" {2}\\* " + Objects.requireNonNull(agent.toComputer()).getDisplayName()+ "\n" +
-            " {6}- Executor #0\n" +
-            " {10}- active: true\n" +
-            " {10}- busy: false\n" +
-            " {10}- causesOfInterruption: \\[]\n" +
-            " {10}- idle: true\n" +
-            " {10}- idleStartMilliseconds: [0-9]* \\(.*\\)\n" +
-            " {10}- progress: -1\n" +
+        assertTrue(Pattern.compile(" {2}\\* " + Objects.requireNonNull(agent.toComputer()).getDisplayName()+ "" + System.lineSeparator() +
+            " {6}- Executor #0" + System.lineSeparator() +
+            " {10}- active: true" + System.lineSeparator() +
+            " {10}- busy: false" + System.lineSeparator() +
+            " {10}- causesOfInterruption: \\[]" + System.lineSeparator() +
+            " {10}- idle: true" + System.lineSeparator() +
+            " {10}- idleStartMilliseconds: [0-9]* \\(.*\\)" + System.lineSeparator() +
+            " {10}- progress: -1" + System.lineSeparator() +
             " {10}- state: NEW\n").matcher(executorMd).find());
 
         // No running task
@@ -88,17 +88,17 @@ public class NodeExecutorsTest {
         assertFalse(executorMd.contains("  * " + Objects.requireNonNull(j.jenkins.toComputer()).getDisplayName()));
         assertTrue(executorMd.contains("  * " + agent.getDisplayName()));
         assertTrue(Pattern.compile(
-            " {2}\\* slave0\n" +
-                " {6}- Executor #0\n" +
-                " {10}- active: true\n" +
-                " {10}- busy: true\n" +
-                " {10}- causesOfInterruption: \\[]\n" +
-                " {10}- idle: false\n" +
-                " {10}- idleStartMilliseconds: [0-9]* \\(.*\\)\n" +
-                " {10}- progress: -1\n" +
-                " {10}- state: (?!NEW).*\n" +
-                " {10}- currentWorkUnit:.*" + workflowRun.getFullDisplayName() + ".*\n" +
-                " {10}- executable:.*" + workflowRun.getFullDisplayName() + ".*\n" +
+            " {2}\\* slave0" + System.lineSeparator() +
+                " {6}- Executor #0" + System.lineSeparator() +
+                " {10}- active: true" + System.lineSeparator() +
+                " {10}- busy: true" + System.lineSeparator() +
+                " {10}- causesOfInterruption: \\[]" + System.lineSeparator() +
+                " {10}- idle: false" + System.lineSeparator() +
+                " {10}- idleStartMilliseconds: [0-9]* \\(.*\\)" + System.lineSeparator() +
+                " {10}- progress: -1" + System.lineSeparator() +
+                " {10}- state: (?!NEW).*" + System.lineSeparator() +
+                " {10}- currentWorkUnit:.*" + workflowRun.getFullDisplayName() + ".*" + System.lineSeparator() +
+                " {10}- executable:.*" + workflowRun.getFullDisplayName() + ".*" + System.lineSeparator() +
                 " {10}- elapsedTime:.*").matcher(executorMd).find());
 
         SemaphoreStep.success("wait/1", null);
@@ -109,14 +109,14 @@ public class NodeExecutorsTest {
         assertFalse(executorMd.contains("  * " + Objects.requireNonNull(j.jenkins.toComputer()).getDisplayName()));
         assertTrue(executorMd.contains("  * " + agent.getDisplayName()));
         assertTrue(Pattern.compile(
-            " {2}\\* slave0\n" +
-            " {6}- Executor #0\n" +
-            " {10}- active: true\n" +
-            " {10}- busy: false\n" +
-            " {10}- causesOfInterruption: \\[]\n" +
-            " {10}- idle: true\n" +
-            " {10}- idleStartMilliseconds: [0-9]* \\(.*\\)\n" +
-            " {10}- progress: -1\n" +
+            " {2}\\* slave0" + System.lineSeparator() +
+            " {6}- Executor #0" + System.lineSeparator() +
+            " {10}- active: true" + System.lineSeparator() +
+            " {10}- busy: false" + System.lineSeparator() +
+            " {10}- causesOfInterruption: \\[]" + System.lineSeparator() +
+            " {10}- idle: true" + System.lineSeparator() +
+            " {10}- idleStartMilliseconds: [0-9]* \\(.*\\)" + System.lineSeparator() +
+            " {10}- progress: -1" + System.lineSeparator() +
             " {10}- state: NEW\n").matcher(executorMd).find());
 
         // No running task

--- a/src/test/java/com/cloudbees/jenkins/support/impl/NodeExecutorsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/NodeExecutorsTest.java
@@ -1,14 +1,26 @@
 package com.cloudbees.jenkins.support.impl;
 
+import com.cloudbees.jenkins.support.SupportPlugin;
 import com.cloudbees.jenkins.support.SupportTestUtils;
+import com.cloudbees.jenkins.support.filter.ContentFilter;
+import com.cloudbees.jenkins.support.filter.ContentFilters;
+import com.cloudbees.jenkins.support.filter.ContentMappings;
 import hudson.model.Label;
 import hudson.slaves.DumbSlave;
+import junit.framework.AssertionFailedError;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Pattern;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -24,8 +36,124 @@ public class NodeExecutorsTest {
     public void addContents() throws Exception {
         DumbSlave agent = j.createOnlineSlave(Label.parseExpression("test"), null);
 
-        Map<String, String> output = SupportTestUtils.invokeComponentToMap(new NodeExecutors(), agent.toComputer());
+        String executorMd = SupportTestUtils.invokeComponentToString(new NodeExecutors());
+        assertNotNull(executorMd);
+        assertTrue(Pattern.compile(
+            " {2}\\* " + Objects.requireNonNull(j.jenkins.toComputer()).getDisplayName()+ "\n" +
+            " {6}- Executor #0\n" +
+            " {10}- active: true\n" +
+            " {10}- busy: false\n" +
+            " {10}- causesOfInterruption: \\[]\n" +
+            " {10}- idle: true\n" +
+            " {10}- idleStartMilliseconds: [0-9]* \\(.*\\)\n" +
+            " {10}- progress: -1\n" +
+            " {10}- state: NEW\n" +
+            " {6}- Executor #1\n" +
+            " {10}- active: true\n" +
+            " {10}- busy: false\n" +
+            " {10}- causesOfInterruption: \\[]\n" +
+            " {10}- idle: true\n" +
+            " {10}- idleStartMilliseconds: [0-9]* \\(.*\\)\n" +
+            " {10}- progress: -1\n" +
+            " {10}- state: NEW\n").matcher(executorMd).find());
+        assertTrue(Pattern.compile(" {2}\\* " + Objects.requireNonNull(agent.toComputer()).getDisplayName()+ "\n" +
+            " {6}- Executor #0\n" +
+            " {10}- active: true\n" +
+            " {10}- busy: false\n" +
+            " {10}- causesOfInterruption: \\[]\n" +
+            " {10}- idle: true\n" +
+            " {10}- idleStartMilliseconds: [0-9]* \\(.*\\)\n" +
+            " {10}- progress: -1\n" +
+            " {10}- state: NEW\n").matcher(executorMd).find());
 
-        assertTrue(output.keySet().stream().anyMatch(key -> key.matches("executors.md")));
+        // No running task
+        assertFalse(executorMd.contains("- currentWorkUnit:"));
+        assertFalse(executorMd.contains("- executable:"));
+        assertFalse(executorMd.contains("- elapsedTime:"));
+    }
+
+    @Test
+    public void addContentsRunningBuild() throws Exception {
+        DumbSlave agent = j.createOnlineSlave(Label.parseExpression("test"), null);
+
+        WorkflowJob p = j.createProject(WorkflowJob.class, "nodeExecutorTestJob");
+        p.setDefinition(new CpsFlowDefinition("node('test') {semaphore 'wait'}", true));
+        WorkflowRun workflowRun = Optional.ofNullable(p.scheduleBuild2(0))
+            .orElseThrow(AssertionFailedError::new)
+            .waitForStart();
+        j.waitForMessage("Running on", workflowRun);
+
+        String executorMd = SupportTestUtils.invokeComponentToMap(new NodeExecutors(), agent.toComputer()).get("executors.md");
+        assertNotNull(executorMd);
+        assertFalse(executorMd.contains("  * " + Objects.requireNonNull(j.jenkins.toComputer()).getDisplayName()));
+        assertTrue(executorMd.contains("  * " + agent.getDisplayName()));
+        assertTrue(Pattern.compile(
+            " {2}\\* slave0\n" +
+                " {6}- Executor #0\n" +
+                " {10}- active: true\n" +
+                " {10}- busy: true\n" +
+                " {10}- causesOfInterruption: \\[]\n" +
+                " {10}- idle: false\n" +
+                " {10}- idleStartMilliseconds: [0-9]* \\(.*\\)\n" +
+                " {10}- progress: -1\n" +
+                " {10}- state: (?!NEW).*\n" +
+                " {10}- currentWorkUnit:.*" + workflowRun.getFullDisplayName() + ".*\n" +
+                " {10}- executable:.*" + workflowRun.getFullDisplayName() + ".*\n" +
+                " {10}- elapsedTime:.*").matcher(executorMd).find());
+
+        SemaphoreStep.success("wait/1", null);
+        j.waitForCompletion(workflowRun);
+
+        executorMd = SupportTestUtils.invokeComponentToMap(new NodeExecutors(), agent.toComputer()).get("executors.md");
+        assertNotNull(executorMd);
+        assertFalse(executorMd.contains("  * " + Objects.requireNonNull(j.jenkins.toComputer()).getDisplayName()));
+        assertTrue(executorMd.contains("  * " + agent.getDisplayName()));
+        assertTrue(Pattern.compile(
+            " {2}\\* slave0\n" +
+            " {6}- Executor #0\n" +
+            " {10}- active: true\n" +
+            " {10}- busy: false\n" +
+            " {10}- causesOfInterruption: \\[]\n" +
+            " {10}- idle: true\n" +
+            " {10}- idleStartMilliseconds: [0-9]* \\(.*\\)\n" +
+            " {10}- progress: -1\n" +
+            " {10}- state: NEW\n").matcher(executorMd).find());
+
+        // No running task
+        assertFalse(executorMd.contains("- currentWorkUnit:"));
+        assertFalse(executorMd.contains("- executable:"));
+        assertFalse(executorMd.contains("- elapsedTime:"));
+    }
+
+    @Test
+    public void addContentsFiltered() throws Exception {
+        ContentFilters.get().setEnabled(true);
+        DumbSlave agent = j.createOnlineSlave(Label.parseExpression("test"), null);
+
+        WorkflowJob p = j.createProject(WorkflowJob.class, "nodeExecutorTestJob");
+        p.setDefinition(new CpsFlowDefinition("node('test') {semaphore 'wait'}", true));
+        WorkflowRun workflowRun = Optional.ofNullable(p.scheduleBuild2(0))
+            .orElseThrow(AssertionFailedError::new)
+            .waitForStart();
+        j.waitForMessage("Running on", workflowRun);
+
+        ContentFilter filter = SupportPlugin.getContentFilter().orElseThrow(AssertionFailedError::new);
+
+        String filteredNodeName = ContentMappings.get().getMappings().get(agent.getNodeName());
+        String filteredNodeDisplayName = ContentMappings.get().getMappings().get(agent.getDisplayName());
+
+        String filteredJobName = ContentMappings.get().getMappings().get(p.getName());
+        String filteredJobDisplayName = ContentMappings.get().getMappings().get(p.getDisplayName());
+
+        String executorMd = SupportTestUtils.invokeComponentToString(new NodeExecutors(), filter);
+        assertNotNull(executorMd);
+        assertFalse(executorMd.contains(p.getName()));
+        assertFalse(executorMd.contains(p.getDisplayName()));
+        assertFalse(executorMd.contains(agent.getNodeName()));
+        assertFalse(executorMd.contains(agent.getDisplayName()));
+        assertTrue(executorMd.contains(filteredNodeName));
+        assertTrue(executorMd.contains(filteredNodeDisplayName));
+        assertTrue(executorMd.contains(filteredJobName));
+        assertTrue(executorMd.contains(filteredJobDisplayName));
     }
 }


### PR DESCRIPTION
[JENKINS-71732](https://issues.jenkins.io/browse/JENKINS-71732): when recently troubleshooting issue with pipeline execution leaks on heavyweight executors (https://issues.jenkins.io/browse/JENKINS-71692), I found it hard to get information about the state of the executor and what was running on it from a Support Bundle. And other components such as thread dumps / pipeline thread dumps did not help either... So proposing a component that dumps the node executors details (not selected by default).

### Testing done

* Generate a Support Bundle with the "Node Executors" component selected:

```
Nodes Executors
===========

  * built-in (Jenkins)
      - Executor #-1
          - active: true
          - busy: true
          - causesOfInterruption: []
          - currentWorkUnit: hudson.model.queue.WorkUnit@5497813c[work=item_visible_omission » item_national_mosaic » item_first_difficulty #26]
          - elapsedTime: 93413
          - executable: org.jenkinsci.plugins.workflow.job.WorkflowJob@74a96fcf[item_visible_omission/item_national_mosaic/item_first_difficulty]
          - idle: false
          - idleStartMilliseconds: 1690860144069
          - progress: 99
          - state: TERMINATED
  * computer_appropriate_vein
      - Executor #0
          - active: true
          - busy: true
          - causesOfInterruption: []
          - currentWorkUnit: hudson.model.queue.WorkUnit@23dd8d[work=item_visible_omission » item_national_mosaic » item_first_difficulty #26 (Sleep)]
          - elapsedTime: 80003
          - executable: ExecutorStepExecution.PlaceholderTask{runId=item_visible_omission/item_national_mosaic/item_first_difficulty#26,label=computer_appropriate_vein,context=CpsStepContext[5:node]:Owner[item_visible_omission/item_national_mosaic/item_first_difficulty/26:item_visible_omission/item_national_mosaic/item_first_difficulty #26],cookie=e3b4dd75-68bf-4a94-a9a7-77c98de899d6,auth=null}
          - idle: false
          - idleStartMilliseconds: 1690860144075
          - progress: 99
          - state: TERMINATED
```


* Start a pipeline that sleeps, then generate an Agent Bundle with the "Node Executors" component selected. validate the information:

```
Node Executors
===========

  * computer_interesting_liability
      - Executor #0
          - active: true
          - busy: true
          - causesOfInterruption: []
          - currentWorkUnit: hudson.model.queue.WorkUnit@511d2729[work=item_visible_omission » item_national_mosaic » item_first_difficulty #25 (Sleep)]
          - elapsedTime: 5299629
          - executable: PlaceholderExecutable:ExecutorStepExecution.PlaceholderTask{runId=item_visible_omission/item_national_mosaic/item_first_difficulty#25,label=computer_interesting_liability,context=CpsStepContext[5:node]:Owner[item_visible_omission/item_national_mosaic/item_first_difficulty/25:item_visible_omission/item_national_mosaic/item_first_difficulty #25],cookie=f957cc44-539e-488d-93c8-d323477f4d6a,auth=null}
          - idle: false
          - idleStartMilliseconds: 1690857010516
          - progress: 99
          - state: TERMINATED
```

* Start a pipeline that sleeps, then abort it and immediately generate an Agent Bundle with the "Node Executors" component selected. Validate the information, including cause of interruptions in that case:

```
Node Executors
===========

  * computer_appropriate_vein
      - Executor #0
          - active: true
          - busy: true
          - causesOfInterruption: [Aborted by user_terminal_composer]
          - currentWorkUnit: hudson.model.queue.WorkUnit@23dd8d[work=part of item_visible_omission » item_national_mosaic » item_first_difficulty #26]
          - elapsedTime: 97796
          - executable: ExecutorStepExecution.PlaceholderTask{runId=item_visible_omission/item_national_mosaic/item_first_difficulty#26,label=computer_appropriate_vein,context=CpsStepContext[5:node]:Owner[item_visible_omission/item_national_mosaic/item_first_difficulty/26:item_visible_omission/item_national_mosaic/item_first_difficulty #26],cookie=e3b4dd75-68bf-4a94-a9a7-77c98de899d6,auth=null}
          - idle: false
          - idleStartMilliseconds: 1690860161868
          - progress: 99
          - state: TERMINATED
```

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```