### PR TITLE
Removing `JNLPLauncher.webSocket` notation in `nodes.md`

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
@@ -33,7 +33,6 @@ import hudson.model.Slave;
 import hudson.remoting.Launcher;
 import hudson.remoting.VirtualChannel;
 import hudson.security.Permission;
-import hudson.slaves.JNLPLauncher;
 import hudson.util.IOUtils;
 import java.io.File;
 import java.io.FileInputStream;
@@ -782,9 +781,6 @@ public class AboutJenkins extends Component {
                 if (node instanceof Slave) {
                     Slave agent = (Slave) node;
                     out.println("      - Launch method:  " + getDescriptorName(agent.getLauncher()));
-                    if (agent.getLauncher() instanceof JNLPLauncher) {
-                        out.println("      - WebSocket:      " + ((JNLPLauncher) agent.getLauncher()).isWebSocket());
-                    }
                     out.println("      - Availability:   " + getDescriptorName(agent.getRetentionStrategy()));
                 }
                 Optional.ofNullable(node.toComputer())

--- a/src/test/java/com/cloudbees/jenkins/support/impl/AboutJenkinsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/AboutJenkinsTest.java
@@ -56,28 +56,16 @@ public class AboutJenkinsTest {
     }
 
     @Test
-    @Issue("JENKINS-65097")
     public void testAboutNodesContent() throws Exception {
 
         DumbSlave tcp1 = j.createSlave("tcp1", "test", null);
-        tcp1.setLauncher(new JNLPLauncher(false));
-        ((JNLPLauncher) tcp1.getLauncher()).setWebSocket(false);
+        tcp1.setLauncher(new JNLPLauncher());
         tcp1.save();
 
         String aboutMdToString = SupportTestUtils.invokeComponentToString(
                 Objects.requireNonNull(ExtensionList.lookup(Component.class).get(AboutJenkins.class)));
         assertThat(aboutMdToString, containsString("  * `" + tcp1.getNodeName() + "` (`hudson.slaves.DumbSlave`)"));
         assertThat(aboutMdToString, containsString("      - Launch method:  `hudson.slaves.JNLPLauncher`"));
-        assertThat(aboutMdToString, containsString("      - WebSocket:      false"));
-
-        ((JNLPLauncher) tcp1.getLauncher()).setWebSocket(true);
-        tcp1.save();
-
-        aboutMdToString = SupportTestUtils.invokeComponentToString(
-                Objects.requireNonNull(ExtensionList.lookup(Component.class).get(AboutJenkins.class)));
-        assertThat(aboutMdToString, containsString("  * `" + tcp1.getNodeName() + "` (`hudson.slaves.DumbSlave`)"));
-        assertThat(aboutMdToString, containsString("      - Launch method:  `hudson.slaves.JNLPLauncher`"));
-        assertThat(aboutMdToString, containsString("      - WebSocket:      true"));
     }
 
     @Test


### PR DESCRIPTION
Reverting most of #271 since it is obsolete as of https://github.com/jenkinsci/jenkins/pull/8762.