### PR TITLE
Removing duplicate `dependency`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,11 +191,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.quicktheories</groupId>
       <artifactId>quicktheories</artifactId>
       <version>0.26</version>


### PR DESCRIPTION
Current Maven warns about this; in the future it might be fatal.