### PR TITLE
Forward compatibility with EE 9

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
@@ -507,6 +507,8 @@ public class AboutJenkins extends Component {
                 out.println("      - Specification: " + servletContext.getMajorVersion() + "."
                         + servletContext.getMinorVersion());
                 out.println("      - Name:          `" + Markdown.escapeBacktick(servletContext.getServerInfo()) + "`");
+            } catch (LinkageError e) {
+                // TODO switch javax import to jakarta after bumping core baseline, ignore for now
             } catch (NullPointerException e) {
                 // pity Stapler.getCurrent() throws an NPE when outside of a request
             }
@@ -860,38 +862,42 @@ public class AboutJenkins extends Component {
                 // the method is not always safe :-(
             }
             if (stapler != null) {
-                final ServletContext servletContext = stapler.getServletContext();
-                Set<String> resourcePaths = (Set<String>) servletContext.getResourcePaths("/WEB-INF/lib");
-                for (String resourcePath : new TreeSet<String>(resourcePaths)) {
-                    try {
-                        out.println(Util.getDigestOf(servletContext.getResourceAsStream(resourcePath))
-                                + "  war" // FIPS OK: Not security related.
-                                + resourcePath);
-                    } catch (IOException e) {
-                        logger.log(Level.WARNING, "Could not compute MD5 of war" + resourcePath, e);
-                    }
-                }
-                for (String resourcePath : Arrays.asList("/WEB-INF/jenkins-cli.jar", "/WEB-INF/web.xml")) {
-                    try {
-                        InputStream resourceAsStream = servletContext.getResourceAsStream(resourcePath);
-                        if (resourceAsStream == null) {
-                            continue;
+                try {
+                    final ServletContext servletContext = stapler.getServletContext();
+                    Set<String> resourcePaths = (Set<String>) servletContext.getResourcePaths("/WEB-INF/lib");
+                    for (String resourcePath : new TreeSet<String>(resourcePaths)) {
+                        try {
+                            out.println(Util.getDigestOf(servletContext.getResourceAsStream(resourcePath))
+                                    + "  war" // FIPS OK: Not security related.
+                                    + resourcePath);
+                        } catch (IOException e) {
+                            logger.log(Level.WARNING, "Could not compute MD5 of war" + resourcePath, e);
                         }
-                        out.println(Util.getDigestOf(resourceAsStream) + "  war" // FIPS OK: Not security related.
-                                + resourcePath);
-                    } catch (IOException e) {
-                        logger.log(Level.WARNING, "Could not compute MD5 of war" + resourcePath, e);
                     }
-                }
-                resourcePaths = (Set<String>) servletContext.getResourcePaths("/WEB-INF/update-center-rootCAs");
-                for (String resourcePath : new TreeSet<String>(resourcePaths)) {
-                    try {
-                        out.println(Util.getDigestOf(servletContext.getResourceAsStream(resourcePath))
-                                + "  war" // FIPS OK: Not security related.
-                                + resourcePath);
-                    } catch (IOException e) {
-                        logger.log(Level.WARNING, "Could not compute MD5 of war" + resourcePath, e);
+                    for (String resourcePath : Arrays.asList("/WEB-INF/jenkins-cli.jar", "/WEB-INF/web.xml")) {
+                        try {
+                            InputStream resourceAsStream = servletContext.getResourceAsStream(resourcePath);
+                            if (resourceAsStream == null) {
+                                continue;
+                            }
+                            out.println(Util.getDigestOf(resourceAsStream) + "  war" // FIPS OK: Not security related.
+                                    + resourcePath);
+                        } catch (IOException e) {
+                            logger.log(Level.WARNING, "Could not compute MD5 of war" + resourcePath, e);
+                        }
                     }
+                    resourcePaths = (Set<String>) servletContext.getResourcePaths("/WEB-INF/update-center-rootCAs");
+                    for (String resourcePath : new TreeSet<String>(resourcePaths)) {
+                        try {
+                            out.println(Util.getDigestOf(servletContext.getResourceAsStream(resourcePath))
+                                    + "  war" // FIPS OK: Not security related.
+                                    + resourcePath);
+                        } catch (IOException e) {
+                            logger.log(Level.WARNING, "Could not compute MD5 of war" + resourcePath, e);
+                        }
+                    }
+                } catch (LinkageError e) {
+                    // TODO switch javax import to jakarta after bumping core baseline, ignore for now
                 }
             }
 


### PR DESCRIPTION
While in general the project to move Jenkins onto EE 9 will maintain full compatibility with EE 8 (including the introduction of EE 9 `StaplerRequest2` and `StaplerResponse2` APIs), creating an EE 9 `Stapler2` class is overkill, since almost nothing outside of Stapler and Jenkins core calls `Stapler` methods other than `Stapler#getCurrentRequest` and `Stapler#getCurrentResponse`, both of which we can deprecate in favor of `Stapler#getCurrentRequest2` and `Stapler#getCurrentResponse2` (thus preserving compatibility for those two important methods but otherwise migrating the entire class to EE 9 without the maintainence burden of retaining a separate EE 8 version of the class). The only exception I found was this plugin, which called a few methods on the underlying `HttpServlet`, which will break when `Stapler` is migrated to EE 9. Since this isn't critical functionality and is just a diagnostic tool, ignore these failures to faciliate an easier upgrade process. Once this plugin has a baseline of EE 9, we can swap the import to `jakarta.servlet` and remove the catch block to restore this functionality. This minor ugliness is far more practical than trying to create a `Stapler2` class just for this use case (with all the maintenance burden entailed with changing references and maintaining an EE 8 `Stapler` class just for the benefit of the code being changed in this PR).

### Notes for reviewers

I recommend reviewing this with the **Hide Whitespace** feature enabled.

### Testing done

This test was failing with an EE 9-based `Stapler` class from my prototype; now this plugin tolerates the situation gracefully.