### PR TITLE
Overhaul of `SlaveLogs`

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/NodeRemoteDirectoryComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/NodeRemoteDirectoryComponent.java
@@ -45,6 +45,9 @@ public class NodeRemoteDirectoryComponent extends DirectoryComponent<Computer> i
             return;
         }
 
+        // TODO this is not necessarily the right root for workDir.
+        // Engine.workDir says that the workDir “should” be the agent root but this is not enforced.
+        // Safer to use Engine.current().internalDir.
         FilePath rootPath = node.getRootPath();
         if (rootPath == null) {
             LOGGER.log(Level.WARNING, "Node " + node.getDisplayName() + " seems to be offline");

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLogs.java
@@ -210,6 +210,12 @@ public class SlaveLogs extends Component {
             tasks.add(new java.util.concurrent.Callable<List<FileContent>>() {
                 public List<FileContent> call() throws Exception {
                     List<FileContent> result = new ArrayList<FileContent>();
+                    // TODO presumes that WinSW’s %BASE% would be the remoteFS as in
+                    // https://docs.cloudbees.com/docs/cloudbees-ci-kb/latest/client-and-managed-controllers/how-to-install-windows-agents-as-a-service
+                    // and that
+                    // https://github.com/winsw/winsw/blob/6cf303c1d3fbe1069d95af230b8efa117d29cdf2/src/WinSW.Core/Configuration/XmlServiceConfig.cs#L273
+                    // is not overridden from e.g.
+                    // https://github.com/winsw/winsw/blob/e4cf507bae5981363a9cdc0f7301c1aa892af401/samples/shared-directory-mapper.xml#L8
                     final Map<String, File> logFiles = logFetcher.forNode(node).getLogFiles(rootPath);
                     for (Map.Entry<String, File> entry : logFiles.entrySet()) {
                         result.add(new FileContent(

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SmartLogCleaner.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SmartLogCleaner.java
@@ -1,3 +1,4 @@
+// TODO delete?
 package com.cloudbees.jenkins.support.impl;
 
 import com.cloudbees.jenkins.support.SupportPlugin;

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SmartLogFetcher.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SmartLogFetcher.java
@@ -1,3 +1,4 @@
+// TODO delete? (9aeca363ce4812f5f6c084d673e8d8bcdb266498)
 package com.cloudbees.jenkins.support.impl;
 
 import com.cloudbees.jenkins.support.SupportPlugin;

--- a/src/main/java/com/cloudbees/jenkins/support/impl/WinswLogfileFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/WinswLogfileFilter.java
@@ -7,7 +7,8 @@ import java.io.Serializable;
 /**
  * Matches log files from winsw.
  *
- * @see <a href="https://github.com/kohsuke/winsw/blob/master/LogAppenders.cs">LogAppenders.cs</a>
+ * @see <a href="https://github.com/winsw/winsw/blob/e4cf507bae5981363a9cdc0f7301c1aa892af401/src/WinSW.Core/LogAppenders.cs#L169-L170">LogAppenders.cs</a>
+ * @see SlaveLogs
  * @author Kohsuke Kawaguchi
  */
 class WinswLogfileFilter implements FilenameFilter, Serializable {

--- a/src/test/java/com/cloudbees/jenkins/support/impl/SlaveLogsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/SlaveLogsTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2020, CloudBees, Inc.
+ * Copyright 2024 CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,31 +24,22 @@
 
 package com.cloudbees.jenkins.support.impl;
 
-import java.io.File;
-import java.io.FilenameFilter;
-import java.io.Serializable;
-import java.util.Date;
-import java.util.concurrent.TimeUnit;
+import org.junit.Rule;
+import org.jvnet.hudson.test.JenkinsRule;
 
-/**
- * Matches agent log files in an interval of time
- * @see SlaveLogs
- */
-class LogFilenameAgentFilter implements FilenameFilter, Serializable {
+public final class SlaveLogsTest {
 
-    public static final long MAX_TIME_AGENT_LOG_RETRIEVAL = Long.getLong(
-            System.getProperty(LogFilenameAgentFilter.class.getName() + ".maxTimeAgentLogRetrieval"),
-            TimeUnit.DAYS.toMillis(7));
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
-    public boolean accept(File dir, String name) {
-        // We should avoid taking agent files which are very old
-        // as they are not usually very helpful to troubleshoot
-        // 1 week should be enough in most of the cases
-        if (name.endsWith(".log") && new Date().getTime() - dir.lastModified() < MAX_TIME_AGENT_LOG_RETRIEVAL) {
-            return true;
-        }
-        return false;
-    }
+    // TODO INFO messages from online agent after connection
+    // TODO messages from online agent prior to connection (if -workDir set)
+    // TODO messages from disconnected agent
+    // TODO messages from deleted agent
+    // TODO messages from reconnected agent
+    // TODO FINE messages
+    // TODO winsw logs
+    // TODO honor SafeTimerTask.getLogsRoot (if applicable)
+    // TODO rotation of old or excessively long logs
 
-    private static final long serialVersionUID = 1L;
 }


### PR DESCRIPTION
The collection of Java logging from agents is rather antiquated given the prevalence of `Cloud`s and is missing a lot of critical diagnostics. (CloudBees-internal reference: BEE-46766) Some draft observations:

`SlaveLogs` only lists information from currently online agents. It might be more useful to run something like `JenkinsRule.RemoteLogDumper` to stream agent JUL messages back to a file on the controller, so we could collect these at any time for support bundles, including agents currently defined but disconnected, or agents which have since been deleted. Most agent logs are brief (9aeca363ce4812f5f6c084d673e8d8bcdb266498 notwithstanding) so this does not seem unreasonable. Could still collect `remoting.log` from the agent when `-workDir` is defined, as this would capture messages about connection attempts before the agent is fully online.

`SlaveLogs.addAgentJulLogRecords` does not seem to work well. It stores the logs on the agent, making it impossible to retrieve them if the agent is not currently online, begging the question of why this method even exists (since `SlaveLogs` also uses `Computer.getLogRecords` which has the same information). Also the logs are stored in the root path, rather than using the workdir when one is defined.

Even for an agent currently connected it is not that helpful since it relies on `SupportPlugin.LogInitializer` capturing JUL records from the agent JVM after `ComputerListener.onOnline`, whereas `remoting/logs/remoting.log.0` inside the workdir includes all the details of the connection logic starting from `hudson.remoting.jnlp.Main.createEngine` up through `hudson.remoting.jnlp.Main$CuiListener.status` saying `Connected`.

`SmartLogCleaner` is deliberately deleting information about historical agents.

I would expect custom loggers at fine levels defined on the controller to be honored inside the agent JVM as well, as [`log-cli` does](https://plugins.jenkins.io/log-cli/#plugin-content-streaming-detailed-logs-to-standard-error).

`NodeRemoteDirectoryComponent` would include `remoting.log.0` but this is not exactly apparent, and only available for one agent at a time by selecting **Agent Support**.

(Extracted from #517 for clarity.)
