### PR TITLE
[chore] Add "up" and "running" as stop words

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/filter/DefaultStopWords.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/DefaultStopWords.java
@@ -31,6 +31,8 @@ public class DefaultStopWords implements StopWords {
                 "everyone",
                 "system",
                 "admin",
+                "up",
+                "running",
                 Jenkins.VERSION);
     }
 }


### PR DESCRIPTION
If an instance contains jobs named "up" and/or "running", those end up being anonymized, leading to a log entry like: `Jenkins is fully item_outer_pub and item_square_life`.

This is not really convenient when browsing through the logs and looking for "up and running".

With this change, the log entry becomes `Jenkins is up and running`.

More generally, and outside of the context of this PR, I wonder if some groups of words should not be automatically excluded, like two letter words, adverbs etc...

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
