### PR TITLE
Add ability to filter more Config Files from OtherConfigFilesComponent

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ This version changes the configuration fields to be more intuitive. Please updat
 you update support-core to version 2.68 or later.
 
 
-## Support Bundle sensitive data auto redaction
+## Support Bundle - Sensitive data auto redaction
 Starting from version 2.72.2, Support Core plugin could automatically redact any passwords stored in the following files:
 * `nodes.md`
 * `about.md`
@@ -210,6 +210,25 @@ will be changed to:
 -username.net.passwd=REDACTED
 ````
 To disable this feature, delete all of the security stop words from the security-stop-words.txt file (but not the file itself, because it will be automatically regenerated with a default values). Any changes made to the security-stop-words.txt file are applied after a Jenkins instance restart.
+
+### Support Bundle - Other Jenkins Configuration Files Filters
+
+The `Other Jenkins Configuration Files (Encrypted secrets are redacted)` option
+collects `$JENKINS_HOME/*.xml` with redacted secrets with some exceptions such as the
+`com.cloudbees.jenkins.support.filter.ContentMappings.xml` and `credentials.xml`.
+Additional filter can be provided in a text file located at
+`$JENKINS_HOME/support/other-config-files-filters.txt`. Each non-blank line of
+the file is treated as a regular expression filter. For example, the following 
+exclude files with `credentials` or `secrets` in their names and only includes 
+files that start with `org.jenkins`:
+
+```
+((?!(credentials|secrets)).)*
+^org\.jenkins.*
+```
+
+The system property `com.cloudbees.jenkins.support.configfiles.OtherConfigFilesComponent.otherConfigFilesFilterFile`
+can be used to override the file location.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -211,25 +211,6 @@ will be changed to:
 ````
 To disable this feature, delete all of the security stop words from the security-stop-words.txt file (but not the file itself, because it will be automatically regenerated with a default values). Any changes made to the security-stop-words.txt file are applied after a Jenkins instance restart.
 
-### Support Bundle - Other Jenkins Configuration Files Filters
-
-The `Other Jenkins Configuration Files (Encrypted secrets are redacted)` option
-collects `$JENKINS_HOME/*.xml` with redacted secrets with some exceptions such as the
-`com.cloudbees.jenkins.support.filter.ContentMappings.xml` and `credentials.xml`.
-Additional filter can be provided in a text file located at
-`$JENKINS_HOME/support/other-config-files-filters.txt`. Each non-blank line of
-the file is treated as a regular expression filter. For example, the following 
-exclude files with `credentials` or `secrets` in their names and only includes 
-files that start with `org.jenkins`:
-
-```
-((?!(credentials|secrets)).)*
-^org\.jenkins.*
-```
-
-The system property `com.cloudbees.jenkins.support.configfiles.OtherConfigFilesComponent.otherConfigFilesFilterFile`
-can be used to override the file location.
-
 ## Changelog
 
 ### Version 2.71 and newer

--- a/src/main/java/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponent.java
@@ -102,7 +102,8 @@ public class OtherConfigFilesComponent extends Component {
     private static final Logger LOGGER = Logger.getLogger(OtherConfigFilesComponent.class.getName());
 
     /**
-     * Extension to contribute to the list of configuration files to filter.
+     * Extension to contribute to the list of configuration files to filter. A file need to be accepted by all
+     * {@link ConfigFilesFilter} implementations to be included in the content.
      */
     public interface ConfigFilesFilter extends ExtensionPoint {
 
@@ -127,7 +128,7 @@ public class OtherConfigFilesComponent extends Component {
         }
 
         /**
-         * Return the a {@link java.io.FilenameFilter} of files to accept in the {@link OtherConfigFilesComponent}.
+         * Return a {@link java.io.FilenameFilter} to filter out files from {@link OtherConfigFilesComponent}.
          * @return a {@link java.io.FilenameFilter}
          */
         @NonNull

--- a/src/main/java/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponent.java
@@ -24,19 +24,29 @@
 
 package com.cloudbees.jenkins.support.configfiles;
 
+import com.cloudbees.jenkins.support.SupportPlugin;
 import com.cloudbees.jenkins.support.api.Component;
 import com.cloudbees.jenkins.support.api.Container;
 import com.cloudbees.jenkins.support.filter.ContentMappings;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
 import hudson.security.Permission;
 import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
 
 /**
@@ -44,14 +54,6 @@ import jenkins.model.Jenkins;
  */
 @Extension
 public class OtherConfigFilesComponent extends Component {
-
-    private static final List<String> BLACKLISTED_FILENAMES = Arrays.asList(
-            // contains anonymized content mappings
-            ContentMappings.class.getName() + ".xml",
-            // credentials.xml contains rather sensitive data
-            "credentials.xml",
-            // config.xml is handled by ConfigFileComponent
-            "config.xml");
 
     @NonNull
     @Override
@@ -70,8 +72,7 @@ public class OtherConfigFilesComponent extends Component {
         Jenkins jenkins = Jenkins.getInstanceOrNull();
         if (jenkins != null) {
             File dir = jenkins.getRootDir();
-            File[] files = dir.listFiles(
-                    (dir1, name) -> name.toLowerCase().endsWith(".xml") && !BLACKLISTED_FILENAMES.contains(name));
+            File[] files = dir.listFiles(ConfigFilesFilter.getAllFileFilter());
             if (files != null) {
                 for (File configFile : files) {
                     if (configFile.exists()) {
@@ -99,4 +100,101 @@ public class OtherConfigFilesComponent extends Component {
     }
 
     private static final Logger LOGGER = Logger.getLogger(OtherConfigFilesComponent.class.getName());
+
+    /**
+     * Extension to contribute to the list of configuration files to filter.
+     */
+    public interface ConfigFilesFilter extends ExtensionPoint {
+
+        /**
+         * @return all {@link ConfigFilesFilter} extensions
+         */
+        static ExtensionList<ConfigFilesFilter> all() {
+            return ExtensionList.lookup(ConfigFilesFilter.class);
+        }
+
+        static FilenameFilter getAllFileFilter() {
+            final List<FilenameFilter> allFilters =
+                    all().stream().map(ConfigFilesFilter::getFilenameFilter).collect(Collectors.toList());
+            return (dir, name) -> {
+                for (FilenameFilter filenameFilter : allFilters) {
+                    if (!filenameFilter.accept(dir, name)) {
+                        return false;
+                    }
+                }
+                return true;
+            };
+        }
+
+        /**
+         * Return the a {@link java.io.FilenameFilter} of files to accept in the {@link OtherConfigFilesComponent}.
+         * @return a {@link java.io.FilenameFilter}
+         */
+        @NonNull
+        FilenameFilter getFilenameFilter();
+    }
+
+    @Extension
+    public static class DefaultConfigFilesFilter implements ConfigFilesFilter {
+
+        private static final List<String> BLACKLISTED_FILENAMES = Arrays.asList(
+                // contains anonymized content mappings
+                ContentMappings.class.getName() + ".xml",
+                // credentials.xml contains rather sensitive data
+                "credentials.xml",
+                // config.xml is handled by ConfigFileComponent
+                "config.xml");
+
+        @NonNull
+        @Override
+        public FilenameFilter getFilenameFilter() {
+            return (dir, name) -> name.toLowerCase().endsWith(".xml") && !BLACKLISTED_FILENAMES.contains(name);
+        }
+    }
+
+    @Extension
+    public static class RegexpsFromFileConfigFilesFilter implements ConfigFilesFilter {
+
+        private static final String OTHER_CONFIG_FILES_FILTER_FILENAME = "other-config-files-filters.txt";
+        private static final String OTHER_CONFIG_FILES_FILTER_PROPERTY =
+                OtherConfigFilesComponent.class.getName() + ".otherConfigFilesFilterFile";
+
+        @NonNull
+        @Override
+        public FilenameFilter getFilenameFilter() {
+            String fileLocationFromProperty = System.getProperty(OTHER_CONFIG_FILES_FILTER_PROPERTY);
+            String fileLocation = fileLocationFromProperty == null
+                    ? SupportPlugin.getRootDirectory() + "/" + OTHER_CONFIG_FILES_FILTER_FILENAME
+                    : fileLocationFromProperty;
+            LOGGER.log(Level.FINE, "Attempting to load user provided regexp filters from ''{0}''.", fileLocation);
+            File f = new File(fileLocation);
+            if (f.exists()) {
+                if (!f.canRead()) {
+                    LOGGER.log(
+                            Level.WARNING,
+                            "Could not load user provided regexp filters as " + fileLocation + " is not readable.");
+                } else {
+                    try {
+                        final Pattern allPattern = Pattern.compile("("
+                                + Files.readAllLines(Path.of(fileLocation), Charset.defaultCharset()).stream()
+                                        .map(s -> "(?=" + s + ")")
+                                        .collect(Collectors.joining(""))
+                                + ".*)");
+                        return (dir, name) -> allPattern.matcher(name).matches();
+                    } catch (IOException ex) {
+                        LOGGER.log(
+                                Level.WARNING,
+                                "Could not load user provided regexps. there was an error reading " + fileLocation,
+                                ex);
+                    }
+                }
+            } else if (fileLocationFromProperty != null) {
+                LOGGER.log(
+                        Level.WARNING,
+                        "Could not load user provided stop regexps as " + fileLocationFromProperty
+                                + " does not exists.");
+            }
+            return (dir, name) -> true;
+        }
+    }
 }

--- a/src/test/java/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponentTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponentTest.java
@@ -195,10 +195,9 @@ public class OtherConfigFilesComponentTest {
     @TestExtension
     public static class TestConfigFilesFilter implements OtherConfigFilesComponent.ConfigFilesFilter {
 
-        @NotNull
         @Override
-        public List<String> getFilenames() {
-            return List.of("test-abc.xml", "test-efgh.xml", "toexclude.xml");
+        public boolean include(@NotNull File file) {
+            return !List.of("test-abc.xml", "test-efgh.xml", "toexclude.xml").contains(file.getName());
         }
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponentTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponentTest.java
@@ -34,7 +34,6 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.TestExtension;
-import org.jvnet.hudson.test.recipes.LocalData;
 
 public class OtherConfigFilesComponentTest {
 
@@ -155,7 +154,6 @@ public class OtherConfigFilesComponentTest {
     }
 
     @Test
-    @LocalData
     public void regexpFromFileFilter() throws Exception {
         List<String> filesToExclude = List.of(
                 "test-abc.xml",

--- a/src/test/resources/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponentTest/regexpFromFileFilter/support/other-config-files-filters.txt
+++ b/src/test/resources/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponentTest/regexpFromFileFilter/support/other-config-files-filters.txt
@@ -1,2 +1,0 @@
-^((?!(abc|efg)).)*.\.xml
-test-.*\.xml

--- a/src/test/resources/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponentTest/regexpFromFileFilter/support/other-config-files-filters.txt
+++ b/src/test/resources/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponentTest/regexpFromFileFilter/support/other-config-files-filters.txt
@@ -1,0 +1,2 @@
+^((?!(abc|efg)).)*.\.xml
+test-.*\.xml


### PR DESCRIPTION
Add ability to provide more filters to the `OtherConfigFilesComponent` if some `xml` files are meant to be excluded in extensions and plugins.

### Testing done

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue