### PR TITLE
Fix Markdown syntax of Non proxy hosts and Proxy host

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/UpdateCenter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/UpdateCenter.java
@@ -73,7 +73,7 @@ public class UpdateCenter extends Component {
         out.println("=== Proxy ===");
         ProxyConfiguration proxy = Jenkins.get().getProxy();
         if (proxy != null) {
-            out.println(" - Host: " + ContentFilter.filter(filter, proxy.getName()));
+            out.println(" - Host: `" + Markdown.escapeBacktick(ContentFilter.filter(filter, proxy.getName())) + "`");
             out.println(" - Port: " + proxy.getPort());
             out.println(" - No Proxy Hosts: ");
             String noProxyHostsString = proxy.getNoProxyHost();

--- a/src/main/java/com/cloudbees/jenkins/support/impl/UpdateCenter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/UpdateCenter.java
@@ -4,6 +4,7 @@ import com.cloudbees.jenkins.support.api.Component;
 import com.cloudbees.jenkins.support.api.Container;
 import com.cloudbees.jenkins.support.api.PrefilteredPrintedContent;
 import com.cloudbees.jenkins.support.filter.ContentFilter;
+import com.cloudbees.jenkins.support.util.Markdown;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ProxyConfiguration;
@@ -78,7 +79,7 @@ public class UpdateCenter extends Component {
             String noProxyHostsString = proxy.getNoProxyHost();
             if (noProxyHostsString != null) {
                 Arrays.stream(noProxyHostsString.split("[ \t\n,|]+"))
-                        .forEach(noProxyHost -> out.println(" * " + ContentFilter.filter(filter, noProxyHost)));
+                        .forEach(noProxyHost -> out.println(" * `" + Markdown.escapeBacktick(ContentFilter.filter(filter, noProxyHost)) + "`"));
             }
         }
     }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/UpdateCenter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/UpdateCenter.java
@@ -79,7 +79,8 @@ public class UpdateCenter extends Component {
             String noProxyHostsString = proxy.getNoProxyHost();
             if (noProxyHostsString != null) {
                 Arrays.stream(noProxyHostsString.split("[ \t\n,|]+"))
-                        .forEach(noProxyHost -> out.println(" * `" + Markdown.escapeBacktick(ContentFilter.filter(filter, noProxyHost)) + "`"));
+                        .forEach(noProxyHost -> out.println(
+                                " * `" + Markdown.escapeBacktick(ContentFilter.filter(filter, noProxyHost)) + "`"));
             }
         }
     }

--- a/src/test/java/com/cloudbees/jenkins/support/impl/UpdateCenterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/UpdateCenterTest.java
@@ -43,7 +43,7 @@ public class UpdateCenterTest {
         assertThat(ucMdToString, not(containsString("proxyUser")));
         assertThat(ucMdToString, not(containsString("proxyPass")));
         for (String noProxyHost : noProxyHosts) {
-            assertThat(ucMdToString, containsString(" * " + noProxyHost));
+            assertThat(ucMdToString, containsString(" * `" + noProxyHost + "`"));
         }
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/support/impl/UpdateCenterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/UpdateCenterTest.java
@@ -26,19 +26,17 @@ public class UpdateCenterTest {
     public void testUpdateCenterProxyContent() {
 
         List<String> noProxyHosts = Arrays.asList(".server.com", "*.example.com");
-        j.jenkins
-                .get()
-                .setProxy(new ProxyConfiguration(
-                        "proxy.server.com",
-                        1234,
-                        "proxyUser",
-                        "proxyPass",
-                        String.join("\n", noProxyHosts),
-                        "http://localhost:8080"));
+        j.jenkins.setProxy(new ProxyConfiguration(
+                "proxy.server.com",
+                1234,
+                "proxyUser",
+                "proxyPass",
+                String.join("\n", noProxyHosts),
+                "http://localhost:8080"));
 
         String ucMdToString = SupportTestUtils.invokeComponentToString(
                 Objects.requireNonNull(ExtensionList.lookup(Component.class).get(UpdateCenter.class)));
-        assertThat(ucMdToString, containsString(" - Host: proxy.server.com"));
+        assertThat(ucMdToString, containsString(" - Host: `proxy.server.com`"));
         assertThat(ucMdToString, containsString(" - Port: 1234"));
         assertThat(ucMdToString, not(containsString("proxyUser")));
         assertThat(ucMdToString, not(containsString("proxyPass")));


### PR DESCRIPTION
Recently discovered that wildcard syntax including several `*` are mis-interpreted by Markdown parsers.. For example `10.1.*.*` would be `10.1..` with a bold dot..

### Testing done

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue