### PR TITLE
Improve output on NodeRemoteDirectoryComponentTest failures

### DIFF
--- a/src/test/java/com/cloudbees/jenkins/support/impl/NodeRemoteDirectoryComponentTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/NodeRemoteDirectoryComponentTest.java
@@ -1,7 +1,9 @@
 package com.cloudbees.jenkins.support.impl;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.text.MatchesPattern.matchesPattern;
 
 import com.cloudbees.jenkins.support.SupportTestUtils;
 import hudson.model.Label;
@@ -30,7 +32,7 @@ public class NodeRemoteDirectoryComponentTest {
                 SupportTestUtils.invokeComponentToMap(new NodeRemoteDirectoryComponent(), agent.toComputer());
 
         String prefix = "nodes/slave/" + agent.getNodeName() + "/remote";
-        assertTrue(output.keySet().stream().anyMatch(key -> key.matches(prefix + "/support/.*.log")));
+        assertThat(output.keySet(), hasItem(matchesPattern(prefix + "/support/.*.log")));
     }
 
     /*
@@ -46,7 +48,7 @@ public class NodeRemoteDirectoryComponentTest {
                 new NodeRemoteDirectoryComponent("", "**/*.log", true, 10), agent.toComputer());
 
         String prefix = "nodes/slave/" + agent.getNodeName() + "/remote";
-        assertFalse(output.keySet().stream().anyMatch(key -> key.matches(prefix + ".*/.*.log")));
+        assertThat(output.keySet(), not(hasItem(matchesPattern(prefix + ".*/.*.log"))));
     }
 
     /*
@@ -62,7 +64,7 @@ public class NodeRemoteDirectoryComponentTest {
                 new NodeRemoteDirectoryComponent("support/*.log", "", true, 10), agent.toComputer());
 
         String prefix = "nodes/slave/" + agent.getNodeName() + "/remote";
-        assertTrue(output.keySet().stream().anyMatch(key -> key.matches(prefix + "/support/.*.log")));
+        assertThat(output.keySet(), hasItem(matchesPattern(prefix + "/support/.*.log")));
     }
 
     /*
@@ -78,6 +80,6 @@ public class NodeRemoteDirectoryComponentTest {
                 new NodeRemoteDirectoryComponent("", "", true, 1), agent.toComputer());
 
         String prefix = "nodes/slave/" + agent.getNodeName() + "/remote";
-        assertFalse(output.keySet().stream().anyMatch(key -> key.matches(prefix + "/support/.*.log")));
+        assertThat(output.keySet(), not(hasItem(matchesPattern(prefix + "/support/.*.log"))));
     }
 }


### PR DESCRIPTION
## Improve output on NodeRemoteDirectoryComponentTest failures

The NodeRemoteDirectoryComponentTest failed 3 of 10 runs on my Red Hat Enterprise Linux 8 computer with Java 21 and the command:

```
  mvn -DforkCount=1C test
```

I see a similar failure rate on my CI server.

I don't understand the cause of the failures. This pull request improves the failure message with more context when the failure occurs.

Now the failure messages report the contents of the collection that is failing the assertion:

```
[ERROR] Failures:
[ERROR]   NodeRemoteDirectoryComponentTest.addContents:37
Expected: a collection containing a string matching the pattern 'nodes/slave/slave0/remote/support/.*.log'
     but: was empty
```

```
[ERROR]   NodeRemoteDirectoryComponentTest.addContentsWithIncludes:71
Expected: a collection containing a string matching the pattern 'nodes/slave/agent1/remote/support/.*.log'
     but: was empty
```

The first run of the job shows the new assertion message.

### Testing done

Confirmed on Linux Java 21 that the expected message is output when the test fails.

Rely on ci.jenkins.io to test Windows and Java 17.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
