### PR TITLE
[doc] Remove misleading javadoc comment

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/api/ObjectComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/ObjectComponent.java
@@ -35,10 +35,6 @@ import jenkins.model.Jenkins;
 
 /**
  * Represents a component of a support bundle for a specific model object.
- *
- * <p>
- * This is the unit of user consent; when creating a bundle for this object, the user would enable/disable
- * individual components.
  */
 public abstract class ObjectComponent<T extends AbstractModelObject> extends Component
         implements Describable<ObjectComponent<T>>, ExtensionPoint {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This might seem like nitpicking, but I was puzzled for a bit going over this class, until I noticed it was most likely a copy paste of the javadoc of the parent `Component` class, which is the actual unit of user consent.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
