### PR TITLE
[JENKINS-64261] BaseFileContent.InputStreamSupplier

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/api/FileContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/FileContent.java
@@ -27,15 +27,11 @@ package com.cloudbees.jenkins.support.api;
 import com.cloudbees.jenkins.support.filter.ContentFilter;
 import com.cloudbees.jenkins.support.filter.PrefilteredContent;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.Functions;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.function.Supplier;
 
 /**
  * Content that is stored as a file on disk. The content is filtered with the {@link ContentFilter} defined in the
@@ -97,13 +93,6 @@ public class FileContent extends PrefilteredContent {
     }
 
     private BaseFileContent createBaseFileContent(File file, long maxSize) {
-        Supplier<InputStream> supplier = () -> {
-            try {
-                return getInputStream();
-            } catch (IOException e) {
-                return new ByteArrayInputStream(Functions.printThrowable(e).getBytes(StandardCharsets.UTF_8));
-            }
-        };
-        return new BaseFileContent(file, supplier, maxSize, this::getSimpleValueOrRedactedPassword);
+        return new BaseFileContent(file, this::getInputStream, maxSize, this::getSimpleValueOrRedactedPassword);
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/api/UnfilteredFileContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/UnfilteredFileContent.java
@@ -29,8 +29,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.function.Supplier;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -86,15 +84,7 @@ public class UnfilteredFileContent extends Content {
     }
 
     private BaseFileContent createBaseFileContent(File file, long maxSize) {
-        Supplier<InputStream> supplier = () -> {
-            try {
-                return getInputStream();
-            } catch (IOException e) {
-                LOGGER.log(Level.WARNING, "Error opening file " + file, e);
-                return null;
-            }
-        };
-        return new BaseFileContent(file, supplier, maxSize, s -> s);
+        return new BaseFileContent(file, this::getInputStream, maxSize, s -> s);
     }
 
     @Override


### PR DESCRIPTION
Noticed in a support bundle several exceptions of the form

```
WARNING	c.c.j.s.a.UnfilteredFileContent#lambda$createBaseFileContent$0: Error opening file /var/jenkins_home/slow-requests/20250424-134904.013.txt
java.io.FileNotFoundException: /var/jenkins_home/slow-requests/20250424-134904.013.txt (No such file or directory)
	at java.base/java.io.FileInputStream.open0(Native Method)
	at java.base/java.io.FileInputStream.open(FileInputStream.java:213)
	at java.base/java.io.FileInputStream.<init>(FileInputStream.java:152)
	at PluginClassLoader for support-core//com.cloudbees.jenkins.support.api.UnfilteredFileContent.getInputStream(UnfilteredFileContent.java:85)
	at PluginClassLoader for support-core//com.cloudbees.jenkins.support.api.UnfilteredFileContent.lambda$createBaseFileContent$0(UnfilteredFileContent.java:91)
	at PluginClassLoader for support-core//com.cloudbees.jenkins.support.api.BaseFileContent.writeTo(BaseFileContent.java:102)
	at PluginClassLoader for support-core//com.cloudbees.jenkins.support.api.UnfilteredFileContent.writeTo(UnfilteredFileContent.java:71)
	at PluginClassLoader for support-core//com.cloudbees.jenkins.support.SupportPlugin.writeBundle(SupportPlugin.java:491)
	at PluginClassLoader for support-core//com.cloudbees.jenkins.support.SupportPlugin.writeBundle(SupportPlugin.java:355)
	at PluginClassLoader for support-core//com.cloudbees.jenkins.support.SupportPlugin$PeriodicWorkImpl.lambda$doRun$0(SupportPlugin.java:1077)
	at java.base/java.lang.Thread.run(Thread.java:1583)
WARNING	c.c.j.support.SupportPlugin#writeBundle: Could not attach ''slow-requests/20250424-134904.013.txt'' to support bundle
java.lang.NullPointerException: Cannot invoke "java.io.InputStream.read(byte[], int, int)" because "this.in" is null
	at java.base/java.io.FilterInputStream.read(FilterInputStream.java:119)
	at PluginClassLoader for support-core//com.cloudbees.jenkins.support.api.BaseFileContent$TruncatedInputStream.read(BaseFileContent.java:227)
	at java.base/java.io.FilterInputStream.read(FilterInputStream.java:95)
	at org.apache.commons.io.IOUtils.copyLarge(IOUtils.java:1486)
	at org.apache.commons.io.IOUtils.copy(IOUtils.java:1111)
	at org.apache.commons.io.IOUtils.copyLarge(IOUtils.java:1459)
	at org.apache.commons.io.IOUtils.copy(IOUtils.java:1089)
	at PluginClassLoader for support-core//com.cloudbees.jenkins.support.api.BaseFileContent.writeTo(BaseFileContent.java:106)
	at PluginClassLoader for support-core//com.cloudbees.jenkins.support.api.UnfilteredFileContent.writeTo(UnfilteredFileContent.java:71)
	at PluginClassLoader for support-core//com.cloudbees.jenkins.support.SupportPlugin.writeBundle(SupportPlugin.java:491)
	at PluginClassLoader for support-core//com.cloudbees.jenkins.support.SupportPlugin.writeBundle(SupportPlugin.java:355)
	at PluginClassLoader for support-core//com.cloudbees.jenkins.support.SupportPlugin$PeriodicWorkImpl.lambda$doRun$0(SupportPlugin.java:1077)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

This seems to be due to a `Supplier<InputStream>` returning `null`, which was not expected by the caller. #190 fixed this for `FileContent` but not `UnfilteredFileContent`.
