### PR TITLE
remove usages of commons-lang from core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,10 @@
     </dependency>
     <!-- plugin dependencies -->
     <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>commons-lang3-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>metrics</artifactId>
     </dependency>

--- a/src/main/java/com/cloudbees/jenkins/support/BundleFileName.java
+++ b/src/main/java/com/cloudbees/jenkins/support/BundleFileName.java
@@ -6,7 +6,7 @@ import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Objects;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * <p>Generate the support bundle names.</p>

--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -115,7 +115,7 @@ import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.output.CountingOutputStream;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.StaplerRequest2;

--- a/src/main/java/com/cloudbees/jenkins/support/configfiles/SecretHandler.java
+++ b/src/main/java/com/cloudbees/jenkins/support/configfiles/SecretHandler.java
@@ -22,7 +22,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stream.StreamResult;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;

--- a/src/main/java/com/cloudbees/jenkins/support/filter/ContentFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/ContentFilter.java
@@ -31,7 +31,7 @@ import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 import hudson.model.Saveable;
 import java.io.IOException;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Provides a strategy to filter support bundle written contents. This is primarily useful to anonymize data written

--- a/src/main/java/com/cloudbees/jenkins/support/filter/PasswordRedactorRegexBuilder.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/PasswordRedactorRegexBuilder.java
@@ -15,7 +15,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class PasswordRedactorRegexBuilder {
 

--- a/src/main/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilter.java
@@ -37,7 +37,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.stream.StreamSupport;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AdministrativeMonitors.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AdministrativeMonitors.java
@@ -42,7 +42,7 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Warns if any administrative monitors are currently active.

--- a/src/main/java/com/cloudbees/jenkins/support/impl/DirectoryComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/DirectoryComponent.java
@@ -19,7 +19,7 @@ import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.FileSet;

--- a/src/main/java/com/cloudbees/jenkins/support/impl/LoadStats.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/LoadStats.java
@@ -56,7 +56,7 @@ import java.util.TimeZone;
 import java.util.TreeMap;
 import javax.imageio.ImageIO;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * This component captures the Jenkins {@link LoadStatistics} for overall load, jobs not tied to a label and each

--- a/src/main/java/com/cloudbees/jenkins/support/impl/NodeExecutors.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/NodeExecutors.java
@@ -38,6 +38,7 @@ import hudson.model.Queue;
 import hudson.model.queue.WorkUnit;
 import hudson.security.Permission;
 import java.io.PrintWriter;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
@@ -127,7 +128,7 @@ public class NodeExecutors extends ObjectComponent<Computer> {
                 out.println("          - idle: " + executor.isIdle());
                 long idleStartMilliseconds = executor.getIdleStartMilliseconds();
                 out.println("          - idleStartMilliseconds: " + idleStartMilliseconds + " ("
-                        + Util.XS_DATETIME_FORMATTER.format(idleStartMilliseconds) + ")");
+                        + Util.XS_DATETIME_FORMATTER2.format(Instant.ofEpochMilli(idleStartMilliseconds)) + ")");
                 out.println("          - progress: " + executor.getProgress());
                 out.println("          - state: " + executor.getState());
                 WorkUnit workUnit = executor.getCurrentWorkUnit();

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLogs.java
@@ -56,7 +56,7 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Adds the agent logs from all of the machines

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SmartLogFetcher.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SmartLogFetcher.java
@@ -22,7 +22,7 @@ import java.util.logging.Logger;
 import jenkins.MasterToSlaveFileCallable;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Efficient incremental retrieval of log files from {@link Node}, by taking advantages of

--- a/src/main/resources/com/cloudbees/jenkins/support/impl/DirectoryComponent/help-defaultExcludes.groovy
+++ b/src/main/resources/com/cloudbees/jenkins/support/impl/DirectoryComponent/help-defaultExcludes.groovy
@@ -22,7 +22,7 @@
  * THE SOFTWARE.
  */
 
-import org.apache.commons.lang.StringUtils
+import org.apache.commons.lang3.StringUtils
 
 div {
     p {


### PR DESCRIPTION
To be able to remove commons-lang from core all direct and indirect usages must be replaced with commons-lang3 or native Java

use XS_DATETIME_FORMATTER2 instead of deprecated XS_DATETIME_FORMATTER from core
use commons-lang3 api plugin instead of commons-lang provided by core

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
