### PR TITLE
[chore] Enable strict bundled artifact checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.11</version>
+    <version>5.24</version>
     <relativePath />
   </parent>
 
@@ -72,6 +72,8 @@
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <spotless.check.skip>false</spotless.check.skip>
+    <hpi.bundledArtifacts>jsr250-api,quality-check,support-log-formatter,uadetector-core,uadetector-resources,wordnet-random-name</hpi.bundledArtifacts>
+    <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Leverages https://github.com/jenkinsci/maven-hpi-plugin/issues/557 to explicitely declare the plugin bundle.

Note that most of the bundle is due to the very old (unmaintained?) library used for user agent parsing:

```
[INFO] +- net.sf.uadetector:uadetector-resources:jar:2014.10:compile
[INFO] |  \- net.sf.uadetector:uadetector-core:jar:0.9.22:compile
[INFO] |     +- net.sf.qualitycheck:quality-check:jar:1.3:compile
[INFO] |     \- javax.annotation:jsr250-api:jar:1.0:compile
```

Maybe it would be interesting to study a replacement of this old library by something like https://github.com/nielsbasjes/yauaa (or dump a raw user agent in support bundless and let downstream consumers deal with the parsing however they like?).