### PR TITLE
Ensure thread dump file timestamp is in UTC

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/impl/ThreadDumps.java
+++ b/src/main/java/com/cloudbees/jenkins/support/impl/ThreadDumps.java
@@ -29,6 +29,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -80,6 +81,7 @@ public class ThreadDumps extends ObjectComponent<Computer> {
             throw new IllegalArgumentException("delay must be greater than 0");
         }
         var format = new SimpleDateFormat(DATE_FORMAT);
+        format.setTimeZone(TimeZone.getTimeZone("UTC"));
         File threadDumpFile = fileList.file(format.format(new Date(timestamp)) + ".txt");
         try (FileOutputStream fileOutputStream = new FileOutputStream(threadDumpFile)) {
             threadDump(fileOutputStream);


### PR DESCRIPTION
For consistency with slow request report files and general UTC preference, ensure multiple thread dump collection functions set UTC as a TZ explicitly.

<!-- Please describe your pull request here. -->

`SlowRequestChecker` explicitly sets the time zone of its `SimpleDateFormat` which is used for file name generation.
https://github.com/jenkinsci/support-core-plugin/blob/1801.v76b_389d2deec/src/main/java/com/cloudbees/jenkins/support/slowrequest/SlowRequestChecker.java#L61-L65

The `ThreadDumps` utility functions for generating a sequence of thread dumps were not doing that. Hence, file names it creates for thread dumps can be in the local time zone of the server. The PR suggests explicitly setting the time zone to UTC in `ThreadDumps`.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] ~Link to relevant issues in GitHub or Jira~
- [ ] ~Link to relevant pull requests, esp. upstream and downstream changes~
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
