### PR TITLE
[JENKINS-73402] Load LogManager recorder afetr CasC loading

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/CustomLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/CustomLogs.java
@@ -133,7 +133,7 @@ public class CustomLogs extends Component {
         }
     }
 
-    @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED, before = InitMilestone.SYSTEM_CONFIG_LOADED)
+    @Initializer(after = InitMilestone.SYSTEM_CONFIG_ADAPTED, before = InitMilestone.JOB_LOADED)
     @Restricted(NoExternalUse.class)
     public void startCustomHandler() {
         Logger.getLogger("").addHandler(new CustomHandler());


### PR DESCRIPTION
Was probably introduced by https://github.com/jenkinsci/support-core-plugin/pull/338.

Propose to load the recorders after CasC init (see https://github.com/jenkinsci/configuration-as-code-plugin/blob/1810.v9b_c30a_249a_4c/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java#L337). 

I thought about just always targeting the reference `Jenkins.get().getLog().getRecorders()` from [CustomHandler#publish](https://github.com/jenkinsci/support-core-plugin/blob/1459.va_f527ce9a_d64/src/main/java/com/cloudbees/jenkins/support/impl/CustomLogs.java#L166) but wonder if that would be overkill ? We go through this for every log record.. cc @jglick I wonder WDYT about this ?

### Testing done

* Start Jenkins with CasC:
 
```
jenkins:
  log:
    recorders:
    - loggers:
      - level: "ALL"
        name: "jenkins.InitReactorRunner"
      name: "reactor"
```

* verify that `$JENKINS_HOME/logs/custom/reactor.log` exists

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue