### PR TITLE
Fold case consistently when building and looking up anonymization keys

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilter.java
@@ -61,7 +61,26 @@ public class SensitiveContentFilter implements ContentFilter {
 
     @Override
     public @NonNull String filter(@NonNull String input) {
-        return WordReplacer.replaceWords(input, mappingsPattern.get(), replacementsMap.get());
+        Map<String, String> replacements = replacementsMap.get();
+        return WordReplacer.replaceWords(input, mappingsPattern.get(), match -> replacements.get(fold(match)));
+    }
+
+    /**
+     * Canonicalizes a value for use as a key in the replacements map, folding case the same way the compiled
+     * {@link Pattern} does.
+     *
+     * <p>The pattern is compiled with {@link Pattern#CASE_INSENSITIVE} and {@link Pattern#UNICODE_CASE}, which
+     * compares characters via {@code toLowerCase(toUpperCase(c))}. {@link String#toLowerCase(Locale)} does not
+     * always agree with that, so deriving the key one way and the lookup the other lets the pattern match text
+     * that the map has no entry for. Two concrete divergences: {@code U+017F LATIN SMALL LETTER LONG S} matches
+     * the literal {@code s} but {@code toLowerCase} leaves it unchanged, and {@code U+0130 LATIN CAPITAL LETTER I
+     * WITH DOT ABOVE} matches the literal {@code i} but {@code toLowerCase} decomposes it to {@code i U+0307}.
+     * Deriving both sides with this fold keeps them in agreement.
+     */
+    static String fold(String value) {
+        StringBuilder folded = new StringBuilder(value.length());
+        value.codePoints().forEach(cp -> folded.appendCodePoint(Character.toLowerCase(Character.toUpperCase(cp))));
+        return folded.toString();
     }
 
     @Override
@@ -79,35 +98,38 @@ public class SensitiveContentFilter implements ContentFilter {
                 // Filter out IP mappings
                 .filter(mapping -> !mapping.getReplacement().startsWith("ip_"))
                 .forEach(contentMapping -> {
-                    String lowerCaseOriginal = contentMapping.getOriginal().toLowerCase(Locale.ENGLISH);
-                    if (!stopWords.contains(lowerCaseOriginal)) {
+                    String original = contentMapping.getOriginal();
+                    // Stop words are stored lower cased, so they are matched that way; the trie and the map are
+                    // keyed on the case fold instead, so that filter() can look up whatever the pattern matched.
+                    if (!stopWords.contains(original.toLowerCase(Locale.ENGLISH))) {
+                        String key = fold(original);
                         replacementsMap.put(
-                                lowerCaseOriginal,
+                                key,
                                 contentMapping
                                         .getReplacement()
                                         .replaceAll("\\\\", "\\\\\\\\")
                                         .replaceAll("\\$", "\\\\\\$"));
-                        trie.add(lowerCaseOriginal);
+                        trie.add(key);
                     }
                 });
 
         NameProvider.all()
                 .forEach(provider -> provider.names().filter(s -> !s.isBlank()).forEach(name -> {
-                    String lowerCaseOriginal = name.toLowerCase(Locale.ENGLISH);
                     // NOTE: We could well create a WordTrie for the stop words and use it as a filter instead of the
                     // conditional here. Or find a better way to deal with insensitive key mapping in general.
                     // But the reload is already quite fast anyway. (~1s for 10^4 items with 1 CPU / 2 GB memory
                     // container)
-                    if (!stopWords.contains(lowerCaseOriginal)) {
+                    if (!stopWords.contains(name.toLowerCase(Locale.ENGLISH))) {
                         ContentMapping mapping = mappings.getMappingOrCreate(
                                 name, original -> ContentMapping.of(original, provider.generateFake()));
+                        String key = fold(name);
                         // Matcher#appendReplacement needs to have the `\` and `$` escaped.
                         replacementsMap.putIfAbsent(
-                                lowerCaseOriginal,
+                                key,
                                 mapping.getReplacement()
                                         .replaceAll("\\\\", "\\\\\\\\")
                                         .replaceAll("\\$", "\\\\\\$"));
-                        trie.add(lowerCaseOriginal);
+                        trie.add(key);
                     }
                 }));
         this.mappingsPattern.set(Pattern.compile(

--- a/src/test/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilterTest.java
@@ -108,4 +108,26 @@ class SensitiveContentFilterTest {
         assertThat(filter.filter(os)).isEqualTo(os);
         assertThat(filter.filter(label)).startsWith("label_").isNotEqualTo(label);
     }
+
+    @Test
+    void anonymizeUnicodeCaseVariants(JenkinsRule j) {
+        ContentMappings mappings = ContentMappings.get();
+        mappings.getMappingOrCreate("sapphirium", original -> ContentMapping.of(original, "item_test_alpha"));
+        mappings.getMappingOrCreate("idalium", original -> ContentMapping.of(original, "item_test_beta"));
+
+        SensitiveContentFilter filter = SensitiveContentFilter.get();
+        filter.reload();
+
+        // U+017F LATIN SMALL LETTER LONG S matches the literal 's' under CASE_INSENSITIVE|UNICODE_CASE, but
+        // String#toLowerCase leaves it untouched -- so keying the map that way loses the entry.
+        assertThat(filter.filter("build ſapphirium done")).isEqualTo("build item_test_alpha done");
+
+        // U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE matches the literal 'i', but String#toLowerCase
+        // decomposes it to 'i' + U+0307 COMBINING DOT ABOVE.
+        assertThat(filter.filter("job İdalium ran")).isEqualTo("job item_test_beta ran");
+
+        // plain ASCII case-insensitivity must keep working
+        assertThat(filter.filter("SAPPHIRIUM")).isEqualTo("item_test_alpha");
+        assertThat(filter.filter("sapphirium")).isEqualTo("item_test_alpha");
+    }
 }


### PR DESCRIPTION
`SensitiveContentFilter` compiles its pattern with `CASE_INSENSITIVE | UNICODE_CASE`, which folds via `toLowerCase(toUpperCase(c))`, but derives the trie words and `replacementsMap` keys with `String.toLowerCase(Locale.ENGLISH)`. The two disagree for some characters, with two results:

- The pattern matches text the map has no key for, so the replacement is `null` and `Matcher.replaceAll` throws. Literal `sap` matches `ſap` (U+017F), whose `toLowerCase` is unchanged.
- Where a name itself contains a character whose lowercase changes length, the literal is corrupted and matches nothing at all — so that name is never redacted. `İdalium` (U+0130) becomes literal `i` + U+0307 + `dalium`.

Both are fixed by deriving the key and the lookup with the same per-code-point fold.

Found while working on #811 (JENKINS-55995).

Fixes #981

### Related

Four independent PRs from the same pass over the anonymization code, plus the original report in #811:

- #980
- #982 *(this one)*
- #984
- #986

Suggested merge order: **#984 -> #986 -> #980 -> #982**. Any order works; this one just minimises rebasing.

### Testing done

New test in `SensitiveContentFilterTest` covering both characters plus ASCII guards; it fails on `master` with the NPE above.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed



