### PR TITLE
Fixes to `RunDirectoryComponent.excludes`

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/AbstractItemDirectoryComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AbstractItemDirectoryComponent.java
@@ -12,7 +12,10 @@ import hudson.util.FormValidation;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.List;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import jenkins.model.Jenkins;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.FileSet;
@@ -108,8 +111,23 @@ public class AbstractItemDirectoryComponent extends DirectoryComponent<AbstractI
 
         static final int DEFAULT_MAX_DEPTH = 5;
 
+        private static final List<String> EXCLUDES = List.of(
+                // https://github.com/jenkinsci/jenkins/blob/9f790a3142c76a33f1dbd8409715b867a53836c8/core/src/main/java/jenkins/model/Jenkins.java#L3158
+                // https://github.com/jenkinsci/cloudbees-folder-plugin/blob/7c780211d66eee480b1c1b62f61d67c426824714/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java#L529
+                "**/jobs/",
+                // https://github.com/jenkinsci/branch-api-plugin/blob/6f101e97dd77b3022e912b988358713967a7994e/src/main/java/jenkins/branch/MultiBranchProject.java#L862
+                "**/branches/");
+
         public DescriptorImpl() {
-            super("", "**/jobs/**, **/branches/**, **/artifacts/**, **/stashes/**", true, DEFAULT_MAX_DEPTH);
+            super(
+                    "",
+                    Stream.concat(
+                                    EXCLUDES.stream(),
+                                    RunDirectoryComponent.DescriptorImpl.EXCLUDES.stream()
+                                            .map(p -> "builds/*/" + p))
+                            .collect(Collectors.joining(",")),
+                    true,
+                    DEFAULT_MAX_DEPTH);
         }
 
         /**

--- a/src/main/java/com/cloudbees/jenkins/support/impl/RunDirectoryComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/RunDirectoryComponent.java
@@ -12,7 +12,9 @@ import hudson.util.FormValidation;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.List;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.FileSet;
@@ -118,8 +120,20 @@ public class RunDirectoryComponent extends DirectoryComponent<Run> {
 
         static final int DEFAULT_MAX_DEPTH = 10;
 
+        static final List<String> EXCLUDES = List.of(
+                // https://github.com/jenkinsci/jenkins/blob/9f790a3142c76a33f1dbd8409715b867a53836c8/core/src/main/java/hudson/model/Run.java#L1143
+                "archive/",
+                // https://github.com/jenkinsci/workflow-api-plugin/blob/2e338a5c7a3c17be60e168faf80e7dbbdd47ceb5/src/main/java/org/jenkinsci/plugins/workflow/flow/StashManager.java#L254
+                "stashes/",
+                // https://github.com/jenkinsci/junit-attachments-plugin/blob/7e439b0efd070a5bf4ea50f51a3296e35ca5f814/src/main/java/hudson/plugins/junitattachments/AttachmentPublisher.java#L39
+                "junit-attachments/",
+                // https://github.com/jenkinsci/warnings-ng-plugin/blob/8c41827040ae8f8659a1c370b3efcb364c60cd29/plugin/src/main/java/io/jenkins/plugins/analysis/core/util/AffectedFilesResolver.java#L32
+                "files-with-issues/",
+                // https://github.com/jenkinsci/jacoco-plugin/blob/f5ea36e9aff4db394bb88944139bb7bb8f55187d/src/main/java/hudson/plugins/jacoco/JacocoReportDir.java#L20
+                "jacoco/");
+
         public DescriptorImpl() {
-            super("", "**/artifacts/**, **/stashes/**", true, DEFAULT_MAX_DEPTH);
+            super("", EXCLUDES.stream().collect(Collectors.joining(",")), true, DEFAULT_MAX_DEPTH);
         }
 
         /**

--- a/src/main/resources/com/cloudbees/jenkins/support/impl/AbstractItemDirectoryComponent/help.html
+++ b/src/main/resources/com/cloudbees/jenkins/support/impl/AbstractItemDirectoryComponent/help.html
@@ -1,3 +1,3 @@
 <div>
-  Archives the content of this item root directory: {0}
+  Archives the content of this item root directory.
 </div>

--- a/src/main/resources/com/cloudbees/jenkins/support/impl/DirectoryComponent/help-excludes.html
+++ b/src/main/resources/com/cloudbees/jenkins/support/impl/DirectoryComponent/help-excludes.html
@@ -1,5 +1,6 @@
 <div>
-  Optionally specify <a href='http://ant.apache.org/manual/Types/fileset.html'>the 'excludes' pattern</a>,
-  such as "foo/bar/**/*". A file that matches this mask will not be archived even if it matches the
-  mask specified in 'Includes' section.
+  Optionally specify <a href="http://ant.apache.org/manual/Types/fileset.html">the “excludes” pattern</a>,
+  such as <code>**/subdir/subsubdir/</code> or <code>dir/file*.txt</code>
+  (<a href="https://ant.apache.org/manual/dirtasks.html#patterns">syntax reference</a>).
+  A file that matches this mask will not be archived even if it matches the mask specified in <b>Includes</b> section.
 </div>

--- a/src/main/resources/com/cloudbees/jenkins/support/impl/DirectoryComponent/help-includes.html
+++ b/src/main/resources/com/cloudbees/jenkins/support/impl/DirectoryComponent/help-includes.html
@@ -1,5 +1,5 @@
 <div>
-  Optionally specify <a href='http://ant.apache.org/manual/Types/fileset.html'>the 'includes' pattern</a>,
-  such as "foo/bar/**/*". A file that matches this mask will be archived unless it matches the
-  mask specified in 'Excludes' section.
+  Optionally specify <a href='http://ant.apache.org/manual/Types/fileset.html'>the “includes” pattern</a>,
+  such as <code>jobs/**/log*</code>.
+  A file that matches this mask will be archived unless it matches the mask specified in the <b>Excludes</b> section.
 </div>

--- a/src/main/resources/com/cloudbees/jenkins/support/impl/RunDirectoryComponent/help.html
+++ b/src/main/resources/com/cloudbees/jenkins/support/impl/RunDirectoryComponent/help.html
@@ -1,3 +1,3 @@
 <div>
-  Archives the content of this build root directory: {0}
+  Archives the content of this build root directory.
 </div>

--- a/src/test/java/com/cloudbees/jenkins/support/impl/AbstractItemDirectoryComponentTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/AbstractItemDirectoryComponentTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockFolder;
 
-public class AbstractItemComponentTest {
+public class AbstractItemDirectoryComponentTest {
 
     private static final String JOB_NAME = "job-name";
     private static final String FOLDER_NAME = "folder-name";
@@ -156,7 +156,8 @@ public class AbstractItemComponentTest {
     public void addContentsFromPipeline() throws Exception {
         MockFolder folder = j.createFolder(FOLDER_NAME);
         WorkflowJob p = folder.createProject(WorkflowJob.class, JOB_NAME);
-        p.setDefinition(new CpsFlowDefinition("node { echo 'test' }", true));
+        p.setDefinition(
+                new CpsFlowDefinition("node {writeFile file: 'test.txt', text: ''; archiveArtifacts '*.txt'}", true));
         WorkflowRun workflowRun = Optional.ofNullable(p.scheduleBuild2(0))
                 .orElseThrow(AssertionFailedError::new)
                 .waitForStart();
@@ -174,6 +175,7 @@ public class AbstractItemComponentTest {
         assertThat(output.keySet(), hasItem(startsWith(prefix + "/builds/1/workflow")));
         assertThat(output.get(prefix + "/config.xml"), containsString("<flow-definition"));
         assertThat(output.get(prefix + "/nextBuildNumber"), containsString("2"));
+        assertThat(output.keySet(), not(hasItem(containsString("test.txt"))));
     }
 
     /*

--- a/src/test/java/com/cloudbees/jenkins/support/impl/RunDirectoryComponentTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/RunDirectoryComponentTest.java
@@ -49,7 +49,8 @@ public class RunDirectoryComponentTest {
     @Test
     public void addContentsFromPipeline() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, JOB_NAME);
-        p.setDefinition(new CpsFlowDefinition("node { echo 'test' }", true));
+        p.setDefinition(
+                new CpsFlowDefinition("node {writeFile file: 'test.txt', text: ''; archiveArtifacts '*.txt'}", true));
         WorkflowRun workflowRun = Optional.ofNullable(p.scheduleBuild2(0))
                 .orElseThrow(AssertionFailedError::new)
                 .waitForStart();
@@ -65,6 +66,7 @@ public class RunDirectoryComponentTest {
         assertThat(output.keySet(), hasItem(startsWith(prefix + "/workflow")));
         assertThat(output.get(prefix + "/build.xml"), Matchers.containsString("<flow-build"));
         assertThat(output.get(prefix + "/log"), Matchers.containsString("[Pipeline] node"));
+        assertThat(output.keySet(), not(hasItem(Matchers.containsString("test.txt"))));
     }
 
     @Test


### PR DESCRIPTION
* **Build Support** excludes needlessly looked in subdirectories for things like `stashes`.
* `artifacts` is not a directory name; it is `archive`. This particular important exclusion lacked test coverage. (Be careful not to mix up directory names with URL components, which are often subtly different: `archive` vs. `artifact`; `jobs` vs. `job`.)
* Default excludes were missing several kinds of directories that I have observed containing many (and often large) files in builds running on @cloudbees servers.
* **Project Support** excludes were mixing two sorts of entries: subitems; and standard excludes for builds. More clearly separate them and refine the patterns.
* Some help files displayed `{0}` which was apparently meant to be subtituted with something but was not.
* Links to Apache Ant references were light on detail.
* Switching to `xxx/` as a shortcut for `xxx/**`.
* `AbstractItemComponentTest` was not using a standard naming convention.
