### PR TITLE
Removing `requesterAuthentication`

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
@@ -33,8 +33,6 @@ import hudson.Extension;
 import hudson.model.Api;
 import hudson.model.Failure;
 import hudson.model.RootAction;
-import hudson.security.ACL;
-import hudson.security.ACLContext;
 import hudson.security.Permission;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletOutputStream;
@@ -397,18 +395,10 @@ public class SupportAction implements RootAction, StaplerProxy {
         rsp.addHeader("Content-Disposition", "inline; filename=" + BundleFileName.generate() + ";");
         final ServletOutputStream servletOutputStream = rsp.getOutputStream();
         try {
-            SupportPlugin.setRequesterAuthentication(Jenkins.getAuthentication2());
-            try {
-                try (ACLContext ignored = ACL.as2(ACL.SYSTEM2)) {
-                    SupportPlugin.writeBundle(servletOutputStream, components);
-                } catch (IOException e) {
-                    logger.log(Level.FINE, e.getMessage(), e);
-                }
-            } finally {
-                SupportPlugin.clearRequesterAuthentication();
-            }
-        } finally {
+            SupportPlugin.writeBundle(servletOutputStream, components);
             logger.fine("Response completed");
+        } catch (IOException e) {
+            logger.log(Level.FINE, e.getMessage(), e);
         }
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/SupportCommand.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportCommand.java
@@ -31,8 +31,6 @@ import hudson.CloseProofOutputStream;
 import hudson.Extension;
 import hudson.cli.CLICommand;
 import hudson.remoting.RemoteOutputStream;
-import hudson.security.ACL;
-import hudson.security.ACLContext;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -93,20 +91,13 @@ public class SupportCommand extends CLICommand {
                 selected.add(c);
             }
         }
-        SupportPlugin.setRequesterAuthentication(Jenkins.getAuthentication2());
-        try {
-            try (ACLContext ignored = ACL.as2(ACL.SYSTEM2)) {
-                OutputStream os;
-                if (channel != null) { // Remoting mode
-                    os = channel.call(new SaveBundle(BundleFileName.generate()));
-                } else { // redirect output to a ZIP file yourself
-                    os = new CloseProofOutputStream(stdout);
-                }
-                SupportPlugin.writeBundle(os, new ArrayList<>(selected));
-            }
-        } finally {
-            SupportPlugin.clearRequesterAuthentication();
+        OutputStream os;
+        if (channel != null) { // Remoting mode
+            os = channel.call(new SaveBundle(BundleFileName.generate()));
+        } else { // redirect output to a ZIP file yourself
+            os = new CloseProofOutputStream(stdout);
         }
+        SupportPlugin.writeBundle(os, new ArrayList<>(selected));
         return 0;
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -158,7 +158,6 @@ public class SupportPlugin extends Plugin {
             Jenkins.ADMINISTER,
             PermissionScope.JENKINS);
 
-    private static final ThreadLocal<Authentication> requesterAuthentication = new InheritableThreadLocal<>();
     private static final AtomicLong nextBundleWrite = new AtomicLong(Long.MIN_VALUE);
     private static final Logger logger = Logger.getLogger(SupportPlugin.class.getName());
     public static final String SUPPORT_DIRECTORY_NAME = "support";
@@ -234,16 +233,12 @@ public class SupportPlugin extends Plugin {
         return new File(SafeTimerTask.getLogsRoot(), SUPPORT_DIRECTORY_NAME);
     }
 
+    /**
+     * @deprecated Check permissions directly.
+     */
+    @Deprecated
     public static Authentication getRequesterAuthentication() {
-        return requesterAuthentication.get();
-    }
-
-    public static void setRequesterAuthentication(Authentication authentication) {
-        requesterAuthentication.set(authentication);
-    }
-
-    public static void clearRequesterAuthentication() {
-        requesterAuthentication.remove();
+        return Jenkins.getAuthentication2();
     }
 
     public void setSupportProvider(SupportProvider supportProvider) throws IOException {
@@ -969,7 +964,6 @@ public class SupportPlugin extends Plugin {
                                 thread.setName(String.format(
                                         "%s periodic bundle generator: since %s",
                                         SupportPlugin.class.getSimpleName(), new Date()));
-                                clearRequesterAuthentication();
                                 try (ACLContext ignored = ACL.as2(ACL.SYSTEM2)) {
                                     File bundleDir = getRootDirectory();
                                     if (!bundleDir.exists()) {

--- a/src/main/java/com/cloudbees/jenkins/support/actions/SupportObjectAction.java
+++ b/src/main/java/com/cloudbees/jenkins/support/actions/SupportObjectAction.java
@@ -13,8 +13,6 @@ import hudson.model.AbstractModelObject;
 import hudson.model.Action;
 import hudson.model.Descriptor;
 import hudson.model.Saveable;
-import hudson.security.ACL;
-import hudson.security.ACLContext;
 import hudson.util.DescribableList;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletResponse;
@@ -139,21 +137,15 @@ public abstract class SupportObjectAction<T extends AbstractModelObject> impleme
                 "Content-Disposition", "inline; filename=" + BundleFileName.generate(getBundleNameQualifier()) + ";");
 
         try {
-            SupportPlugin.setRequesterAuthentication(Jenkins.getAuthentication2());
-            try (ACLContext old = ACL.as2(ACL.SYSTEM2)) {
-                SupportPlugin.writeBundle(rsp.getOutputStream(), components, new ComponentVisitor() {
-                    @Override
-                    public <C extends Component> void visit(Container container, C component) {
-                        ((ObjectComponent<T>) component).addContents(container, object);
-                    }
-                });
-            } catch (IOException e) {
-                LOGGER.log(Level.WARNING, e.getMessage(), e);
-            } finally {
-                SupportPlugin.clearRequesterAuthentication();
-            }
-        } finally {
+            SupportPlugin.writeBundle(rsp.getOutputStream(), components, new ComponentVisitor() {
+                @Override
+                public <C extends Component> void visit(Container container, C component) {
+                    ((ObjectComponent<T>) component).addContents(container, object);
+                }
+            });
             LOGGER.fine("Response completed");
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, e.getMessage(), e);
         }
     }
 

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutUser.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutUser.java
@@ -1,6 +1,5 @@
 package com.cloudbees.jenkins.support.impl;
 
-import com.cloudbees.jenkins.support.SupportPlugin;
 import com.cloudbees.jenkins.support.api.Component;
 import com.cloudbees.jenkins.support.api.Container;
 import com.cloudbees.jenkins.support.api.PrefilteredPrintedContent;
@@ -13,6 +12,7 @@ import java.io.PrintWriter;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
+import jenkins.model.Jenkins;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 
@@ -36,33 +36,31 @@ public class AboutUser extends Component {
 
     @Override
     public void addContents(@NonNull Container result) {
-        final Authentication authentication = SupportPlugin.getRequesterAuthentication();
-        if (authentication != null) {
-            result.add(new PrefilteredPrintedContent("user.md") {
-                @Override
-                protected void printTo(PrintWriter out, ContentFilter filter) throws IOException {
-                    out.println("User");
-                    out.println("====");
-                    out.println();
-                    out.println("Authentication");
-                    out.println("--------------");
-                    out.println();
-                    out.println("  * Authenticated: " + authentication.isAuthenticated());
-                    out.println("  * Name: " + ContentFilter.filter(filter, authentication.getName()));
-                    Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
-                    if (authorities != null) {
-                        out.println("  * Authorities ");
-                        for (GrantedAuthority authority : authorities) {
-                            out.println("      - "
-                                    + (authority == null
-                                            ? "null"
-                                            : "`" + authority.toString().replaceAll("`", "&#96;") + "`"));
-                        }
+        final Authentication authentication = Jenkins.getAuthentication2();
+        result.add(new PrefilteredPrintedContent("user.md") {
+            @Override
+            protected void printTo(PrintWriter out, ContentFilter filter) throws IOException {
+                out.println("User");
+                out.println("====");
+                out.println();
+                out.println("Authentication");
+                out.println("--------------");
+                out.println();
+                out.println("  * Authenticated: " + authentication.isAuthenticated());
+                out.println("  * Name: " + ContentFilter.filter(filter, authentication.getName()));
+                Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+                if (authorities != null) {
+                    out.println("  * Authorities ");
+                    for (GrantedAuthority authority : authorities) {
+                        out.println("      - "
+                                + (authority == null
+                                        ? "null"
+                                        : "`" + authority.toString().replaceAll("`", "&#96;") + "`"));
                     }
-                    out.println();
                 }
-            });
-        }
+                out.println();
+            }
+        });
     }
 
     @NonNull

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutUser.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutUser.java
@@ -6,6 +6,7 @@ import com.cloudbees.jenkins.support.api.PrefilteredPrintedContent;
 import com.cloudbees.jenkins.support.filter.ContentFilter;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import hudson.security.ACL;
 import hudson.security.Permission;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -37,30 +38,32 @@ public class AboutUser extends Component {
     @Override
     public void addContents(@NonNull Container result) {
         final Authentication authentication = Jenkins.getAuthentication2();
-        result.add(new PrefilteredPrintedContent("user.md") {
-            @Override
-            protected void printTo(PrintWriter out, ContentFilter filter) throws IOException {
-                out.println("User");
-                out.println("====");
-                out.println();
-                out.println("Authentication");
-                out.println("--------------");
-                out.println();
-                out.println("  * Authenticated: " + authentication.isAuthenticated());
-                out.println("  * Name: " + ContentFilter.filter(filter, authentication.getName()));
-                Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
-                if (authorities != null) {
-                    out.println("  * Authorities ");
-                    for (GrantedAuthority authority : authorities) {
-                        out.println("      - "
-                                + (authority == null
-                                        ? "null"
-                                        : "`" + authority.toString().replaceAll("`", "&#96;") + "`"));
+        if (!authentication.equals(ACL.SYSTEM2)) {
+            result.add(new PrefilteredPrintedContent("user.md") {
+                @Override
+                protected void printTo(PrintWriter out, ContentFilter filter) throws IOException {
+                    out.println("User");
+                    out.println("====");
+                    out.println();
+                    out.println("Authentication");
+                    out.println("--------------");
+                    out.println();
+                    out.println("  * Authenticated: " + authentication.isAuthenticated());
+                    out.println("  * Name: " + ContentFilter.filter(filter, authentication.getName()));
+                    Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+                    if (authorities != null) {
+                        out.println("  * Authorities ");
+                        for (GrantedAuthority authority : authorities) {
+                            out.println("      - "
+                                    + (authority == null
+                                            ? "null"
+                                            : "`" + authority.toString().replaceAll("`", "&#96;") + "`"));
+                        }
                     }
+                    out.println();
                 }
-                out.println();
-            }
-        });
+            });
+        }
     }
 
     @NonNull

--- a/src/test/java/com/cloudbees/jenkins/support/CheckFilterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/CheckFilterTest.java
@@ -28,6 +28,7 @@ import hudson.model.FreeStyleProject;
 import hudson.model.User;
 import hudson.model.labels.LabelAtom;
 import hudson.model.queue.QueueTaskFuture;
+import hudson.security.ACL;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -90,25 +91,28 @@ public class CheckFilterTest {
         // Generate the filtered words
         checker.generateFilteredWords();
 
-        // Check the components are filtered correctly
-        assertComponent(
-                Arrays.asList(
-                        AboutJenkins.class,
-                        AboutUser.class,
-                        AgentsConfigFile.class,
-                        BuildQueue.class,
-                        ConfigFileComponent.class,
-                        DumpExportTable.class,
-                        EnvironmentVariables.class,
-                        JVMProcessSystemMetricsContents.Agents.class,
-                        JVMProcessSystemMetricsContents.Master.class,
-                        SystemConfiguration.class,
-                        NetworkInterfaces.class,
-                        NodeMonitors.class,
-                        UpdateCenter.class,
-                        SystemProperties.class,
-                        ThreadDumps.class),
-                checker);
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        try (var ignored = ACL.as(User.getById("admin", true))) {
+            // Check the components are filtered correctly
+            assertComponent(
+                    Arrays.asList(
+                            AboutJenkins.class,
+                            AboutUser.class,
+                            AgentsConfigFile.class,
+                            BuildQueue.class,
+                            ConfigFileComponent.class,
+                            DumpExportTable.class,
+                            EnvironmentVariables.class,
+                            JVMProcessSystemMetricsContents.Agents.class,
+                            JVMProcessSystemMetricsContents.Master.class,
+                            SystemConfiguration.class,
+                            NetworkInterfaces.class,
+                            NodeMonitors.class,
+                            UpdateCenter.class,
+                            SystemProperties.class,
+                            ThreadDumps.class),
+                    checker);
+        }
         assertThat(checker.unchecked.stream().map(f -> f.filePattern).toList(), empty());
 
         // Cancel the job running
@@ -235,7 +239,7 @@ public class CheckFilterTest {
             // The agent node name should be filtered
             fileSet.add(of("nodes.md", AGENT_NAME, true));
             // AboutUser
-            fileSet.add(of("user.md", "SYSTEM", true));
+            fileSet.add(of("user.md", "admin", true));
 
             // fileSet.add(of("node-monitors.md", AGENT_NAME, true));
 

--- a/src/test/java/com/cloudbees/jenkins/support/CheckFilterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/CheckFilterTest.java
@@ -23,6 +23,7 @@ import com.cloudbees.jenkins.support.impl.ThreadDumps;
 import com.cloudbees.jenkins.support.impl.UpdateCenter;
 import hudson.EnvVars;
 import hudson.ExtensionList;
+import hudson.Functions;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.User;
@@ -113,7 +114,9 @@ public class CheckFilterTest {
                             ThreadDumps.class),
                     checker);
         }
-        assertThat(checker.unchecked.stream().map(f -> f.filePattern).toList(), empty());
+        if (!Functions.isWindows()) { // some entries for procfs skipped on Windows
+            assertThat(checker.unchecked.stream().map(f -> f.filePattern).toList(), empty());
+        }
 
         // Cancel the job running
         build.cancel(true);


### PR DESCRIPTION
Reviewing #617, I was alarmed to find that this plugin defaults to impersonating `SYSTEM` during interactive bundle generation, and (as of the old a6de1be6ea1e3b77ea7bbb6c6893745fbf1d11ce) relies on the author of a `Component` to actually check the requester’s authentication where applicable. This goes against the principle of least surprise and safety by default. In fact most components require `ADMINISTER` anyway (the option to do otherwise dates all the way back to 066bd8d33a88b7866b23c20f66ec56313f57924e), but not all. I could not find any actually problematic cases, but for example https://github.com/jenkinsci/support-core-plugin/blob/3435ec4057ae19e04dee06d2eba8c5f1128e603e/src/main/java/com/cloudbees/jenkins/support/impl/ItemsContent.java#L87 is uncomfortable because it is reporting _statistics_ about the system based on details not accessible to the user. I think we should only use `SYSTEM` during periodic bundle generation. Not sure if this has any practical impact, since 6b177ea7cc7347e13fa87174472400bbbe78d422 and then 84ae1b3a1d326cabcfd755c92c6a4f949a937ffe locked down bundle generation anyway (so why do we offer some components to `MANAGE`?!), even in #198 AFAICT.