### PR TITLE
Add ExtensionPoint to contribute to stop words

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/filter/AdditionalFromFileStopWords.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/AdditionalFromFileStopWords.java
@@ -1,0 +1,72 @@
+package com.cloudbees.jenkins.support.filter;
+
+import com.cloudbees.jenkins.support.SupportPlugin;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.commons.lang.StringUtils;
+
+@Extension
+public class AdditionalFromFileStopWords implements StopWords {
+
+    private static final Logger LOGGER = Logger.getLogger(AdditionalFromFileStopWords.class.getName());
+
+    /**
+     * Name of the file containing additional user-provided stop words.
+     */
+    private static final String ADDITIONAL_STOP_WORDS_FILENAME = "additional-stop-words.txt";
+
+    /**
+     * Property to set to add <b>additional</b> stop words.
+     * The location should point to a line separated file containing words. Each line is treated as a word.
+     */
+    static final String ADDITIONAL_STOP_WORDS_PROPERTY = ContentMappings.class.getName() + ".additionalStopWordsFile";
+
+    @NonNull
+    @Override
+    public Set<String> getWords() {
+        Set<String> words = new HashSet<>();
+        String fileLocationFromProperty = System.getProperty(ADDITIONAL_STOP_WORDS_PROPERTY);
+        String fileLocation = fileLocationFromProperty == null
+                ? SupportPlugin.getRootDirectory() + "/" + ADDITIONAL_STOP_WORDS_FILENAME
+                : fileLocationFromProperty;
+        LOGGER.log(Level.FINE, "Attempting to load user provided stop words from ''{0}''.", fileLocation);
+        File f = new File(fileLocation);
+        if (f.exists()) {
+            if (!f.canRead()) {
+                LOGGER.log(
+                        Level.WARNING,
+                        "Could not load user provided stop words as " + fileLocation + " is not readable.");
+            } else {
+                try (BufferedReader br = new BufferedReader(
+                        new InputStreamReader(new FileInputStream(fileLocation), Charset.defaultCharset()))) {
+                    for (String line = br.readLine(); line != null; line = br.readLine()) {
+                        if (StringUtils.isNotEmpty(line)) {
+                            words.add(line);
+                        }
+                    }
+                    return words;
+                } catch (IOException ex) {
+                    LOGGER.log(
+                            Level.WARNING,
+                            "Could not load user provided stop words. there was an error reading " + fileLocation,
+                            ex);
+                }
+            }
+        } else if (fileLocationFromProperty != null) {
+            LOGGER.log(
+                    Level.WARNING,
+                    "Could not load user provided stop words as " + fileLocationFromProperty + " does not exists.");
+        }
+        return words;
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/support/filter/AdditionalFromFileStopWords.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/AdditionalFromFileStopWords.java
@@ -3,7 +3,6 @@ package com.cloudbees.jenkins.support.filter;
 import com.cloudbees.jenkins.support.SupportPlugin;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;

--- a/src/main/java/com/cloudbees/jenkins/support/filter/AdditionalFromFileStopWords.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/AdditionalFromFileStopWords.java
@@ -3,17 +3,16 @@ package com.cloudbees.jenkins.support.filter;
 import com.cloudbees.jenkins.support.SupportPlugin;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
-import java.io.BufferedReader;
+
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.apache.commons.lang.StringUtils;
 
 @Extension
 public class AdditionalFromFileStopWords implements StopWords {
@@ -47,14 +46,8 @@ public class AdditionalFromFileStopWords implements StopWords {
                         Level.WARNING,
                         "Could not load user provided stop words as " + fileLocation + " is not readable.");
             } else {
-                try (BufferedReader br = new BufferedReader(
-                        new InputStreamReader(new FileInputStream(fileLocation), Charset.defaultCharset()))) {
-                    for (String line = br.readLine(); line != null; line = br.readLine()) {
-                        if (StringUtils.isNotEmpty(line)) {
-                            words.add(line);
-                        }
-                    }
-                    return words;
+                try {
+                    words.addAll(Files.readAllLines(Path.of(fileLocation), Charset.defaultCharset()));
                 } catch (IOException ex) {
                     LOGGER.log(
                             Level.WARNING,

--- a/src/main/java/com/cloudbees/jenkins/support/filter/AllAsciiCharactersStopWords.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/AllAsciiCharactersStopWords.java
@@ -1,0 +1,27 @@
+package com.cloudbees.jenkins.support.filter;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import java.util.HashSet;
+import java.util.Set;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+@Extension
+@Restricted(NoExternalUse.class)
+public class AllAsciiCharactersStopWords implements StopWords {
+
+    @NonNull
+    @Override
+    public Set<String> getWords() {
+        final int SPACE = ' '; // 20
+        final int TILDE = '~'; // 126
+        Set<String> singleChars = new HashSet<>(TILDE - SPACE + 1);
+
+        for (char i = SPACE; i <= TILDE; i++) {
+            singleChars.add(Character.toString(i));
+        }
+
+        return singleChars;
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/support/filter/AllAsciiCharactersStopWords.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/AllAsciiCharactersStopWords.java
@@ -7,6 +7,11 @@ import java.util.Set;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
+/**
+ * To avoid corrupting the content of the files in the bundle just in case we have an object name as 'a' or '.', we
+ * avoid replacing one single character (ascii codes actually). A one single character in other languages could
+ * have a meaning, so we remain replacing them. Example: 日 (Sun)
+ */
 @Extension
 @Restricted(NoExternalUse.class)
 public class AllAsciiCharactersStopWords implements StopWords {

--- a/src/main/java/com/cloudbees/jenkins/support/filter/AllowedOSNamesStopWords.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/AllowedOSNamesStopWords.java
@@ -1,0 +1,34 @@
+package com.cloudbees.jenkins.support.filter;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+@Extension
+@Restricted(NoExternalUse.class)
+public class AllowedOSNamesStopWords implements StopWords {
+
+    @NonNull
+    @Override
+    public Set<String> getWords() {
+        // JENKINS-54688
+        return new HashSet<>(Arrays.asList(
+                "linux",
+                "windows",
+                "win",
+                "mac",
+                "macos",
+                "macosx",
+                "mac os x",
+                "ubuntu",
+                "debian",
+                "fedora",
+                "red hat",
+                "sunos",
+                "freebsd"));
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/support/filter/DefaultStopWords.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/DefaultStopWords.java
@@ -1,0 +1,38 @@
+package com.cloudbees.jenkins.support.filter;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import jenkins.model.Jenkins;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+@Extension
+@Restricted(NoExternalUse.class)
+public class DefaultStopWords implements StopWords {
+
+    @NonNull
+    @Override
+    public Set<String> getWords() {
+        return new HashSet<>(Arrays.asList(
+                "agent",
+                "jenkins",
+                "node",
+                "master",
+                "computer",
+                "item",
+                "label",
+                "view",
+                "all",
+                "unknown",
+                "user",
+                "anonymous",
+                "authenticated",
+                "everyone",
+                "system",
+                "admin",
+                Jenkins.VERSION));
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/support/filter/DefaultStopWords.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/DefaultStopWords.java
@@ -2,12 +2,11 @@ package com.cloudbees.jenkins.support.filter;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import java.util.Set;
 
 @Extension
 @Restricted(NoExternalUse.class)
@@ -16,7 +15,7 @@ public class DefaultStopWords implements StopWords {
     @NonNull
     @Override
     public Set<String> getWords() {
-        return new HashSet<>(Arrays.asList(
+        return Set.of(
                 "agent",
                 "jenkins",
                 "node",
@@ -33,6 +32,6 @@ public class DefaultStopWords implements StopWords {
                 "everyone",
                 "system",
                 "admin",
-                Jenkins.VERSION));
+                Jenkins.VERSION);
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/filter/DefaultStopWords.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/DefaultStopWords.java
@@ -2,11 +2,10 @@ package com.cloudbees.jenkins.support.filter;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import java.util.Set;
 import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
-
-import java.util.Set;
 
 @Extension
 @Restricted(NoExternalUse.class)

--- a/src/main/java/com/cloudbees/jenkins/support/filter/StopWords.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/StopWords.java
@@ -1,0 +1,40 @@
+package com.cloudbees.jenkins.support.filter;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Extension to contribute to the list of stop words in anonymization.
+ */
+public interface StopWords extends ExtensionPoint {
+
+    /**
+     * @return all {@link StopWords} extensions
+     */
+    static ExtensionList<StopWords> all() {
+        return ExtensionList.lookup(StopWords.class);
+    }
+
+    /**
+     * Return the stop words that will be added to {@link ContentMappings}.
+     * @return a set of words
+     */
+    @NonNull
+    Set<String> getWords();
+
+    static class AllStopWords implements StopWords {
+
+        @NonNull
+        @Override
+        public Set<String> getWords() {
+            return all().stream()
+                    .map(StopWords::getWords)
+                    .flatMap(Collection::stream)
+                    .collect(Collectors.toSet());
+        }
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/support/filter/StopWords.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/StopWords.java
@@ -3,7 +3,6 @@ package com.cloudbees.jenkins.support.filter;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
-
 import java.util.Set;
 
 /**

--- a/src/main/java/com/cloudbees/jenkins/support/filter/StopWords.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/StopWords.java
@@ -3,9 +3,8 @@ package com.cloudbees.jenkins.support.filter;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
-import java.util.Collection;
+
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Extension to contribute to the list of stop words in anonymization.
@@ -25,16 +24,4 @@ public interface StopWords extends ExtensionPoint {
      */
     @NonNull
     Set<String> getWords();
-
-    static class AllStopWords implements StopWords {
-
-        @NonNull
-        @Override
-        public Set<String> getWords() {
-            return all().stream()
-                    .map(StopWords::getWords)
-                    .flatMap(Collection::stream)
-                    .collect(Collectors.toSet());
-        }
-    }
 }


### PR DESCRIPTION
Add an extension that allow plugins to add additional stop words. Which is useful for extension that produce filtered String / File contents that have words that should not be filtered.
I was also wondering if we should add the annotated `@Symbol` values to the list of stop words...

### Testing done

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```