### PR TITLE
BEE-53476 Removes Yahoo UI usages from support-core plugin

### DIFF
--- a/src/main/resources/com/cloudbees/jenkins/support/SupportAction/index.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/support/SupportAction/index.jelly
@@ -86,20 +86,11 @@
           </f:entry>
         </j:forEach>
         <f:entry>
-          <span class="yui-button yui-submit-button submit-button primary">
-            <span class="first-child">
-              <button type="submit" formaction="downloadBundles">${%Download Bundle}</button>
-            </span>
-          </span>
-          <span class="yui-button yui-submit-button submit-button danger">
-            <span class="first-child">
-              <button type="submit" formaction="deleteBundles">${%Delete Bundle}</button>
-            </span>
-          </span>
+          <button type="submit" class="jenkins-button jenkins-button--primary jenkins-!-margin-1" formaction="downloadBundles">${%Download Bundle}</button>
+          <button type="submit" class="jenkins-button jenkins-!-destructive-color" formaction="deleteBundles">${%Delete Bundle}</button>
         </f:entry>
       </f:form>
       </f:section>
-
     </l:main-panel>
   </l:layout>
 </j:jelly>


### PR DESCRIPTION
## Changes
- Replaced yui button references with jenkins-button

Note: button location got changed (renders on left side now) after using jenkins-button css and it seemed more in line with the other buttons. Hence, I didn't put effort to keep it in original location. 

### Testing done

Before
<img width="1276" alt="image" src="https://github.com/user-attachments/assets/bd0f5169-e0ed-4e01-88cf-8ea2e39a4c8e" />

After
<img width="973" alt="image" src="https://github.com/user-attachments/assets/9c165700-5ee9-4efb-a368-cff7ccd08013" />


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
