### PR TITLE
Show `AdministrativeMonitor.displayName`

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/AdministrativeMonitors.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AdministrativeMonitors.java
@@ -28,6 +28,7 @@ import com.cloudbees.jenkins.support.api.Component;
 import com.cloudbees.jenkins.support.api.Container;
 import com.cloudbees.jenkins.support.api.PrefilteredPrintedContent;
 import com.cloudbees.jenkins.support.filter.ContentFilter;
+import com.cloudbees.jenkins.support.util.Markdown;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.diagnosis.OldDataMonitor;
@@ -76,10 +77,10 @@ public final class AdministrativeMonitors extends Component {
                         .sorted(Comparator.comparing(o -> o.id))
                         .forEach(monitor -> {
                             out.println();
-                            out.println("`" + monitor.id + "`");
+                            out.println("`" + monitor.id + "` _" + Markdown.escapeUnderscore(monitor.getDisplayName())
+                                    + "_");
                             out.println("--------------");
-                            if (monitor instanceof OldDataMonitor) {
-                                OldDataMonitor odm = (OldDataMonitor) monitor;
+                            if (monitor instanceof OldDataMonitor odm) {
                                 for (Map.Entry<Saveable, OldDataMonitor.VersionRange> entry :
                                         odm.getData().entrySet()) {
                                     out.println("  * Problematic object: `"

--- a/src/test/java/com/cloudbees/jenkins/support/impl/AdministrativeMonitorsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/impl/AdministrativeMonitorsTest.java
@@ -35,8 +35,9 @@ public class AdministrativeMonitorsTest {
                 .filter(monitor -> monitor.isEnabled() && monitor.isActivated())
                 .forEach(monitor -> assertThat(
                         monitorsMdToString,
-                        containsString("`" + monitor.id + "`" + System.lineSeparator() + "--------------"
-                                + System.lineSeparator() + "(active and enabled)")));
+                        containsString(
+                                "`" + monitor.id + "` _" + monitor.getDisplayName() + "_" + System.lineSeparator()
+                                        + "--------------" + System.lineSeparator() + "(active and enabled)")));
 
         // Disable all monitors and check there is not output for any even if activated
         for (AdministrativeMonitor monitor : j.jenkins.administrativeMonitors) {
@@ -49,8 +50,9 @@ public class AdministrativeMonitorsTest {
                 .filter(AdministrativeMonitor::isActivated)
                 .forEach(monitor -> assertThat(
                         monitorsDisabledMdToString,
-                        not(containsString("`" + monitor.id + "`" + System.lineSeparator() + "--------------"
-                                + System.lineSeparator() + "(active and enabled)"))));
+                        not(containsString(
+                                "`" + monitor.id + "`_" + monitor.getDisplayName() + "_" + System.lineSeparator()
+                                        + "--------------" + System.lineSeparator() + "(active and enabled)"))));
     }
 
     @Test


### PR DESCRIPTION
Example:

----

Monitors
========

`hudson.diagnosis.TooManyJobsButNoView` _Too Many Jobs Not Organized in Views_
--------------
(active and enabled)

`hudson.model.UpdateCenter$CoreUpdateMonitor` _Jenkins Update Notification_
--------------
(active and enabled)

`jenkins.diagnostics.URICheckEncodingMonitor` _Check URI Encoding_
--------------
(active and enabled)

`jenkins.security.UpdateSiteWarningsMonitor` _Update Site Warnings_
--------------
(active and enabled)
