### PR TITLE
Reduce usage of Guice

### DIFF
--- a/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
@@ -43,7 +43,6 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.ZipFile;
-import javax.inject.Inject;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.IOUtils;
 import org.htmlunit.HttpMethod;
@@ -78,12 +77,11 @@ public class SupportActionTest {
     @Rule
     public LoggerRule logger = new LoggerRule();
 
-    @Inject
-    SupportAction root;
+    private SupportAction root;
 
     @Before
     public void setUp() {
-        j.jenkins.getInjector().injectMembers(this);
+        root = ExtensionList.lookupSingleton(SupportAction.class);
     }
 
     @Test


### PR DESCRIPTION
This plugin's tests currently depend on `javax.inject`, preventing them from running against Jenkins core with Guice 7.0 or later which only provide `jakarta.inject` (currently Jenkins core ships Guice 6.0 which provides both `javax.inject` and `jakarta.jnject`). To prepare for this migration, stop using Guice in favor of traditional static dependency injection.

### Testing done

Ran `mvn clean verify -Dtest=com.cloudbees.jenkins.support.SupportActionTest` against https://github.com/jenkinsci/jenkins/pull/8889.