### PR TITLE
Deleting `Jenkins72799Hack`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,8 @@
 
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.414.3</jenkins.version>
+    <!-- TODO pending release -->
+    <jenkins.version>2.440.3-rc34568.387f5a_600b_ee</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
@@ -76,7 +77,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.414.x</artifactId>
+        <artifactId>bom-2.440.x</artifactId>
         <version>2839.v003b_4d9d24fd</version>
         <type>pom</type>
         <scope>import</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,7 @@
 
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <!-- TODO pending release -->
-    <jenkins.version>2.440.3-rc34568.387f5a_600b_ee</jenkins.version>
+    <jenkins.version>2.440.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLaunchLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLaunchLogs.java
@@ -35,18 +35,13 @@ import com.cloudbees.jenkins.support.timer.FileListCapComponent;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ExtensionList;
-import hudson.FilePath;
 import hudson.console.ConsoleLogFilter;
 import hudson.console.LineTransformationOutputStream;
 import hudson.init.Terminator;
 import hudson.model.AbstractModelObject;
 import hudson.model.Computer;
 import hudson.model.Run;
-import hudson.model.TaskListener;
-import hudson.remoting.Channel;
 import hudson.security.Permission;
-import hudson.slaves.ComputerListener;
-import hudson.slaves.JNLPLauncher;
 import hudson.slaves.SlaveComputer;
 import hudson.util.io.RewindableRotatingFileOutputStream;
 import java.io.File;
@@ -57,9 +52,7 @@ import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
-import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -173,49 +166,6 @@ public class SlaveLaunchLogs extends ObjectComponent<Computer> {
         }
     }
 
-    // TODO delete if updating to 2.440.3 and JENKINS-72799 is backported, else 2.448+
-    @Extension
-    public static final class Jenkins72799Hack extends ComputerListener {
-
-        /**
-         * Names of inbound agents which have recently gotten to {@link #preLaunch}
-         * but for which we did not receive typical output in {@link SlaveComputer#setChannel(Channel, OutputStream, Channel.Listener)}
-         * prior to {@link #preOnline}.
-         */
-        private final Map<String, Boolean> launching = new ConcurrentHashMap<>();
-
-        @Override
-        public void preLaunch(Computer c, TaskListener taskListener) {
-            if (c instanceof SlaveComputer && ((SlaveComputer) c).getLauncher() instanceof JNLPLauncher) {
-                String name = c.getName();
-                LOGGER.fine(() -> "preLaunch " + name);
-                launching.put(name, true);
-            }
-        }
-
-        @Override
-        public void preOnline(Computer c, Channel channel, FilePath root, TaskListener listener) throws IOException {
-            if (c instanceof SlaveComputer && ((SlaveComputer) c).getLauncher() instanceof JNLPLauncher) {
-                String name = c.getName();
-                if (launching.put(name, false)) {
-                    LOGGER.fine(() -> "preOnline " + name + " need to work around lack of JENKINS-72799");
-                    OutputStream stream = ExtensionList.lookupSingleton(LogArchiver.class).stream;
-                    synchronized (stream) {
-                        String nowish = DateTimeFormatter.ISO_INSTANT.format(
-                                Instant.now().truncatedTo(ChronoUnit.MILLIS));
-                        for (String line : c.getLog().trim().split("\n")) {
-                            LOGGER.fine(() -> "adding: " + line);
-                            stream.write(
-                                    ("[" + nowish + " " + name + "] " + line + "\n").getBytes(StandardCharsets.UTF_8));
-                        }
-                    }
-                } else {
-                    LOGGER.fine(() -> "preOnline " + name + " OK, have JENKINS-72799");
-                }
-            }
-        }
-    }
-
     static class PrefixedStream extends LineTransformationOutputStream.Delegating {
         private final String name;
 
@@ -226,10 +176,6 @@ public class SlaveLaunchLogs extends ObjectComponent<Computer> {
 
         @Override
         protected void eol(byte[] b, int len) throws IOException {
-            if (new String(b, 0, len, StandardCharsets.UTF_8).startsWith("Remoting version: ")) {
-                LOGGER.fine(() -> "receiving expected setChannel text on " + name);
-                ExtensionList.lookupSingleton(Jenkins72799Hack.class).launching.put(name, false);
-            }
             synchronized (out) {
                 out.write('[');
                 out.write(DateTimeFormatter.ISO_INSTANT


### PR DESCRIPTION
Cleaning up from #517 since https://github.com/jenkinsci/jenkins/pull/9009 was accepted for backport to LTS.