### PR TITLE
Outdated opt-in startup performance component is removed

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -789,58 +789,12 @@ public class SupportPlugin extends Plugin {
         if (instance != null) instance.load();
     }
 
-    private static final boolean logStartupPerformanceIssues =
-            Boolean.getBoolean(SupportPlugin.class.getCanonicalName() + ".threadDumpStartup");
-    private static final int secondsPerThreadDump =
-            Integer.getInteger(SupportPlugin.class.getCanonicalName() + ".secondsPerTD", 60);
-
     @Deprecated
     @Restricted(NoExternalUse.class)
     public static void completedMilestones() throws IOException {
         // Do nothing
     }
 
-    @Initializer(after = InitMilestone.STARTED)
-    public static void threadDumpStartup() throws Exception {
-        if (!logStartupPerformanceIssues) return;
-        final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd_HH.mm.ss");
-        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-        final File f = new File(getRootDirectory(), "/startup-threadDump" + dateFormat.format(new Date()) + ".txt");
-        if (!f.exists()) {
-            try {
-                f.createNewFile();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }
-
-        Thread t = new Thread("Support core plugin startup diagnostics") {
-            @Override
-            public void run() {
-                try {
-                    while (true) {
-                        final Jenkins jenkins = Jenkins.getInstanceOrNull();
-                        if (jenkins == null || jenkins.getInitLevel() != InitMilestone.COMPLETED) {
-                            continue;
-                        }
-                        try (PrintStream ps = new PrintStream(new FileOutputStream(f, true), false, "UTF-8")) {
-                            ps.println("=== Thread dump at " + new Date() + " ===");
-                            ThreadDumps.threadDump(ps);
-                            // Generate a thread dump every few seconds/minutes
-                            ps.flush();
-                            TimeUnit.SECONDS.sleep(secondsPerThreadDump);
-                        } catch (FileNotFoundException | UnsupportedEncodingException e) {
-                            e.printStackTrace();
-                        }
-                    }
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                    Thread.currentThread().interrupt();
-                }
-            }
-        };
-        t.start();
-    }
 
     @Override
     public synchronized void start() throws Exception {

--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -38,7 +38,6 @@ import com.cloudbees.jenkins.support.filter.ContentFilter;
 import com.cloudbees.jenkins.support.filter.ContentFilters;
 import com.cloudbees.jenkins.support.filter.FilteredOutputStream;
 import com.cloudbees.jenkins.support.filter.PrefilteredContent;
-import com.cloudbees.jenkins.support.impl.ThreadDumps;
 import com.cloudbees.jenkins.support.util.CallAsyncWrapper;
 import com.cloudbees.jenkins.support.util.IgnoreCloseOutputStream;
 import com.cloudbees.jenkins.support.util.OutputStreamSelector;
@@ -73,14 +72,11 @@ import hudson.triggers.SafeTimerTask;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -794,7 +790,6 @@ public class SupportPlugin extends Plugin {
     public static void completedMilestones() throws IOException {
         // Do nothing
     }
-
 
     @Override
     public synchronized void start() throws Exception {


### PR DESCRIPTION
More advanced enabled by default `StartupComponent` (#646) makes the `threadDumpStartup` obsolete. Let us remove the old code.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] ~Link to relevant issues in GitHub or Jira~
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] ~Ensure you have provided tests that demonstrate the feature works or the issue is fixed~

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
