### PR TITLE
[JENKINS-75968] allow the tuning of the number of Jenkins logs caputred

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -149,6 +149,14 @@ public class SupportPlugin extends Plugin {
     public static final int AUTO_BUNDLE_PERIOD_HOURS = Math.max(
             Math.min(24, Integer.getInteger(SupportPlugin.class.getName() + ".AUTO_BUNDLE_PERIOD_HOURS", 1)), 0);
 
+    /**
+     * How many log Jenkins log entries to capture for each file before rotating.
+     * On an active Jenkins instance logs can accumulate quickly, so the default value of {@code 2048} may not be enough to capture an hours worth of logs.
+     * Conversely on an inactive Jenkins setting this too high will cause the hourly captured bundles to contain lots of duplicate information, which wastes disk space.
+     */
+    public static final int MAX_JENKINS_LOG_ENTRIES_PER_FILE =
+            Integer.getInteger(SupportPlugin.class.getName() + ".MAX_JENKINS_LOG_ENTRIES_PER_FILE ", 2048);
+
     public static final PermissionGroup SUPPORT_PERMISSIONS =
             new PermissionGroup(SupportPlugin.class, Messages._SupportPlugin_PermissionGroup());
 
@@ -166,7 +174,7 @@ public class SupportPlugin extends Plugin {
     private static final AtomicLong nextBundleWrite = new AtomicLong(Long.MIN_VALUE);
     private static final Logger logger = Logger.getLogger(SupportPlugin.class.getName());
     public static final String SUPPORT_DIRECTORY_NAME = "support";
-    private final transient SupportLogHandler handler = new SupportLogHandler(256, 2048, 8);
+    private final transient SupportLogHandler handler = new SupportLogHandler(256, MAX_JENKINS_LOG_ENTRIES_PER_FILE, 8);
 
     private transient SupportContextImpl context = null;
     private transient Logger rootLogger;


### PR DESCRIPTION
[JENKINS-75968](https://issues.jenkins.io/browse/JENKINS-75968)
The system property `com.cloudbees.jenkins.support.SupportPlugin.MAX_JENKINS_LOG_ENTRIES_PER_FILE` can now be set to tune the amount of log records to have before log rollover.

<!-- Please describe your pull request here. -->

### Testing done

deployed to an instance start as `java  -Dcom.cloudbees.jenkins.support.SupportPlugin.MAX_LOG_ENTRIES_PER_FILE=10 -jar jenkins.war --httpListenAddress=127.0.0.2` 
validated that the files are really small (they contain 11 log entries as there is an off by one in the existing code that I am not intending to fix).

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
