### PR TITLE
Preserve line endings in `FileContent` when anonymization is disabled and avoid duplicating binary content

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/api/BaseFileContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/BaseFileContent.java
@@ -124,8 +124,9 @@ class BaseFileContent {
     }
 
     protected void writeTo(OutputStream os, @NonNull ContentFilter filter) throws IOException {
-        if (isBinary) {
+        if (isBinary || filter == ContentFilter.NONE) {
             writeTo(os);
+            return;
         }
 
         try {


### PR DESCRIPTION
https://github.com/jenkinsci/support-core-plugin/pull/502 had the side effect of normalizing line endings for all instances of `FileContent` even when anonymization is disabled, which makes it difficult to use support bundles to analyze issues where exact file contents are significant (e.g. build logs and associated metadata).

While looking at that issue, I _also_ noticed that any kind of `FileContent` that was detected as binary was actually written twice, once as binary and then once as text. Oops! From a quick look I think this has been broken since https://github.com/jenkinsci/support-core-plugin/pull/174.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
