### PR TITLE
Stop bundling SLF4J JAR file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,13 @@
       <groupId>net.sf.uadetector</groupId>
       <artifactId>uadetector-resources</artifactId>
       <version>2014.10</version>
+      <exclusions>
+        <!-- Provided by core -->
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!-- Managed by BOM -->
     <dependency>


### PR DESCRIPTION
This library has been provided by core for a long time.