### PR TITLE
API to supersede components if not required

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -596,8 +596,13 @@ public class SupportPlugin extends Plugin {
 
         manifest.append("Requested components:\n\n");
         ContentContainer contentsContainer = new ContentContainer(contentFilter, components);
+        Set<Class<? extends Component>> supersededComponents = new HashSet<>();
+        components.forEach(c -> supersededComponents.addAll(c.getSupersededComponents()));
         for (Component component : components) {
             try {
+                if (supersededComponents.contains(component.getClass())) {
+                    continue;
+                }
                 manifest.append("  * ").append(component.getDisplayName()).append("\n\n");
                 LOGGER.log(Level.FINE, "Start processing " + component.getDisplayName());
                 long startTime = System.currentTimeMillis();

--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -596,13 +596,12 @@ public class SupportPlugin extends Plugin {
 
         manifest.append("Requested components:\n\n");
         ContentContainer contentsContainer = new ContentContainer(contentFilter, components);
-        Set<Class<? extends Component>> supersededComponents = new HashSet<>();
-        components.forEach(c -> supersededComponents.addAll(c.getSupersededComponents()));
         for (Component component : components) {
             try {
-                if (supersededComponents.contains(component.getClass())) {
+                if (components.stream().anyMatch(c -> c.supersedes(component))) {
                     continue;
                 }
+
                 manifest.append("  * ").append(component.getDisplayName()).append("\n\n");
                 LOGGER.log(Level.FINE, "Start processing " + component.getDisplayName());
                 long startTime = System.currentTimeMillis();

--- a/src/main/java/com/cloudbees/jenkins/support/api/Component.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/Component.java
@@ -154,7 +154,7 @@ public abstract class Component implements ExtensionPoint {
     }
 
     public Set<Class<? extends Component>> getSupersededComponents() {
-        return Collections.emptySet();
+        return Set.of();
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/support/api/Component.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/Component.java
@@ -153,6 +153,10 @@ public abstract class Component implements ExtensionPoint {
         return ComponentCategory.UNCATEGORIZED;
     }
 
+    public Set<Class<? extends Component>> getSupersededComponents() {
+        return Collections.emptySet();
+    }
+
     /**
      * Categories supported by this version of support-core
      *

--- a/src/main/java/com/cloudbees/jenkins/support/api/Component.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/Component.java
@@ -153,8 +153,13 @@ public abstract class Component implements ExtensionPoint {
         return ComponentCategory.UNCATEGORIZED;
     }
 
-    public Set<Class<? extends Component>> getSupersededComponents() {
-        return Set.of();
+    /**
+     * Returns true if a component is superseded by this component.
+     * useful if we write a component that makes another one obsolete.
+     * @return
+     */
+    public boolean supersedes(Component component) {
+        return false;
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/support/api/Component.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/Component.java
@@ -156,7 +156,6 @@ public abstract class Component implements ExtensionPoint {
     /**
      * Returns true if a component is superseded by this component.
      * useful if we write a component that makes another one obsolete.
-     * @return
      */
     public boolean supersedes(Component component) {
         return false;

--- a/src/test/java/com/cloudbees/jenkins/support/SupportPluginTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportPluginTest.java
@@ -40,11 +40,6 @@ public class SupportPluginTest {
     public TemporaryFolder temp = new TemporaryFolder();
 
     @Test
-    public void testSomething(){
-        j.getInstance();
-    }
-
-    @Test
     @Issue("JENKINS-63722")
     public void testComponentIdsAreUnique() {
         // If component IDs have duplicate, the Set size should be different because it only add an item if it is unique

--- a/src/test/java/com/cloudbees/jenkins/support/SupportPluginTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportPluginTest.java
@@ -108,6 +108,7 @@ public class SupportPluginTest {
      * Test that a component can supersede another component.
      * This is similar to testGenerateBundleExceptionHandler() but we are superseding
      * AboutJenkins and BuildQueue components. even if is added to the list of components to create.
+     * I will not add its files to the bundle
      * @throws Exception
      */
     @Test
@@ -146,7 +147,6 @@ public class SupportPluginTest {
                 ExtensionList.lookup(Component.class).get(SystemProperties.class));
 
         File bundleFile = temp.newFile();
-
         try (OutputStream os = Files.newOutputStream(bundleFile.toPath())) {
             SupportPlugin.writeBundle(os, components);
         }

--- a/src/test/java/com/cloudbees/jenkins/support/SupportPluginTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportPluginTest.java
@@ -112,7 +112,7 @@ public class SupportPluginTest {
      */
     @Test
     public void testSupersedesComponent() throws Exception {
-        List<Component> components = Arrays.asList(
+        List<Component> components = List.of(
                 new Component() {
                     @NonNull
                     @Override
@@ -128,7 +128,7 @@ public class SupportPluginTest {
 
                     @Override
                     public boolean supersedes(Component component) {
-                        return Set.of(AboutJenkins.class, BuildQueue.class).contains(component.getClass());
+                        return component instanceof AboutJenkins || component instanceof BuildQueue;
                     }
 
                     @Override
@@ -141,9 +141,9 @@ public class SupportPluginTest {
                         });
                     }
                 },
-                ExtensionList.lookup(Component.class).get(AboutJenkins.class),
-                ExtensionList.lookup(Component.class).get(BuildQueue.class),
-                ExtensionList.lookup(Component.class).get(SystemProperties.class));
+                ExtensionList.lookupSingleton(AboutJenkins.class),
+                ExtensionList.lookupSingleton(BuildQueue.class),
+                ExtensionList.lookupSingleton(SystemProperties.class));
 
         File bundleFile = temp.newFile();
         try (OutputStream os = Files.newOutputStream(bundleFile.toPath())) {

--- a/src/test/java/com/cloudbees/jenkins/support/SupportPluginTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportPluginTest.java
@@ -155,7 +155,7 @@ public class SupportPluginTest {
         assertNotNull(zip.getEntry("manifest.md"));
         assertNotNull(zip.getEntry("nodes/master/system.properties"));
 
-        //Assert null for AboutJenkins.class, BuildQueue.class components
+        // Assert null for AboutJenkins.class, BuildQueue.class components
         assertNull(zip.getEntry("buildqueue.md"));
         assertNull(zip.getEntry("about.md"));
         assertNull(zip.getEntry("nodes.md"));

--- a/src/test/java/com/cloudbees/jenkins/support/SupportPluginTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportPluginTest.java
@@ -109,7 +109,6 @@ public class SupportPluginTest {
      * We are superseding AboutJenkins and BuildQueue components.
      * even if is added to the list of components to create.
      * It will not add its files to the bundle
-     * @throws Exception
      */
     @Test
     public void testSupersedesComponent() throws Exception {

--- a/src/test/java/com/cloudbees/jenkins/support/SupportPluginTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportPluginTest.java
@@ -106,9 +106,9 @@ public class SupportPluginTest {
 
     /**
      * Test that a component can supersede another component.
-     * This is similar to testGenerateBundleExceptionHandler() but we are superseding
-     * AboutJenkins and BuildQueue components. even if is added to the list of components to create.
-     * I will not add its files to the bundle
+     * We are superseding AboutJenkins and BuildQueue components.
+     * even if is added to the list of components to create.
+     * It will not add its files to the bundle
      * @throws Exception
      */
     @Test


### PR DESCRIPTION
Added a way for components to supersede other components in the support bundle creation process

