### PR TITLE
NPE in `AgentsConfigFile.addContents`

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/configfiles/AgentsConfigFile.java
+++ b/src/main/java/com/cloudbees/jenkins/support/configfiles/AgentsConfigFile.java
@@ -34,7 +34,6 @@ import hudson.security.Permission;
 import java.io.File;
 import java.text.MessageFormat;
 import java.util.Collections;
-import java.util.Objects;
 import java.util.Set;
 import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
@@ -84,7 +83,12 @@ public class AgentsConfigFile extends ObjectComponent<Computer> {
 
     @Override
     public void addContents(@NonNull Container container) {
-        Jenkins.get().getNodes().forEach(node -> addContents(container, Objects.requireNonNull(node.toComputer())));
+        for (var n : Jenkins.get().getNodes()) {
+            var c = n.toComputer();
+            if (c != null) {
+                addContents(container, c);
+            }
+        }
     }
 
     @Override
@@ -105,7 +109,7 @@ public class AgentsConfigFile extends ObjectComponent<Computer> {
 
     @Override
     public boolean isApplicable(Computer item) {
-        return item != Jenkins.get().toComputer();
+        return !(item instanceof Jenkins.MasterComputer);
     }
 
     @Override


### PR DESCRIPTION
Apparently a regression in #198:

```
WARNING	c.c.j.support.SupportPlugin#appendManifestContents: Could not get content from Agent Configuration File for support bundle
java.lang.NullPointerException
	at java.base/java.util.Objects.requireNonNull(Objects.java:233)
	at PluginClassLoader for support-core//com.cloudbees.jenkins.support.configfiles.AgentsConfigFile.lambda$addContents$0(AgentsConfigFile.java:87)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at PluginClassLoader for support-core//com.cloudbees.jenkins.support.configfiles.AgentsConfigFile.addContents(AgentsConfigFile.java:87)
	at PluginClassLoader for support-core//com.cloudbees.jenkins.support.SupportPlugin$1.visit(SupportPlugin.java:358)
	at PluginClassLoader for support-core//com.cloudbees.jenkins.support.SupportPlugin.appendManifestContents(SupportPlugin.java:608)
	at PluginClassLoader for support-core//com.cloudbees.jenkins.support.SupportPlugin.writeBundle(SupportPlugin.java:389)
	at PluginClassLoader for support-core//com.cloudbees.jenkins.support.SupportPlugin.writeBundle(SupportPlugin.java:355)
	at PluginClassLoader for support-core//com.cloudbees.jenkins.support.SupportPlugin$PeriodicWorkImpl.lambda$doRun$0(SupportPlugin.java:986)
```

Observed in a heavily loaded controller.
