### PR TITLE
Added plugin name terms and more common terms to stop words

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/filter/DefaultStopWords.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/DefaultStopWords.java
@@ -17,8 +17,15 @@ public class DefaultStopWords implements StopWords {
         return Set.of(
                 "agent",
                 "jenkins",
+                "build",
+                "scm",
+                "builder",
+                "publisher",
+                "test",
+                "plugin",
                 "node",
                 "master",
+                "controller",
                 "computer",
                 "item",
                 "label",
@@ -40,6 +47,8 @@ public class DefaultStopWords implements StopWords {
                 "vault",
                 "exists",
                 "log",
-                "info");
+                "info",
+                "java",
+                "url");
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/filter/PluginsStopWords.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/PluginsStopWords.java
@@ -1,0 +1,25 @@
+package com.cloudbees.jenkins.support.filter;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import jenkins.model.Jenkins;
+
+@Extension
+public class PluginsStopWords implements StopWords {
+    @NonNull
+    @Override
+    public Set<String> getWords() {
+        final Set<String> pluginsWords = new HashSet<>();
+        Jenkins.get().pluginManager.getPlugins().forEach(pluginWrapper -> {
+            pluginsWords.addAll(List.of(
+                    pluginWrapper.getShortName().toLowerCase(Locale.ENGLISH).split("-")));
+            pluginsWords.addAll(List.of(
+                    pluginWrapper.getDisplayName().toLowerCase(Locale.ENGLISH).split(" ")));
+        });
+        return pluginsWords;
+    }
+}


### PR DESCRIPTION
Adding more stop words after looking at a recent anonymized bundle, and also terms from installed plugin names.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
