### PR TITLE
[bug] Ensure a sync component archive exists before using it

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -519,12 +519,16 @@ public class SupportPlugin extends Plugin {
                 if (outputPath != null) {
                     try {
                         File zipFile = outputPath.resolve(SYNC_SUPPORT_BUNDLE).toFile();
-                        try (ZipInputStream zis = new ZipInputStream(new FileInputStream(zipFile))) {
-                            ZipEntry entry;
-                            while ((entry = zis.getNextEntry()) != null) {
-                                binaryOut.putNextEntry(entry);
-                                zis.transferTo(binaryOut);
+                        if (zipFile.exists()) {
+                            try (ZipInputStream zis = new ZipInputStream(new FileInputStream(zipFile))) {
+                                ZipEntry entry;
+                                while ((entry = zis.getNextEntry()) != null) {
+                                    binaryOut.putNextEntry(entry);
+                                    zis.transferTo(binaryOut);
+                                }
                             }
+                        } else {
+                            LOGGER.log(Level.FINE, "No sync component to process");
                         }
                     } catch (Exception e) {
                         LOGGER.log(Level.WARNING, "Error while processing sync components in async mode", e);


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
In case no async component is selected while generating a new bundle, the following stack appears in the logs:

```
2025-04-25 13:50:46.324+0000 [id=91]	WARNING	c.c.j.support.SupportPlugin#writeBundle: Error while processing sync components in async mode
java.io.FileNotFoundException: /var/folders/jl/z9cm5_452pv9hbm1k6pr0fyc0000gn/T/support-bundle/6faf6b7f-08f4-4414-b8c0-7fc19d49922e/support-bundle.zip (No such file or directory)
	at java.base/java.io.FileInputStream.open0(Native Method)
	at java.base/java.io.FileInputStream.open(FileInputStream.java:213)
	at java.base/java.io.FileInputStream.<init>(FileInputStream.java:152)
	at PluginClassLoader for support-core//com.cloudbees.jenkins.support.SupportPlugin.writeBundle(SupportPlugin.java:522)
	at PluginClassLoader for support-core//com.cloudbees.jenkins.support.SupportPlugin.writeBundle(SupportPlugin.java:406)
	at PluginClassLoader for support-core//com.cloudbees.jenkins.support.SupportAction$SupportBundleAsyncGenerator.compute(SupportAction.java:542)
	at jenkins.util.ProgressiveRendering$1.run(ProgressiveRendering.java:121)
	at jenkins.security.ImpersonatingScheduledExecutorService$1.run(ImpersonatingScheduledExecutorService.java:67)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

NOTE: it's merely cosmetic the bundle is properly generated, but it's still not a good look

### Testing done

Ensured the stack doesn't appear in the log when generating with a single async component (eg Proxy).

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
