### PR TITLE
Modify Pipeline-related test assertions to not assume that `SimpleXStreamFlowNodeStorage` is being used

### DIFF
--- a/src/test/java/com/cloudbees/jenkins/support/actions/SupportAbstractItemActionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/actions/SupportAbstractItemActionTest.java
@@ -1,5 +1,8 @@
 package com.cloudbees.jenkins.support.actions;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -10,9 +13,11 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.model.queue.QueueTaskFuture;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import jenkins.model.Jenkins;
 import junit.framework.AssertionFailedError;
@@ -127,6 +132,8 @@ public class SupportAbstractItemActionTest {
         assertNotNull(z.getEntry("manifest.md"));
         assertNotNull(z.getEntry(itemEntryPrefix + "/config.xml"));
         assertNotNull(z.getEntry(itemEntryPrefix + "/builds/1/build.xml"));
-        assertNotNull(z.getEntry(itemEntryPrefix + "/builds/1/workflow/2.xml"));
+        assertThat(
+                Collections.list(z.entries()).stream().map(ZipEntry::getName).collect(Collectors.toList()),
+                hasItem(startsWith(itemEntryPrefix + "/builds/1/workflow")));
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/support/impl/AbstractItemComponentTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/AbstractItemComponentTest.java
@@ -2,6 +2,9 @@ package com.cloudbees.jenkins.support.impl;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -168,7 +171,7 @@ public class AbstractItemComponentTest {
         assertTrue(output.containsKey(prefix + "/nextBuildNumber"));
         assertTrue(output.containsKey(prefix + "/builds/1/build.xml"));
         assertTrue(output.containsKey(prefix + "/builds/1/log"));
-        assertTrue(output.containsKey(prefix + "/builds/1/workflow/2.xml"));
+        assertThat(output.keySet(), hasItem(startsWith(prefix + "/builds/1/workflow")));
         assertThat(output.get(prefix + "/config.xml"), containsString("<flow-definition"));
         assertThat(output.get(prefix + "/nextBuildNumber"), containsString("2"));
     }
@@ -196,7 +199,7 @@ public class AbstractItemComponentTest {
         assertTrue(output.containsKey(prefix + "/config.xml"));
         assertFalse(output.containsKey(prefix + "/builds/1/build.xml"));
         assertFalse(output.containsKey(prefix + "/builds/1/log"));
-        assertFalse(output.containsKey(prefix + "/builds/1/workflow/2.xml"));
+        assertThat(output.keySet(), not(hasItem(startsWith(prefix + "/builds/1/workflow"))));
     }
 
     /*
@@ -220,7 +223,7 @@ public class AbstractItemComponentTest {
         assertTrue(output.containsKey(prefix + "/config.xml"));
         assertTrue(output.containsKey(prefix + "/builds/1/build.xml"));
         assertFalse(output.containsKey(prefix + "/builds/1/log"));
-        assertFalse(output.containsKey(prefix + "/builds/1/workflow/2.xml"));
+        assertThat(output.keySet(), not(hasItem(startsWith(prefix + "/builds/1/workflow"))));
     }
 
     /*
@@ -244,7 +247,7 @@ public class AbstractItemComponentTest {
         assertTrue(output.containsKey(prefix + "/config.xml"));
         assertTrue(output.containsKey(prefix + "/builds/1/build.xml"));
         assertTrue(output.containsKey(prefix + "/builds/1/log"));
-        assertFalse(output.containsKey(prefix + "/builds/1/workflow/2.xml"));
+        assertThat(output.keySet(), not(hasItem(startsWith(prefix + "/builds/1/workflow"))));
     }
 
     /*
@@ -262,12 +265,12 @@ public class AbstractItemComponentTest {
         j.waitUntilNoActivity();
 
         Map<String, String> output = SupportTestUtils.invokeComponentToMap(
-                new AbstractItemDirectoryComponent("**/*.xml", "**/workflow/**", true, 10), p);
+                new AbstractItemDirectoryComponent("**/*.xml", "**/workflow*/**", true, 10), p);
 
         String prefix = "items/" + JOB_NAME;
         assertTrue(output.containsKey(prefix + "/config.xml"));
         assertTrue(output.containsKey(prefix + "/builds/1/build.xml"));
         assertFalse(output.containsKey(prefix + "/builds/1/log"));
-        assertFalse(output.containsKey(prefix + "/builds/1/workflow/2.xml"));
+        assertThat(output.keySet(), not(hasItem(startsWith(prefix + "/builds/1/workflow"))));
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/support/impl/RunDirectoryComponentTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/RunDirectoryComponentTest.java
@@ -1,6 +1,9 @@
 package com.cloudbees.jenkins.support.impl;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -59,7 +62,7 @@ public class RunDirectoryComponentTest {
         String prefix = "items/" + JOB_NAME + "/builds/" + workflowRun.number;
         assertTrue(output.containsKey(prefix + "/build.xml"));
         assertTrue(output.containsKey(prefix + "/log"));
-        assertTrue(output.containsKey(prefix + "/workflow/2.xml"));
+        assertThat(output.keySet(), hasItem(startsWith(prefix + "/workflow")));
         assertThat(output.get(prefix + "/build.xml"), Matchers.containsString("<flow-build"));
         assertThat(output.get(prefix + "/log"), Matchers.containsString("[Pipeline] node"));
     }
@@ -76,12 +79,12 @@ public class RunDirectoryComponentTest {
         j.waitUntilNoActivity();
 
         Map<String, String> output = SupportTestUtils.invokeComponentToMap(
-                new RunDirectoryComponent("", "workflow/**, */log", true, 10), workflowRun);
+                new RunDirectoryComponent("", "workflow*/**, */log", true, 10), workflowRun);
 
         String prefix = "items/" + JOB_NAME + "/builds/" + workflowRun.number;
         assertTrue(output.containsKey(prefix + "/build.xml"));
         assertTrue(output.containsKey(prefix + "/log"));
-        assertFalse(output.containsKey(prefix + "/workflow/2.xml"));
+        assertThat(output.keySet(), not(hasItem(startsWith(prefix + "/workflow"))));
     }
 
     @Test
@@ -96,12 +99,12 @@ public class RunDirectoryComponentTest {
         j.waitUntilNoActivity();
 
         Map<String, String> output = SupportTestUtils.invokeComponentToMap(
-                new RunDirectoryComponent("workflow/**", "", true, 10), workflowRun);
+                new RunDirectoryComponent("workflow*/**", "", true, 10), workflowRun);
 
         String prefix = "items/" + JOB_NAME + "/builds/" + workflowRun.number;
         assertFalse(output.containsKey(prefix + "/build.xml"));
         assertFalse(output.containsKey(prefix + "/log"));
-        assertTrue(output.containsKey(prefix + "/workflow/2.xml"));
+        assertThat(output.keySet(), hasItem(startsWith(prefix + "/workflow")));
     }
 
     @Test
@@ -121,7 +124,7 @@ public class RunDirectoryComponentTest {
         String prefix = "items/" + JOB_NAME + "/builds/" + workflowRun.number;
         assertTrue(output.containsKey(prefix + "/build.xml"));
         assertTrue(output.containsKey(prefix + "/log"));
-        assertFalse(output.containsKey(prefix + "/workflow/2.xml"));
+        assertThat(output.keySet(), not(hasItem(startsWith(prefix + "/workflow"))));
     }
 
     @Test
@@ -136,11 +139,11 @@ public class RunDirectoryComponentTest {
         j.waitUntilNoActivity();
 
         Map<String, String> output = SupportTestUtils.invokeComponentToMap(
-                new RunDirectoryComponent("**/*.xml", "workflow/**", true, 10), workflowRun);
+                new RunDirectoryComponent("**/*.xml", "workflow*/**", true, 10), workflowRun);
 
         String prefix = "items/" + JOB_NAME + "/builds/" + workflowRun.number;
         assertTrue(output.containsKey(prefix + "/build.xml"));
         assertFalse(output.containsKey(prefix + "/log"));
-        assertFalse(output.containsKey(prefix + "/workflow/2.xml"));
+        assertThat(output.keySet(), not(hasItem(startsWith(prefix + "/workflow"))));
     }
 }


### PR DESCRIPTION
As of https://github.com/jenkinsci/workflow-cps-plugin/pull/807, `BulkFlowNodeStorage` will be used by default for completed Pipelines, and the flow node data will be stored in a single file in a `/workflow-completed` directory, not as individual files in `/workflow`, so various test assertions in this plugin need to be modified.

I tested this manually against `workflow-cps` [3806.va_3a_6988277b_2](https://github.com/jenkinsci/workflow-cps-plugin/releases/tag/3806.va_3a_6988277b_2), but consuming that here requires both Jenkins minimum version updates and BOM updates, so I left those changes out here.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
