### PR TITLE
Trying to deflake `CheckFilterTest`

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
@@ -235,7 +235,7 @@ public class AboutJenkins extends Component {
          * @return the Java information.
          */
         @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
-        private String getInfo(ContentFilter filter) {
+        private String getInfo(@CheckForNull ContentFilter filter) {
             StringBuilder result = new StringBuilder();
             Runtime runtime = Runtime.getRuntime();
             result.append(maj).append(" Java\n");
@@ -439,7 +439,7 @@ public class AboutJenkins extends Component {
                         .append(" arg[")
                         .append(count++)
                         .append("]: `")
-                        .append(Markdown.escapeBacktick(ContentFilter.filter(filter, arg)))
+                        .append(Markdown.escapeBacktick(filter != null ? ContentFilter.filter(filter, arg) : arg))
                         .append("`\n");
             }
             return result.toString();

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
@@ -235,7 +235,7 @@ public class AboutJenkins extends Component {
          * @return the Java information.
          */
         @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
-        private String getInfo(@CheckForNull ContentFilter filter) {
+        private String getInfo(ContentFilter filter) {
             StringBuilder result = new StringBuilder();
             Runtime runtime = Runtime.getRuntime();
             result.append(maj).append(" Java\n");
@@ -439,7 +439,7 @@ public class AboutJenkins extends Component {
                         .append(" arg[")
                         .append(count++)
                         .append("]: `")
-                        .append(Markdown.escapeBacktick(filter != null ? ContentFilter.filter(filter, arg) : arg))
+                        .append(Markdown.escapeBacktick(ContentFilter.filter(filter, arg)))
                         .append("`\n");
             }
             return result.toString();


### PR DESCRIPTION
https://github.com/jenkinsci/support-core-plugin/runs/22561627825 is not reproducibe locally but has also been observed in PCT (@cloudbees reference BEE-10081). The failure does not make much sense because `AsyncResultCache.get` should always succeed on the built-in node (`Jenkins`). Locally:

```
FINER	c.c.j.support.AsyncResultCache#get: com.cloudbees.jenkins.support.impl.NetworkInterfaces$GetNetworkInterfaces@6ba48c4d on master succeeded
FINER	c.c.j.support.AsyncResultCache#get: com.cloudbees.jenkins.support.impl.NetworkInterfaces$GetNetworkInterfaces@35c553e2 on agent0 succeeded
```
