### PR TITLE
Use a passthrough filter if Anonymization disabled

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/api/BaseFileContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/BaseFileContent.java
@@ -26,6 +26,7 @@ package com.cloudbees.jenkins.support.api;
 
 import com.cloudbees.jenkins.support.filter.ContentFilter;
 import com.cloudbees.jenkins.support.util.StreamUtils;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Functions;
 import java.io.BufferedReader;
 import java.io.File;
@@ -122,8 +123,8 @@ class BaseFileContent {
         }
     }
 
-    protected void writeTo(OutputStream os, ContentFilter filter) throws IOException {
-        if (isBinary || filter == null) {
+    protected void writeTo(OutputStream os, @NonNull ContentFilter filter) throws IOException {
+        if (isBinary) {
             writeTo(os);
         }
 

--- a/src/main/java/com/cloudbees/jenkins/support/api/FileContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/FileContent.java
@@ -26,6 +26,7 @@ package com.cloudbees.jenkins.support.api;
 
 import com.cloudbees.jenkins.support.filter.ContentFilter;
 import com.cloudbees.jenkins.support.filter.PrefilteredContent;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Functions;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -73,7 +74,7 @@ public class FileContent extends PrefilteredContent {
     }
 
     @Override
-    public void writeTo(OutputStream os, ContentFilter filter) throws IOException {
+    public void writeTo(OutputStream os, @NonNull ContentFilter filter) throws IOException {
         baseFileContent.writeTo(os, filter);
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/api/PrefilteredPrintedContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/PrefilteredPrintedContent.java
@@ -29,6 +29,7 @@ import com.cloudbees.jenkins.support.filter.FilteredOutputStream;
 import com.cloudbees.jenkins.support.filter.PrefilteredContent;
 import com.cloudbees.jenkins.support.util.IgnoreCloseWriter;
 import com.cloudbees.jenkins.support.util.WrapperOutputStream;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -52,11 +53,11 @@ public abstract class PrefilteredPrintedContent extends PrefilteredContent {
 
     @Override
     public final void writeTo(OutputStream os) throws IOException {
-        writeTo(os, null);
+        writeTo(os, ContentFilter.NONE);
     }
 
     @Override
-    public void writeTo(OutputStream os, ContentFilter filter) throws IOException {
+    public void writeTo(OutputStream os, @NonNull ContentFilter filter) throws IOException {
         final PrintWriter writer = getWriter(os);
         try {
             printTo(writer, filter);
@@ -83,8 +84,8 @@ public abstract class PrefilteredPrintedContent extends PrefilteredContent {
     }
 
     protected void printTo(PrintWriter out) throws IOException {
-        printTo(out, null);
+        printTo(out, ContentFilter.NONE);
     }
 
-    protected abstract void printTo(PrintWriter out, ContentFilter filter) throws IOException;
+    protected abstract void printTo(PrintWriter out, @NonNull ContentFilter filter) throws IOException;
 }

--- a/src/main/java/com/cloudbees/jenkins/support/api/StringContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/StringContent.java
@@ -26,8 +26,10 @@ package com.cloudbees.jenkins.support.api;
 
 import com.cloudbees.jenkins.support.filter.ContentFilter;
 import com.cloudbees.jenkins.support.filter.PrefilteredContent;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Content that is a string.
@@ -50,12 +52,12 @@ public class StringContent extends PrefilteredContent {
 
     @Override
     public void writeTo(OutputStream os) throws IOException {
-        writeTo(os, null);
+        writeTo(os, ContentFilter.NONE);
     }
 
     @Override
-    public void writeTo(OutputStream os, ContentFilter filter) throws IOException {
+    public void writeTo(OutputStream os, @NonNull ContentFilter filter) throws IOException {
         String filtered = ContentFilter.filter(filter, value);
-        os.write(filtered.getBytes("UTF-8"));
+        os.write(filtered.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/filter/AllContentFilters.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/AllContentFilters.java
@@ -45,11 +45,6 @@ class AllContentFilters implements ContentFilter {
     }
 
     @Override
-    public void ensureLoaded() {
-        ContentFilter.all().forEach(ContentFilter::ensureLoaded);
-    }
-
-    @Override
     public void reload() {
         ContentFilter.all().forEach(ContentFilter::reload);
     }

--- a/src/main/java/com/cloudbees/jenkins/support/filter/ContentFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/ContentFilter.java
@@ -51,6 +51,11 @@ public interface ContentFilter extends ExtensionPoint {
     ContentFilter ALL = new AllContentFilters();
 
     /**
+     * Provides a noop ContentFilter that pass through the value.
+     */
+    ContentFilter NONE = new NoneFilter();
+
+    /**
      * Filters a line or snippet of text.
      *
      * @param input input data to filter
@@ -61,7 +66,9 @@ public interface ContentFilter extends ExtensionPoint {
 
     /**
      * Ensure that the filter has been loaded at least once.
+     * @deprecated use reload() instead
      */
+    @Deprecated
     default void ensureLoaded() {}
 
     /**
@@ -76,8 +83,8 @@ public interface ContentFilter extends ExtensionPoint {
      * @param text the text to filter
      * @return the text filtered if it is not empty and the filter is not null
      */
-    static String filter(@CheckForNull ContentFilter filter, @CheckForNull String text) {
-        if (filter != null && StringUtils.isNotEmpty(text)) {
+    static String filter(@NonNull ContentFilter filter, @CheckForNull String text) {
+        if (StringUtils.isNotEmpty(text)) {
             return filter.filter(text);
         } else {
             return text;

--- a/src/main/java/com/cloudbees/jenkins/support/filter/NoneFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/NoneFilter.java
@@ -1,0 +1,17 @@
+package com.cloudbees.jenkins.support.filter;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * A {@link ContentFilter} that blindly pass the value through.
+ */
+@Restricted(NoExternalUse.class)
+public class NoneFilter implements ContentFilter {
+    @NonNull
+    @Override
+    public String filter(@NonNull String input) {
+        return input;
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/support/filter/PrefilteredContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/PrefilteredContent.java
@@ -25,6 +25,7 @@
 package com.cloudbees.jenkins.support.filter;
 
 import com.cloudbees.jenkins.support.api.Content;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -47,7 +48,7 @@ public abstract class PrefilteredContent extends Content {
      * @param filter ContentFilter to apply
      * @throws IOException If an input or output exception occurs
      */
-    public abstract void writeTo(OutputStream os, ContentFilter filter) throws IOException;
+    public abstract void writeTo(OutputStream os, @NonNull ContentFilter filter) throws IOException;
 
     @Override
     public final boolean shouldBeFiltered() {

--- a/src/main/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilter.java
@@ -66,13 +66,6 @@ public class SensitiveContentFilter implements ContentFilter {
     }
 
     @Override
-    public void ensureLoaded() {
-        if (mappingsPattern.get() == null || replacementsMap.get() == null) {
-            reload();
-        }
-    }
-
-    @Override
     public synchronized void reload() {
         final long startTime = System.currentTimeMillis();
         final Map<String, String> replacementsMap = new HashMap<>();

--- a/src/main/java/com/cloudbees/jenkins/support/impl/LogRecordContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/LogRecordContent.java
@@ -4,6 +4,7 @@ import com.cloudbees.jenkins.support.api.Content;
 import com.cloudbees.jenkins.support.filter.ContentFilter;
 import com.cloudbees.jenkins.support.filter.PrefilteredContent;
 import com.google.common.collect.Lists;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.jenkins.lib.support_log_formatter.SupportLogFormatter;
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -40,11 +41,11 @@ public abstract class LogRecordContent extends PrefilteredContent {
 
     @Override
     public final void writeTo(OutputStream os) throws IOException {
-        writeTo(os, null);
+        writeTo(os, ContentFilter.NONE);
     }
 
     @Override
-    public final void writeTo(OutputStream os, ContentFilter filter) throws IOException {
+    public final void writeTo(OutputStream os, @NonNull ContentFilter filter) throws IOException {
         final PrintWriter writer = getWriter(os);
         try {
             printTo(writer, filter);
@@ -54,10 +55,10 @@ public abstract class LogRecordContent extends PrefilteredContent {
     }
 
     protected void printTo(PrintWriter out) throws IOException {
-        printTo(out, null);
+        printTo(out, ContentFilter.NONE);
     }
 
-    protected void printTo(PrintWriter out, ContentFilter filter) throws IOException {
+    protected void printTo(PrintWriter out, @NonNull ContentFilter filter) throws IOException {
         for (LogRecord logRecord : getLogRecords()) {
             String filtered = LOG_FORMATTER.format(logRecord);
             filtered = ContentFilter.filter(filter, filtered);

--- a/src/main/java/com/cloudbees/jenkins/support/slowrequest/InflightRequest.java
+++ b/src/main/java/com/cloudbees/jenkins/support/slowrequest/InflightRequest.java
@@ -4,7 +4,6 @@ import com.cloudbees.jenkins.support.filter.ContentFilter;
 import java.io.File;
 import java.io.PrintWriter;
 import java.util.Date;
-import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import jenkins.model.Jenkins;
 import net.sf.uadetector.service.UADetectorServiceFactory;
@@ -70,22 +69,15 @@ final class InflightRequest {
         locale = req.getLocale().toString();
     }
 
-    void writeHeader(PrintWriter w) {
-        writeHeader(w, Optional.empty());
-    }
-
-    void writeHeader(PrintWriter w, Optional<ContentFilter> filter) {
-        w.println("Username: "
-                + filter.map(contentFilter -> contentFilter.filter(userName)).orElse(userName));
-        w.println("Referer: "
-                + filter.map(contentFilter -> contentFilter.filter(referer)).orElse(referer));
+    void writeHeader(PrintWriter w, ContentFilter filter) {
+        w.println("Username: " + filter.filter(userName));
+        w.println("Referer: " + filter.filter(referer));
         w.println("User Agent: "
                 + (userAgent != null
                         ? UADetectorServiceFactory.getResourceModuleParser().parse(userAgent)
                         : null));
         w.println("Date: " + new Date());
-        w.println(
-                "URL: " + filter.map(contentFilter -> contentFilter.filter(url)).orElse(url));
+        w.println("URL: " + filter.filter(url));
         w.println("Locale: " + locale);
         w.println();
     }

--- a/src/main/java/com/cloudbees/jenkins/support/timer/DeadlockTrackChecker.java
+++ b/src/main/java/com/cloudbees/jenkins/support/timer/DeadlockTrackChecker.java
@@ -55,7 +55,7 @@ public class DeadlockTrackChecker extends PeriodicWork {
                 builder.println("==============");
                 ThreadInfo[] deadLockThreads = mbean.getThreadInfo(deadLocks, Integer.MAX_VALUE);
 
-                ContentFilter contentFilter = SupportPlugin.getContentFilter().orElse(null);
+                ContentFilter contentFilter = SupportPlugin.getDefaultContentFilter();
                 for (ThreadInfo threadInfo : deadLockThreads) {
                     try {
                         ThreadDumps.printThreadInfo(builder, threadInfo, mbean, contentFilter);

--- a/src/test/java/com/cloudbees/jenkins/support/CheckFilterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/CheckFilterTest.java
@@ -368,7 +368,7 @@ public class CheckFilterTest {
          * After creating all the contents and
          */
         private void generateFilteredWords() {
-            ContentFilter filter = SupportPlugin.getContentFilter().orElse(null);
+            ContentFilter filter = SupportPlugin.getDefaultContentFilter();
             for (FileToCheck file : fileSet) {
                 file.wordFiltered = file.fileIsFiltered ? ContentFilter.filter(filter, file.word) : file.word;
             }

--- a/src/test/java/com/cloudbees/jenkins/support/SupportTestUtils.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportTestUtils.java
@@ -103,7 +103,7 @@ public class SupportTestUtils {
                     Objects.requireNonNull(content).writeTo(baos);
                     contents.put(
                             SupportPlugin.getNameFiltered(
-                                    SupportPlugin.getContentFilter(),
+                                    SupportPlugin.getDefaultContentFilter(),
                                     content.getName(),
                                     content.getFilterableParameters()),
                             baos.toString());
@@ -135,7 +135,7 @@ public class SupportTestUtils {
                             Objects.requireNonNull(content).writeTo(baos);
                             contents.put(
                                     SupportPlugin.getNameFiltered(
-                                            SupportPlugin.getContentFilter(),
+                                            SupportPlugin.getDefaultContentFilter(),
                                             content.getName(),
                                             content.getFilterableParameters()),
                                     baos.toString());

--- a/src/test/java/com/cloudbees/jenkins/support/impl/FileDescriptorLimitTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/FileDescriptorLimitTest.java
@@ -21,7 +21,6 @@ import java.io.FileOutputStream;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.zip.ZipFile;
-import junit.framework.AssertionFailedError;
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assume;
@@ -67,7 +66,7 @@ public class FileDescriptorLimitTest {
         Assume.assumeTrue(SystemPlatform.LINUX == SystemPlatform.current());
         ContentFilters.get().setEnabled(true);
         FreeStyleProject p = j.createFreeStyleProject(SENSITIVE_JOB_NAME);
-        ContentFilter filter = SupportPlugin.getContentFilter().orElseThrow(AssertionFailedError::new);
+        ContentFilter filter = SupportPlugin.getDefaultContentFilter();
         String filtered = ContentMappings.get().getMappings().get(SENSITIVE_JOB_NAME);
         String output;
         // Hold an open File Descriptor

--- a/src/test/java/com/cloudbees/jenkins/support/impl/NodeExecutorsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/NodeExecutorsTest.java
@@ -170,7 +170,7 @@ public class NodeExecutorsTest {
                 .waitForStart();
         j.waitForMessage("Running on", workflowRun);
 
-        ContentFilter filter = SupportPlugin.getContentFilter().orElseThrow(AssertionFailedError::new);
+        ContentFilter filter = SupportPlugin.getDefaultContentFilter();
 
         String filteredNodeName = ContentMappings.get().getMappings().get(agent.getNodeName());
         String filteredNodeDisplayName = ContentMappings.get().getMappings().get(agent.getDisplayName());

--- a/src/test/java/com/cloudbees/jenkins/support/impl/RunningBuildsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/RunningBuildsTest.java
@@ -57,7 +57,7 @@ public class RunningBuildsTest {
     public void addContentsFiltered() throws Exception {
         ContentFilters.get().setEnabled(true);
         FreeStyleProject p = j.createFreeStyleProject(SENSITIVE_JOB_NAME);
-        ContentFilter filter = SupportPlugin.getContentFilter().orElseThrow(AssertionFailedError::new);
+        ContentFilter filter = SupportPlugin.getDefaultContentFilter();
         String filtered = ContentMappings.get().getMappings().get(SENSITIVE_JOB_NAME);
         SemaphoreBuilder semaphore = new SemaphoreBuilder();
         p.getBuildersList().add(semaphore);


### PR DESCRIPTION
* Remove the use of `Optional<ContentFilter>` passed in parameters through the API. Use a `NoneFilter` implementation instead that simply pass through the value. This should simplify the readability, also avoid NPE and remove the need for null checks in some part of the code.
* Deprecated the existing methods `SupportPlugin#getContentFilter` / `SupportPlugin#getContentFilter(ensureLoaded)` in favor of `SupportPlugin#getDefaultContentFilter` / `SupportPlugin#getDefaultContentFilter(ensureLoaded)` and make sure that `ensureLoaded` also reloads the mappings.
* Deprecate `ContentFilter#ensureLoaded` that does not seem useful in favor of just using the existing `ContentFilter#reload`. 
* Also fixed checkstyle in the classes part of the fix

### Testing done

Tested on a test instance with thousands of items and anonymization off then on.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```