### PR TITLE
Modernizing the UI and adding a HASH

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
@@ -154,6 +154,9 @@ public class SupportAction implements RootAction, StaplerProxy {
 
     public String getGenericOptionCustom() { return Messages.SupportPlugin_GenericOption_Custom(); }
 
+    public String getApplyCustomChanges() { return Messages.SupportPlugin_ApplyCustomChanges(); }
+
+    public String getChooseGeneralOptionApplying() { return Messages.SupportPlugin_ChooseGeneralOptionApplying(); }
 
     public Localizable getActionTitle() {
         SupportPlugin supportPlugin = SupportPlugin.getInstance();

--- a/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
@@ -35,6 +35,7 @@ import hudson.model.Api;
 import hudson.model.Failure;
 import hudson.model.RootAction;
 import hudson.security.Permission;
+import hudson.util.ListBoxModel;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletResponse;
@@ -131,9 +132,28 @@ public class SupportAction implements RootAction, StaplerProxy {
         return "support";
     }
 
+    public String getChooseOptions() { return Messages.SupportPlugin_ChooseOptions(); }
+
+    public String getGenerateSupportBundle() { return Messages.SupportPlugin_GenerateSupportBundle(); }
+
+    public String getClose() { return Messages.SupportPlugin_Close(); }
+
+    public String getChooseGeneralOption() { return Messages.SupportPlugin_ChooseGeneralOption(); }
+
+    public String getChooseGeneralOptionApplied() { return Messages.SupportPlugin_ChooseGeneralOptionApplied(); }
+
     public String getActionTitleText() {
         return getActionTitle().toString();
     }
+
+    public String getGenericOptionConfigurationFiles() { return Messages.SupportPlugin_GenericOption_ConfigurationFiles(); }
+
+    public String getGenericOptionPerformanceData() { return Messages.SupportPlugin_GenericOption_PerformanceData(); }
+
+    public String getGenericOptionDefault() { return Messages.SupportPlugin_GenericOption_Default(); }
+
+    public String getGenericOptionCustom() { return Messages.SupportPlugin_GenericOption_Custom(); }
+
 
     public Localizable getActionTitle() {
         SupportPlugin supportPlugin = SupportPlugin.getInstance();

--- a/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportAction.java
@@ -35,7 +35,6 @@ import hudson.model.Api;
 import hudson.model.Failure;
 import hudson.model.RootAction;
 import hudson.security.Permission;
-import hudson.util.ListBoxModel;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletResponse;
@@ -132,31 +131,19 @@ public class SupportAction implements RootAction, StaplerProxy {
         return "support";
     }
 
-    public String getChooseOptions() { return Messages.SupportPlugin_ChooseOptions(); }
-
-    public String getGenerateSupportBundle() { return Messages.SupportPlugin_GenerateSupportBundle(); }
-
-    public String getClose() { return Messages.SupportPlugin_Close(); }
-
-    public String getChooseGeneralOption() { return Messages.SupportPlugin_ChooseGeneralOption(); }
-
-    public String getChooseGeneralOptionApplied() { return Messages.SupportPlugin_ChooseGeneralOptionApplied(); }
-
-    public String getActionTitleText() {
-        return getActionTitle().toString();
-    }
-
-    public String getGenericOptionConfigurationFiles() { return Messages.SupportPlugin_GenericOption_ConfigurationFiles(); }
-
-    public String getGenericOptionPerformanceData() { return Messages.SupportPlugin_GenericOption_PerformanceData(); }
-
-    public String getGenericOptionDefault() { return Messages.SupportPlugin_GenericOption_Default(); }
-
-    public String getGenericOptionCustom() { return Messages.SupportPlugin_GenericOption_Custom(); }
+    public String getActionTitleText() { return getActionTitle().toString(); }
 
     public String getApplyCustomChanges() { return Messages.SupportPlugin_ApplyCustomChanges(); }
-
+    public String getChooseGeneralOption() { return Messages.SupportPlugin_ChooseGeneralOption(); }
+    public String getChooseGeneralOptionApplied() { return Messages.SupportPlugin_ChooseGeneralOptionApplied(); }
     public String getChooseGeneralOptionApplying() { return Messages.SupportPlugin_ChooseGeneralOptionApplying(); }
+    public String getChooseOptions() { return Messages.SupportPlugin_ChooseOptions(); }
+    public String getClose() { return Messages.SupportPlugin_Close(); }
+    public String getGenerateSupportBundle() { return Messages.SupportPlugin_GenerateSupportBundle(); }
+    public String getGenericOptionConfigurationFiles() { return Messages.SupportPlugin_GenericOption_ConfigurationFiles(); }
+    public String getGenericOptionCustom() { return Messages.SupportPlugin_GenericOption_Custom(); }
+    public String getGenericOptionDefault() { return Messages.SupportPlugin_GenericOption_Default(); }
+    public String getGenericOptionPerformanceData() { return Messages.SupportPlugin_GenericOption_PerformanceData(); }
 
     public Localizable getActionTitle() {
         SupportPlugin supportPlugin = SupportPlugin.getInstance();

--- a/src/main/java/com/cloudbees/jenkins/support/api/Component.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/Component.java
@@ -148,6 +148,8 @@ public abstract class Component implements ExtensionPoint {
         return getClass().getSimpleName();
     }
 
+    public int getHash() { return -1; };
+
     @Deprecated
     public void start(@NonNull SupportContext context) {}
 

--- a/src/main/java/com/cloudbees/jenkins/support/api/Component.java
+++ b/src/main/java/com/cloudbees/jenkins/support/api/Component.java
@@ -148,6 +148,14 @@ public abstract class Component implements ExtensionPoint {
         return getClass().getSimpleName();
     }
 
+    /**
+     * Used for getting a hash code with the options selected by the user.
+     * Each component (class that extends the Component class) should have a unique value.
+     * Only child components were treated in this plugin. Other plugins that extends the Component class
+     * should implement (override) the getHash method with a unique value.
+     * The UI will ignore any component with a "-1" value in the id (extracted from this getHash method)
+     * in order to generate the final hash value for the selected options.
+     */
     public int getHash() { return -1; };
 
     @Deprecated

--- a/src/main/java/com/cloudbees/jenkins/support/configfiles/AgentsConfigFile.java
+++ b/src/main/java/com/cloudbees/jenkins/support/configfiles/AgentsConfigFile.java
@@ -82,6 +82,9 @@ public class AgentsConfigFile extends ObjectComponent<Computer> {
     }
 
     @Override
+    public int getHash() { return 5; }
+
+    @Override
     public void addContents(@NonNull Container container) {
         for (var n : Jenkins.get().getNodes()) {
             var c = n.toComputer();

--- a/src/main/java/com/cloudbees/jenkins/support/configfiles/ConfigFileComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/configfiles/ConfigFileComponent.java
@@ -30,6 +30,9 @@ public class ConfigFileComponent extends Component {
     }
 
     @Override
+    public int getHash() { return 7; }
+
+    @Override
     public void addContents(@NonNull Container container) {
         Jenkins jenkins = Jenkins.get();
         File configFile = new File(jenkins.getRootDir(), "config.xml");

--- a/src/main/java/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/configfiles/OtherConfigFilesComponent.java
@@ -59,6 +59,9 @@ public class OtherConfigFilesComponent extends Component {
     }
 
     @Override
+    public int getHash() { return 27; }
+
+    @Override
     public void addContents(@NonNull Container container) {
         Jenkins jenkins = Jenkins.getInstanceOrNull();
         if (jenkins != null) {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutBrowser.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutBrowser.java
@@ -33,6 +33,9 @@ public class AboutBrowser extends Component {
     }
 
     @Override
+    public int getHash() { return 0; }
+
+    @Override
     public Set<Permission> getRequiredPermissions() {
         return Collections.emptySet();
     }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutJenkins.java
@@ -104,6 +104,9 @@ public class AboutJenkins extends Component {
         return "About Jenkins";
     }
 
+    @Override
+    public int getHash() { return 1; }
+
     @NonNull
     @Override
     public ComponentCategory getCategory() {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AboutUser.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AboutUser.java
@@ -31,6 +31,9 @@ public class AboutUser extends Component {
     }
 
     @Override
+    public int getHash() { return 2; }
+
+    @Override
     public Set<Permission> getRequiredPermissions() {
         return Collections.emptySet();
     }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AbstractItemDirectoryComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AbstractItemDirectoryComponent.java
@@ -32,6 +32,9 @@ import org.kohsuke.stapler.QueryParameter;
 @Extension
 public class AbstractItemDirectoryComponent extends DirectoryComponent<AbstractItem> {
 
+    @Override
+    public int getHash() { return 3; }
+
     public AbstractItemDirectoryComponent() {
         super();
     }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/AdministrativeMonitors.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/AdministrativeMonitors.java
@@ -55,6 +55,9 @@ public final class AdministrativeMonitors extends Component {
         return "Administrative monitors";
     }
 
+    @Override
+    public int getHash() { return 4; }
+
     @NonNull
     @Override
     public Set<Permission> getRequiredPermissions() {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/BuildQueue.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/BuildQueue.java
@@ -64,6 +64,9 @@ public class BuildQueue extends Component {
     }
 
     @Override
+    public int getHash() { return 6; }
+
+    @Override
     public void addContents(@NonNull Container container) {
         container.add(new PrefilteredPrintedContent("buildqueue.md") {
             @Override

--- a/src/main/java/com/cloudbees/jenkins/support/impl/CustomLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/CustomLogs.java
@@ -60,6 +60,9 @@ public class CustomLogs extends Component {
     }
 
     @Override
+    public int getHash() { return 8; }
+
+    @Override
     public void addContents(@NonNull Container result) {
         addLogRecorders(result);
     }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/DumpExportTable.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/DumpExportTable.java
@@ -57,6 +57,9 @@ public class DumpExportTable extends ObjectComponent<Computer> {
     }
 
     @Override
+    public int getHash() { return 10; }
+
+    @Override
     public void addContents(@NonNull Container result) {
         Jenkins.get().getNodes().stream().map(Node::toComputer).forEach(computer -> Optional.ofNullable(computer)
                 .ifPresent(comp -> addContents(result, comp)));

--- a/src/main/java/com/cloudbees/jenkins/support/impl/EnvironmentVariables.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/EnvironmentVariables.java
@@ -51,6 +51,9 @@ public class EnvironmentVariables extends Component {
     }
 
     @Override
+    public int getHash() { return 11; }
+
+    @Override
     public void addContents(@NonNull Container result) {
         result.add(new PrintedContent("nodes/master/environment.txt") {
             @Override

--- a/src/main/java/com/cloudbees/jenkins/support/impl/FileDescriptorLimit.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/FileDescriptorLimit.java
@@ -53,6 +53,9 @@ public class FileDescriptorLimit extends Component {
     }
 
     @Override
+    public int getHash() { return 12; }
+
+    @Override
     public void addContents(@NonNull Container container) {
         Jenkins j = Jenkins.get();
         addContents(container, j);

--- a/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/GCLogs.java
@@ -74,6 +74,9 @@ public class GCLogs extends Component {
     }
 
     @Override
+    public int getHash() { return 13; }
+
+    @Override
     public void addContents(@NonNull Container result) {
         LOGGER.fine("Trying to gather GC logs for support bundle");
         String gcLogFileLocation = getGcLogFileLocation();

--- a/src/main/java/com/cloudbees/jenkins/support/impl/HeapUsageHistogram.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/HeapUsageHistogram.java
@@ -52,6 +52,9 @@ public class HeapUsageHistogram extends Component {
     }
 
     @Override
+    public int getHash() { return 14; }
+
+    @Override
     public boolean isSelectedByDefault() {
         return false;
     }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/ItemsContent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/ItemsContent.java
@@ -65,6 +65,9 @@ public class ItemsContent extends Component {
         return "Items Content (Computationally expensive)";
     }
 
+    @Override
+    public int getHash() { return 16; }
+
     private final DateFormat BUILD_FORMAT = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
 
     @Override

--- a/src/main/java/com/cloudbees/jenkins/support/impl/JVMProcessSystemMetricsContents.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/JVMProcessSystemMetricsContents.java
@@ -35,6 +35,9 @@ public abstract class JVMProcessSystemMetricsContents extends AdvancedProcFilesR
         }
 
         @Override
+        public int getHash() { return 18; }
+
+        @Override
         protected List<Node> getNodes() {
             return Collections.singletonList(Jenkins.get());
         }
@@ -88,6 +91,9 @@ public abstract class JVMProcessSystemMetricsContents extends AdvancedProcFilesR
         public String getDisplayName() {
             return "Agent JVM process system metrics (Linux only)";
         }
+
+        @Override
+        public int getHash() { return 19; }
 
         @NonNull
         @Override

--- a/src/main/java/com/cloudbees/jenkins/support/impl/JenkinsLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/JenkinsLogs.java
@@ -41,6 +41,9 @@ public class JenkinsLogs extends Component {
     }
 
     @Override
+    public int getHash() { return 17; }
+
+    @Override
     public void addContents(@NonNull Container result) {
         addControllerJulRingBuffer(result);
         addControllerJulLogRecords(result);

--- a/src/main/java/com/cloudbees/jenkins/support/impl/LoadStats.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/LoadStats.java
@@ -83,6 +83,9 @@ public class LoadStats extends Component {
         return "Load Statistics";
     }
 
+    @Override
+    public int getHash() { return 20; }
+
     /**
      * {@inheritDoc}
      */

--- a/src/main/java/com/cloudbees/jenkins/support/impl/LoggerManager.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/LoggerManager.java
@@ -38,6 +38,9 @@ public class LoggerManager extends Component {
     }
 
     @Override
+    public int getHash() { return 21; }
+
+    @Override
     public void addContents(@NonNull Container container) {
         container.add(new PrintedContent("loggers.md") {
             @Override

--- a/src/main/java/com/cloudbees/jenkins/support/impl/Metrics.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/Metrics.java
@@ -30,6 +30,9 @@ public class Metrics extends Component {
     }
 
     @Override
+    public int getHash() { return 22; }
+
+    @Override
     public Set<Permission> getRequiredPermissions() {
         // TODO was originally no permissions, but that seems iffy
         return Collections.singleton(Jenkins.ADMINISTER);

--- a/src/main/java/com/cloudbees/jenkins/support/impl/NetworkInterfaces.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/NetworkInterfaces.java
@@ -68,6 +68,9 @@ public class NetworkInterfaces extends Component {
     }
 
     @Override
+    public int getHash() { return 23; }
+
+    @Override
     public void addContents(@NonNull Container result) {
         result.add(new Content("nodes/master/networkInterface.md") {
             @Override

--- a/src/main/java/com/cloudbees/jenkins/support/impl/NodeExecutors.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/NodeExecutors.java
@@ -72,6 +72,9 @@ public class NodeExecutors extends ObjectComponent<Computer> {
     }
 
     @Override
+    public int getHash() { return 24; }
+
+    @Override
     public void addContents(@NonNull Container container) {
         container.add(new PrefilteredPrintedContent("executors.md") {
             @Override

--- a/src/main/java/com/cloudbees/jenkins/support/impl/NodeMonitors.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/NodeMonitors.java
@@ -33,6 +33,9 @@ public class NodeMonitors extends Component {
     }
 
     @Override
+    public int getHash() { return 25; }
+
+    @Override
     public void addContents(@NonNull Container container) {
         container.add(new PrefilteredPrintedContent("node-monitors.md") {
             @Override

--- a/src/main/java/com/cloudbees/jenkins/support/impl/NodeRemoteDirectoryComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/NodeRemoteDirectoryComponent.java
@@ -29,6 +29,9 @@ import org.kohsuke.stapler.QueryParameter;
 @Extension
 public class NodeRemoteDirectoryComponent extends DirectoryComponent<Computer> implements Serializable {
 
+    @Override
+    public int getHash() { return 26; }
+
     public NodeRemoteDirectoryComponent() {
         super();
     }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/OtherLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/OtherLogs.java
@@ -39,6 +39,9 @@ public class OtherLogs extends Component {
     }
 
     @Override
+    public int getHash() { return 28; }
+
+    @Override
     public boolean isSelectedByDefault() {
         return false;
     }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/ProxyConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/ProxyConfiguration.java
@@ -32,6 +32,9 @@ public class ProxyConfiguration extends Component {
     }
 
     @Override
+    public int getHash() { return 29; }
+
+    @Override
     public void addContents(@NonNull Container container) {
         container.add(new PrefilteredPrintedContent("proxy.md") {
 

--- a/src/main/java/com/cloudbees/jenkins/support/impl/RemotingDiagnostics.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/RemotingDiagnostics.java
@@ -34,6 +34,9 @@ public class RemotingDiagnostics extends Component {
     }
 
     @Override
+    public int getHash() { return 30; }
+
+    @Override
     public void addContents(@NonNull Container container) {
         container.add(new PrintedContent("channel-diagnostics.md") {
             @Override

--- a/src/main/java/com/cloudbees/jenkins/support/impl/ReverseProxy.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/ReverseProxy.java
@@ -60,6 +60,9 @@ public class ReverseProxy extends Component {
     }
 
     @Override
+    public int getHash() { return 31; }
+
+    @Override
     public void addContents(@NonNull Container container) {
         container.add(new PrintedContent("reverse-proxy.md") {
             @Override

--- a/src/main/java/com/cloudbees/jenkins/support/impl/RootCAs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/RootCAs.java
@@ -77,6 +77,9 @@ public class RootCAs extends Component {
     }
 
     @Override
+    public int getHash() { return 32; }
+
+    @Override
     public void addContents(@NonNull Container container) {
         Jenkins j = Jenkins.get();
         addContents(container, j);

--- a/src/main/java/com/cloudbees/jenkins/support/impl/RunDirectoryComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/RunDirectoryComponent.java
@@ -104,6 +104,9 @@ public class RunDirectoryComponent extends DirectoryComponent<Run> {
     }
 
     @Override
+    public int getHash() { return 33; }
+
+    @Override
     public DescriptorImpl getDescriptor() {
         return Jenkins.get().getDescriptorByType(DescriptorImpl.class);
     }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/RunningBuilds.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/RunningBuilds.java
@@ -31,6 +31,9 @@ public class RunningBuilds extends Component {
     }
 
     @Override
+    public int getHash() { return 34; }
+
+    @Override
     public void addContents(@NonNull Container result) {
         result.add(new PrefilteredPrintedContent("running-builds.txt") {
             @Override

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SlaveCommandStatistics.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SlaveCommandStatistics.java
@@ -79,6 +79,9 @@ public final class SlaveCommandStatistics extends Component {
     }
 
     @Override
+    public int getHash() { return 36; }
+
+    @Override
     public Set<Permission> getRequiredPermissions() {
         return Collections.singleton(Jenkins.ADMINISTER);
     }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLaunchLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLaunchLogs.java
@@ -90,6 +90,9 @@ public class SlaveLaunchLogs extends ObjectComponent<Computer> {
     }
 
     @Override
+    public int getHash() { return 37; }
+
+    @Override
     public void addContents(@NonNull Container container) {
         ExtensionList.lookupSingleton(LogArchiver.class).addContents(container);
     }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SlaveLogs.java
@@ -77,6 +77,9 @@ public class SlaveLogs extends Component {
     }
 
     @Override
+    public int getHash() { return 38; }
+
+    @Override
     public boolean isSelectedByDefault() {
         return false;
     }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SystemConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SystemConfiguration.java
@@ -72,6 +72,9 @@ public abstract class SystemConfiguration extends AdvancedProcFilesRetriever {
         }
 
         @Override
+        public int getHash() { return 42; }
+
+        @Override
         protected List<Node> getNodes() {
             return Collections.singletonList(Jenkins.get());
         }
@@ -125,6 +128,9 @@ public abstract class SystemConfiguration extends AdvancedProcFilesRetriever {
         public String getDisplayName() {
             return "Agent system configuration (Linux only)";
         }
+
+        @Override
+        public int getHash() { return 43; }
 
         @Override
         public boolean isSelectedByDefault() {

--- a/src/main/java/com/cloudbees/jenkins/support/impl/SystemProperties.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/SystemProperties.java
@@ -55,6 +55,9 @@ public class SystemProperties extends Component {
     }
 
     @Override
+    public int getHash() { return 44; }
+
+    @Override
     public void addContents(@NonNull Container result) {
         result.add(new Content("nodes/master/system.properties") {
             @Override

--- a/src/main/java/com/cloudbees/jenkins/support/impl/TaskLogs.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/TaskLogs.java
@@ -35,6 +35,9 @@ public class TaskLogs extends Component {
     }
 
     @Override
+    public int getHash() { return 45; }
+
+    @Override
     public boolean isSelectedByDefault() {
         return true;
     }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/ThreadDumps.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/ThreadDumps.java
@@ -110,6 +110,9 @@ public class ThreadDumps extends ObjectComponent<Computer> {
     }
 
     @Override
+    public int getHash() { return 46; }
+
+    @Override
     public <C extends AbstractModelObject> boolean isApplicable(Class<C> clazz) {
         return Jenkins.class.isAssignableFrom(clazz) || Computer.class.isAssignableFrom(clazz);
     }

--- a/src/main/java/com/cloudbees/jenkins/support/impl/UpdateCenter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/UpdateCenter.java
@@ -34,6 +34,9 @@ public class UpdateCenter extends Component {
     }
 
     @Override
+    public int getHash() { return 47; }
+
+    @Override
     public void addContents(@NonNull Container container) {
         container.add(new PrefilteredPrintedContent("update-center.md") {
             @Override

--- a/src/main/java/com/cloudbees/jenkins/support/impl/UserCount.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/UserCount.java
@@ -54,6 +54,9 @@ public class UserCount extends UnfilteredFileListCapComponent {
     }
 
     @Override
+    public int getHash() { return 48; }
+
+    @Override
     public void addContents(@NonNull Container result) {
         result.add(new PrintedContent("users/count.md") {
             @Override

--- a/src/main/java/com/cloudbees/jenkins/support/slowrequest/SlowRequestComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/slowrequest/SlowRequestComponent.java
@@ -23,6 +23,9 @@ public class SlowRequestComponent extends UnfilteredFileListCapComponent {
     }
 
     @Override
+    public int getHash() { return 39; }
+
+    @Override
     public void addContents(@NonNull Container container) {
         super.addContents(container, checker.logs);
     }

--- a/src/main/java/com/cloudbees/jenkins/support/slowrequest/SlowRequestThreadDumpsComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/slowrequest/SlowRequestThreadDumpsComponent.java
@@ -21,6 +21,9 @@ public class SlowRequestThreadDumpsComponent extends UnfilteredFileListCapCompon
     }
 
     @Override
+    public int getHash() { return 40; }
+
+    @Override
     public void addContents(@NonNull Container container) {
         SlowRequestThreadDumpsGenerator generator =
                 ExtensionList.lookup(SlowRequestThreadDumpsGenerator.class).get(SlowRequestThreadDumpsGenerator.class);

--- a/src/main/java/com/cloudbees/jenkins/support/startup/ShutdownComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/startup/ShutdownComponent.java
@@ -65,6 +65,9 @@ public final class ShutdownComponent extends UnfilteredFileListCapComponent {
     }
 
     @Override
+    public int getHash() { return 35; }
+
+    @Override
     public void addContents(@NonNull Container container) {
         super.addContents(container, logs);
     }

--- a/src/main/java/com/cloudbees/jenkins/support/startup/StartupComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/startup/StartupComponent.java
@@ -51,6 +51,9 @@ public class StartupComponent extends UnfilteredFileListCapComponent {
     }
 
     @Override
+    public int getHash() { return 41; }
+
+    @Override
     public void addContents(@NonNull Container container) {
         super.addContents(container, StartupReport.get().getLogs());
         container.add(new StartupContent(StartupReport.get().getTimesPerMilestone()));

--- a/src/main/java/com/cloudbees/jenkins/support/threaddump/HighLoadComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/threaddump/HighLoadComponent.java
@@ -41,6 +41,9 @@ public class HighLoadComponent extends UnfilteredFileListCapComponent {
     }
 
     @Override
+    public int getHash() { return 15; }
+
+    @Override
     public void addContents(@NonNull Container container) {
         HighLoadCpuChecker checker =
                 ExtensionList.lookup(HighLoadCpuChecker.class).get(HighLoadCpuChecker.class);

--- a/src/main/java/com/cloudbees/jenkins/support/timer/DeadlockRequestComponent.java
+++ b/src/main/java/com/cloudbees/jenkins/support/timer/DeadlockRequestComponent.java
@@ -22,6 +22,9 @@ public class DeadlockRequestComponent extends UnfilteredFileListCapComponent {
     }
 
     @Override
+    public int getHash() { return 9; }
+
+    @Override
     public void addContents(@NonNull Container container) {
         super.addContents(container, checker.logs);
     }

--- a/src/main/resources/com/cloudbees/jenkins/support/Messages.properties
+++ b/src/main/resources/com/cloudbees/jenkins/support/Messages.properties
@@ -42,17 +42,18 @@ SupportPlugin_DeleteBundle=Delete bundle
 SupportPlugin_DownloadBundle=Download bundle
 SupportPlugin_ListBundle=Existing support bundles
 SupportPlugin_loadConfig=Read support plugin configuration
-SupportPlugin_GenerateSupportBundle=Generate Support Bundle
+
+SupportPlugin_ApplyCustomChanges=Apply
 SupportPlugin_ChooseGeneralOption=Choose a general set of options
 SupportPlugin_ChooseGeneralOptionApplied=Success: options have been checked automatically based on the general option selected (above)
 SupportPlugin_ChooseGeneralOptionApplying=Applying options based on the general option selected (above) ...
 SupportPlugin_ChooseOptions=Select options
 SupportPlugin_Close=Close
+SupportPlugin_GenerateSupportBundle=Generate Support Bundle
 SupportPlugin_GenericOption_ConfigurationFiles=Default with configuration files
-SupportPlugin_GenericOption_PerformanceData=Performance data
-SupportPlugin_GenericOption_Default=Default
 SupportPlugin_GenericOption_Custom=Custom
-SupportPlugin_ApplyCustomChanges=Apply
+SupportPlugin_GenericOption_Default=Default
+SupportPlugin_GenericOption_PerformanceData=Performance data
 
 
 SupportPlugin_Category_Agent=Agents

--- a/src/main/resources/com/cloudbees/jenkins/support/Messages.properties
+++ b/src/main/resources/com/cloudbees/jenkins/support/Messages.properties
@@ -42,6 +42,16 @@ SupportPlugin_DeleteBundle=Delete bundle
 SupportPlugin_DownloadBundle=Download bundle
 SupportPlugin_ListBundle=Existing support bundles
 SupportPlugin_loadConfig=Read support plugin configuration
+SupportPlugin_GenerateSupportBundle=Generate Support Bundle
+SupportPlugin_ChooseGeneralOption=Choose a general set of options
+SupportPlugin_ChooseGeneralOptionApplied=Options have been checked automatically based on the general option selected (above)
+SupportPlugin_ChooseOptions=Select options
+SupportPlugin_Close=Close
+SupportPlugin_GenericOption_ConfigurationFiles=Default with configuration files
+SupportPlugin_GenericOption_PerformanceData=Performance data
+SupportPlugin_GenericOption_Default=Default
+SupportPlugin_GenericOption_Custom=Custom
+
 
 SupportPlugin_Category_Agent=Agents
 SupportPlugin_Category_Builds=Builds

--- a/src/main/resources/com/cloudbees/jenkins/support/Messages.properties
+++ b/src/main/resources/com/cloudbees/jenkins/support/Messages.properties
@@ -44,13 +44,15 @@ SupportPlugin_ListBundle=Existing support bundles
 SupportPlugin_loadConfig=Read support plugin configuration
 SupportPlugin_GenerateSupportBundle=Generate Support Bundle
 SupportPlugin_ChooseGeneralOption=Choose a general set of options
-SupportPlugin_ChooseGeneralOptionApplied=Options have been checked automatically based on the general option selected (above)
+SupportPlugin_ChooseGeneralOptionApplied=Success: options have been checked automatically based on the general option selected (above)
+SupportPlugin_ChooseGeneralOptionApplying=Applying options based on the general option selected (above) ...
 SupportPlugin_ChooseOptions=Select options
 SupportPlugin_Close=Close
 SupportPlugin_GenericOption_ConfigurationFiles=Default with configuration files
 SupportPlugin_GenericOption_PerformanceData=Performance data
 SupportPlugin_GenericOption_Default=Default
 SupportPlugin_GenericOption_Custom=Custom
+SupportPlugin_ApplyCustomChanges=Apply
 
 
 SupportPlugin_Category_Agent=Agents

--- a/src/main/resources/com/cloudbees/jenkins/support/SupportAction/index.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/support/SupportAction/index.jelly
@@ -22,74 +22,119 @@
  ~ THE SOFTWARE.
  -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout"
-         xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core"
+         xmlns:l="/lib/layout"
+         xmlns:f="/lib/form"
+         xmlns:st="jelly:stapler">
   <l:layout title="${it.actionTitleText}" permission="${app.ADMINISTER}" type="one-column">
     <l:main-panel>
       <l:app-bar title="${it.actionTitle}" />
-
-      <p>
-        ${it.actionBlurb}
-      </p>
-      <p>
-        ${%detail}
-      </p>
-      <j:if test="${it.anonymized}">
+      <f:section>
         <p>
-          Support bundle anonymization is enabled. View
-          <a href="../anonymizedMappings">anonymized mappings here</a>, or manage anonymization settings in the
-          <a href="${rootURL}/configureSecurity">global security</a> under <i>Support Bundle Anonymization</i>.
+          ${it.actionBlurb}
         </p>
-      </j:if>
-      <j:if test="${!it.anonymized}">
-        <p class="warning">
-          Support bundle anonymization is disabled. This can be enabled in the
-          <a href="${rootURL}/configureSecurity">global security</a> under <i>Support Bundle Anonymization</i>.
+        <p>
+          ${%detail}
         </p>
-      </j:if>
-      <f:form name="bundle-contents" method="POST" action="generateBundleAsync">
-        <j:forEach var="category" items="${it.categorizedComponents.entrySet()}">
-          <section class="jenkins-section jenkins-section--bottom-padding">
-            <h2 class="jenkins-section__title">${category.key.label}</h2>
-            <div class="jenkins-section__items">
-              <j:forEach var="component" items="${category.value}">
-                <div name="components" class="jenkins-section__item">
-                  <j:if test="${component.enabled}">
-                    <f:checkbox title="${component.displayName}" name="selected" checked="${it.selectedByDefault(component)}"/>
-                  </j:if>
-                  <j:if test="${!component.enabled}">
-                    <f:checkbox title="${%permissionPreReqs(component.displayPermissions)}" name="selected" checked="false" readOnlyMode="true"/>
-                  </j:if>
-                  <input type="hidden" name="name" value="${component.id}"/>
-                </div>
+        <j:if test="${it.anonymized}">
+          <p>
+            Support bundle anonymization is enabled. View
+            <a href="../anonymizedMappings">anonymized mappings here</a>, or manage anonymization settings in the
+            <a href="${rootURL}/configureSecurity">global security</a> under <i>Support Bundle Anonymization</i>.
+          </p>
+        </j:if>
+        <j:if test="${!it.anonymized}">
+          <p class="warning">
+            Support bundle anonymization is disabled. This can be enabled in the
+            <a href="${rootURL}/configureSecurity">global security</a> under <i>Support Bundle Anonymization</i>.
+          </p>
+        </j:if>
+      </f:section>
+      <f:section title="${it.generateSupportBundle}">
+        <f:form name="bundle-contents" method="POST" action="generateBundleAsync">
+          <dialog id="categories_dialog" style="padding:20px; border-radius:8px;" >
+            <f:section title="${it.chooseOptions}">
+              <j:forEach var="category" items="${it.categorizedComponents.entrySet()}">
+                <section class="jenkins-section jenkins-section--bottom-padding">
+                  <h2 class="jenkins-section__title">${category.key.label}</h2>
+                  <div class="jenkins-section__items">
+                    <j:forEach var="component" items="${category.value}">
+                      <div name="components" class="jenkins-section__item">
+                        <j:set var="hash" value="${component.hash}"/>
+                        <j:if test="${hash == -1}">
+                          <j:if test="${component.enabled}">
+                            <f:checkbox title="${component.displayName}" name="selected" checked="${it.selectedByDefault(component)}" onclick="showIdMaps()"/>
+                          </j:if>
+                          <j:if test="${!component.enabled}">
+                            <f:checkbox title="${%permissionPreReqs(component.displayPermissions)}" name="selected" checked="false" readOnlyMode="true"/>
+                          </j:if>
+                        </j:if>
+                        <j:if test="${hash != -1}">
+                          <j:if test="${component.enabled}">
+                            <f:checkbox title="${component.displayName}" name="selected" checked="${it.selectedByDefault(component)}" id="${hash}" onclick="showIdMaps()"/>
+                          </j:if>
+                          <j:if test="${!component.enabled}">
+                            <f:checkbox title="${%permissionPreReqs(component.displayPermissions)}" name="selected" checked="false" id="${hash}" readOnlyMode="true"/>
+                          </j:if>
+                        </j:if>
+                        <input type="hidden" name="name" value="${component.id}"/>
+                      </div>
+                    </j:forEach>
+                  </div>
+                </section>
               </j:forEach>
-            </div>
-          </section>
-        </j:forEach>
-        <f:bottomButtonBar>
-          <f:submit value="${%Generate Bundle}" icon="symbol-download" />
-        </f:bottomButtonBar>
-      </f:form>
+              <div id="hashId" style="position: fixed; right: 3rem; bottom: 2rem;">
+                none
+              </div>
+              <button class="jenkins-button jenkins-button--primary" onclick="document.getElementById('categories_dialog').close();return false;">
+                ${it.close}
+              </button>
+            </f:section>
+          </dialog>
+          <f:entry title="${it.chooseGeneralOption}" field="mapText" help="/plugin/support-core/help/help-chooseGeneralOption.html">
+            <select id="idMapSelect" class="jenkins-select__input select">
+              <option value="1F79CB2F69F57">${it.genericOptionDefault}</option>
+              <option value="1F79CBAF69FD7">${it.genericOptionConfigurationFiles}</option>
+              <option value="1F7FCBBFEFFD7">${it.genericOptionPerformanceData}</option>
+              <option value="custom">${it.genericOptionCustom}</option>
+            </select>
+            <f:textbox id="idMapText" value="" onblur="setIdMaps()" style="display:none;margin-top:15px;"/>
+          </f:entry>
+          <p id="chooseGeneralOptionAppliedId" class="error" style="display:none">
+            ${it.chooseGeneralOptionApplied}
+          </p>
+          <p>${%Or}</p>
+          <f:bottomButtonBar>
+            <f:submit id="chooseOptionButtonId" value="${it.chooseOptions}">
+            </f:submit>
+          </f:bottomButtonBar>
+
+          <f:bottomButtonBar>
+            <f:submit value="${%Generate Bundle}" icon="symbol-download" />
+          </f:bottomButtonBar>
+        </f:form>
+      </f:section>
 
       <j:if test="${!it.bundles.isEmpty()}">
         <f:section title="${%Existing support bundles}">
-        <f:form name="bundle-contents" method="POST">
-          <j:forEach var="bundle" items="${it.bundles}">
-            <f:entry field="bundle">
-            <div name="bundles">
-            <f:checkbox name="selected" checked="false"
-                        title="${bundle}"/>
-              <input style="display:none" name="name" value="${bundle}"/>
+          <f:form name="bundle-contents" method="POST">
+            <j:forEach var="bundle" items="${it.bundles}">
+              <f:entry field="bundle">
+              <div name="bundles">
+              <f:checkbox name="selected" checked="false"
+                          title="${bundle}"/>
+                <input style="display:none" name="name" value="${bundle}"/>
+              </div>
+              </f:entry>
+            </j:forEach>
+            <div class="jenkins-buttons-row">
+              <button type="submit" class="jenkins-button jenkins-button--primary" formaction="downloadBundles">${%Download Bundle}</button>
+              <button type="submit" class="jenkins-button jenkins-!-destructive-color" formaction="deleteBundles">${%Delete Bundle}</button>
             </div>
-            </f:entry>
-          </j:forEach>
-          <div class="jenkins-buttons-row">
-            <button type="submit" class="jenkins-button jenkins-button--primary" formaction="downloadBundles">${%Download Bundle}</button>
-            <button type="submit" class="jenkins-button jenkins-!-destructive-color" formaction="deleteBundles">${%Delete Bundle}</button>
-          </div>
-        </f:form>
+          </f:form>
         </f:section>
       </j:if>
     </l:main-panel>
+    <st:adjunct  includes="js/generationAssist"/>
   </l:layout>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/support/SupportAction/index.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/support/SupportAction/index.jelly
@@ -98,9 +98,17 @@
               <option value="1F7FCBBFEFFD7">${it.genericOptionPerformanceData}</option>
               <option value="custom">${it.genericOptionCustom}</option>
             </select>
-            <f:textbox id="idMapText" value="" onblur="setIdMaps()" style="display:none;margin-top:15px;"/>
+            <div id="idMapDiv" style="display: none; align-items: center;margin-top:15px;">
+              <f:textbox id="idMapText" value="" style="margin-right:15px;"/>
+              <button id="idMapTextApply" class="jenkins-button jenkins-submit-button jenkins-button--primary" onclick="setIdMaps(); return false;">
+                ${it.applyCustomChanges}
+              </button>
+            </div>
           </f:entry>
-          <p id="chooseGeneralOptionAppliedId" class="error" style="display:none">
+          <p id="chooseGeneralOptionApplyingId" class="error" style="display:none">
+            ${it.chooseGeneralOptionApplying}
+          </p>
+          <p id="chooseGeneralOptionAppliedId" class="info" style="display:none;color:green">
             ${it.chooseGeneralOptionApplied}
           </p>
           <p>${%Or}</p>

--- a/src/main/resources/js/generationAssist.js
+++ b/src/main/resources/js/generationAssist.js
@@ -24,11 +24,18 @@ function getIdMaps(){
 
 function showIdMaps(){
     var idMaps = getIdMaps()
-    document.getElementById("hashId").innerHTML = idMaps
-    document.getElementById('idMapText').value = idMaps
+    var hashElement = document.getElementById("hashId");
+    var mapTextElement = document.getElementById("idMapText");
+    if (hashElement) { hashElement.innerHTML = idMaps }
+    if (mapTextElement) { mapTextElement.value = idMaps}
 }
 
 function setIdMaps(){
+    var chooseGeneralOptionApplyingElement = document.getElementById("chooseGeneralOptionApplyingId")
+    var chooseGeneralOptionAppliedElement = document.getElementById("chooseGeneralOptionAppliedId")
+    if (chooseGeneralOptionApplyingElement) { chooseGeneralOptionApplyingElement.style.display = 'block' }
+    if (chooseGeneralOptionAppliedElement) { chooseGeneralOptionAppliedElement.style.display = 'none'}
+
     var currentValue = document.getElementById('idMapText').value
     var arrayWithChecked = convertStringToArray(currentValue)
     var components = document.getElementsByName('selected')
@@ -44,10 +51,11 @@ function setIdMaps(){
         }
     });
     document.getElementById("hashId").innerHTML = currentValue
-    document.getElementById("chooseGeneralOptionAppliedId").style.display = 'block';
+
     setTimeout(function() {
-        document.getElementById("chooseGeneralOptionAppliedId").style.display = 'none';
-    }, 5000);
+        if (chooseGeneralOptionApplyingElement) { chooseGeneralOptionApplyingElement.style.display = 'none' }
+        if (chooseGeneralOptionAppliedElement) { chooseGeneralOptionAppliedElement.style.display = 'block' }
+    }, 1000);
 
 }
 
@@ -56,29 +64,54 @@ function convertArrayToString(array){
     while(array.length > 0){
         binary += array.pop()
     }
-    return BigInt("0b" + binary).toString(16).toUpperCase();
+    if(binary.length > 0){
+        return BigInt("0b" + binary).toString(16).toUpperCase();
+    } else {
+        return ""
+    }
 }
 
 function convertStringToArray(hex){
-    return parseInt(hex, 16).toString(2).padStart(hex.length * 4, '0').split('').map(bit => parseInt(bit, 10)).reverse()
+    if(hex.length > 0){
+        return parseInt(hex, 16).toString(2).padStart(hex.length * 4, '0').split('').map(bit => parseInt(bit, 10)).reverse()
+    } else {
+        return [];
+    }
 }
 
 document.addEventListener("DOMContentLoaded", function() {
+    var chooseOptionButtonElement = document.getElementById('chooseOptionButtonId')
+    var mapTextElement = document.getElementById('idMapText')
+    var mapSelectElement = document.getElementById('idMapSelect')
+    var mapDivElement = document.getElementById('idMapDiv')
     showIdMaps()
-    document.getElementById('chooseOptionButtonId').addEventListener('click', function(event) {
-        event.preventDefault();
-        document.getElementById('categories_dialog').showModal();
-        return false;
-    })
-    document.getElementById('idMapSelect').addEventListener('change', function(event) {
-        event.preventDefault();
-        if (document.getElementById('idMapSelect').value == "custom"){
-            document.getElementById('idMapText').style.display = 'block';
-        }else{
-            document.getElementById('idMapText').style.display = 'none';
-            document.getElementById('idMapText').value=document.getElementById('idMapSelect').value
-            setIdMaps()
-        }
 
-    })
+    if (chooseOptionButtonElement) {
+        chooseOptionButtonElement.addEventListener('click', function(event) {
+            event.preventDefault();
+            document.getElementById('categories_dialog').showModal();
+            return false;
+        })
+    }
+    if (mapTextElement) {
+        mapTextElement.addEventListener('keydown', function(event) {
+            if (event.key === 'Enter') {
+              event.preventDefault();
+              setIdMaps()
+            }
+        });
+    }
+
+    if (mapSelectElement && mapDivElement) {
+        mapSelectElement.addEventListener('change', function(event) {
+            event.preventDefault();
+            if (mapSelectElement.value == "custom"){
+                mapDivElement.style.display = 'flex';
+            }else{
+                mapDivElement.style.display = 'none';
+                mapTextElement.value=mapSelectElement.value
+                setIdMaps()
+            }
+        })
+    }
 });

--- a/src/main/resources/js/generationAssist.js
+++ b/src/main/resources/js/generationAssist.js
@@ -1,0 +1,84 @@
+function getIdMaps(){
+  var idMaps = []
+  var components = document.getElementsByName('selected')
+  components.forEach((component, index) => {
+    try {
+        var position = parseInt(component.id)
+        var value = (component.checked)? "1" : "0"
+        if(!Number.isNaN(position)){
+            if (position >= idMaps.length){
+                for(var i = idMaps.length; i < position; i++){
+                    idMaps.push("0")
+                }
+                idMaps.push(value)
+            } else {
+                idMaps[position] = value
+            }
+        }
+    } catch(error){
+
+    }
+  });
+  return convertArrayToString(idMaps)
+}
+
+function showIdMaps(){
+    var idMaps = getIdMaps()
+    document.getElementById("hashId").innerHTML = idMaps
+    document.getElementById('idMapText').value = idMaps
+}
+
+function setIdMaps(){
+    var currentValue = document.getElementById('idMapText').value
+    var arrayWithChecked = convertStringToArray(currentValue)
+    var components = document.getElementsByName('selected')
+    components.forEach((component, index) => {
+        try {
+            var position = parseInt(component.id)
+            if(!Number.isNaN(position) && position < arrayWithChecked.length){
+                var desiredValue = arrayWithChecked[position]
+                component.checked = (desiredValue=="1")
+            }
+        } catch(error){
+
+        }
+    });
+    document.getElementById("hashId").innerHTML = currentValue
+    document.getElementById("chooseGeneralOptionAppliedId").style.display = 'block';
+    setTimeout(function() {
+        document.getElementById("chooseGeneralOptionAppliedId").style.display = 'none';
+    }, 5000);
+
+}
+
+function convertArrayToString(array){
+    var binary = ""
+    while(array.length > 0){
+        binary += array.pop()
+    }
+    return BigInt("0b" + binary).toString(16).toUpperCase();
+}
+
+function convertStringToArray(hex){
+    return parseInt(hex, 16).toString(2).padStart(hex.length * 4, '0').split('').map(bit => parseInt(bit, 10)).reverse()
+}
+
+document.addEventListener("DOMContentLoaded", function() {
+    showIdMaps()
+    document.getElementById('chooseOptionButtonId').addEventListener('click', function(event) {
+        event.preventDefault();
+        document.getElementById('categories_dialog').showModal();
+        return false;
+    })
+    document.getElementById('idMapSelect').addEventListener('change', function(event) {
+        event.preventDefault();
+        if (document.getElementById('idMapSelect').value == "custom"){
+            document.getElementById('idMapText').style.display = 'block';
+        }else{
+            document.getElementById('idMapText').style.display = 'none';
+            document.getElementById('idMapText').value=document.getElementById('idMapSelect').value
+            setIdMaps()
+        }
+
+    })
+});

--- a/src/main/webapp/help/help-chooseGeneralOption.html
+++ b/src/main/webapp/help/help-chooseGeneralOption.html
@@ -1,0 +1,10 @@
+<p>
+    You can select one of the above values to mark a default set of options. For example, you can select the <i>Default with configuration files</i> value if you want to mark (and collect) the default options of the support bundle and the configuration file options.
+
+</p>
+<p>
+    You can also select the <i>Custom</i> option and type a hexadecimal value in the auxiliary text box if you want to check some specific options (the options will be checked depending on this hexadecimal value). To get an example of the hexadecimal value, you click in the <i>Select options</i>> button, mark the options that you want and copy the value that you can find in the bottom and right corne of the widget.
+</p>
+<p>
+    Finally, you can click on <i>Select options</i> directly and check the options that you want to collect during the support bundle generation.
+</p>

--- a/src/test/java/com/cloudbees/jenkins/support/SupportPluginTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportPluginTest.java
@@ -70,6 +70,9 @@ public class SupportPluginTest {
                     }
 
                     @Override
+                    public int getHash() { return 999; }
+
+                    @Override
                     public void addContents(@NonNull Container container) {
                         container.add(new Content("test/testGenerateBundleExceptionHandler.md") {
                             @Override
@@ -125,6 +128,9 @@ public class SupportPluginTest {
                     public String getDisplayName() {
                         return "Test Component";
                     }
+
+                    @Override
+                    public int getHash() { return 999; }
 
                     @Override
                     public boolean supersedes(Component component) {

--- a/src/test/java/com/cloudbees/jenkins/support/api/ComponentTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/api/ComponentTest.java
@@ -1,0 +1,34 @@
+package com.cloudbees.jenkins.support.api;
+
+
+import jenkins.model.Jenkins;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
+public class ComponentTest {
+
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
+
+
+    @Test
+    public void hashValidation() throws Exception {
+        long distinctCount = Jenkins.get().getExtensionList(Component.class).stream()
+                .filter(component -> component.isApplicable(Jenkins.class))
+                .map(component -> component.getHash())
+                .distinct()
+                .count();
+        long count = Jenkins.get().getExtensionList(Component.class).stream()
+                .filter(component -> component.isApplicable(Jenkins.class)).count();
+        System.out.println("distinctCount: " + distinctCount + "; count: " + count);
+        assertTrue( "It seems there is at least to components with the same HASH, the HASH should be uniq and lower as possible (Total components: " +
+                count + ", number of component with different hashes: " + distinctCount + ")",
+                distinctCount == count);
+    }
+
+}


### PR DESCRIPTION
This is an attempt to enhance the Support Bundle Generation view. The improvements introduced are:

### Moving the list of options from the main page to a pop-up/widget.

Users don't always need to mark or unmark any options if they just want to generate a default support bundle. Moving the list to a pop-up or widget allows us to add more elements to manage the checked options in the main view (see next improvement sections).

To open the widget we will need to click on `Select options`:

<img width="2532" height="1242" alt="SCR-20250828-mckr" src="https://github.com/user-attachments/assets/255d8d5e-02a8-4ae3-abde-7017b88f3bf4" />

The new widget shows the following:

<img width="2552" height="1368" alt="SCR-20250828-mczm" src="https://github.com/user-attachments/assets/460f8a4e-f771-453e-88c9-62727f2e57c1" />

Please pay attention to the code displayed in the bottom-right corner. This is a HASH generated from the current selected (checked) options. Please refer to the "Custom options" section for more information about this new element.

You can close the widget by clicking on `Close` or pressing the `Esc` key.

### Choose a general set of options

Selecting which options should be checked can be complex for standards users, so it may be a good idea to have a dropdown element with some standard options (such as configuration files, performance, etc.). For the moment, only three options were added (default, default + configuration files, and performance). As soon as the user clicks or selects one general option in this dropdown, the options will be checked in the widget (by JS).

<img width="2533" height="1295" alt="SCR-20250828-mgck" src="https://github.com/user-attachments/assets/73eabd87-6807-4679-8e10-5f5b19db13b8" />

### Custom options

This could be the most interesting part of this development. 

Each option will have an ID in the list of options. Anytime that a user check or uncheck any option in the widget a HASH value will be calculated in base on the current selected options. This HASH will appear in two locations: in the bottom-right corner of the widget, and in the input textbox under the `Choose a general set of options`. 

<img width="2539" height="1365" alt="SCR-20250828-mhsg" src="https://github.com/user-attachments/assets/431efe1b-3593-427c-b54d-bf9a74d88665" />

Selecting the `Custom` value in the `Choose a general set of options` dropdown, the textbox for the custom value will appear. If you type a HASH value in this textbox and press the `Enter` key (or click in the `Apply` button), the options in the widget will be selected according to this HASH value. After that, we could optionally click on `Select options` and alter this set of select options.

There is an issue with plugins that extend the `Component` class. The elements shown in the widget (and originally on that page) are classes that extend the `Component` class and satisfy some requirements. Those classes can be provided by any plugin (not only the support-core-plugin). This question makes the management of this HASH so hard (since we cannot ensure that all the child components will implement the `getHash` method (inherited from the `Component` class). Therefore, the decision was made to disregard the child components that would not correctly implement the `getHash` method. By doing that, we can share a HASH code that we can ensure will work.

## Testing done

The development was tested in three different ways:

1. A Junit test was created for the `getHash` method of the child components.
2. The plugin was deployed in Jenkins version `2.479.3` and passed the basic integration tests:
    1. Selecting all the general options and confirming that the options were checked correctly in the widget.
    2. Selecting the `Custom` general options and confirming that the correct options were checked with different known HASH codes.
    3. Checking and unckecking different options in the widget and confirming that the generated HASH was correct.
    4. Confirming the usage of events (like the `Esc` for the widget or the `Enter` for the custom textbox).
    5. Generating a support bundle and confirming that the options checked in the widget were included in the file.  

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

## Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
