### PR TITLE
Make anonymization pseudonyms unique and reproducible

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/filter/DataFaker.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/DataFaker.java
@@ -33,7 +33,7 @@ import java.util.function.Function;
 import jenkins.security.HMACConfidentialKey;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
-import org.kohsuke.randname.RandomNameGenerator;
+import org.kohsuke.randname.Dictionary;
 
 /**
  * Provides deterministic pseudonym generation for anonymization.
@@ -48,6 +48,7 @@ import org.kohsuke.randname.RandomNameGenerator;
 public class DataFaker implements ExtensionPoint, Function<Function<String, String>, Function<String, String>> {
 
     private static final HMACConfidentialKey PSEUDONYMS = new HMACConfidentialKey(DataFaker.class, "pseudonyms");
+    private static final Dictionary DICTIONARY = new Dictionary();
 
     /**
      * @return the singleton instance
@@ -66,14 +67,11 @@ public class DataFaker implements ExtensionPoint, Function<Function<String, Stri
     public Function<String, String> apply(@NonNull Function<String, String> nameTransformer) {
         return original -> {
             String hex = PSEUDONYMS.mac(original);
-            // Masked because RandomNameGenerator computes Math.abs(pos + prime) % size, and
-            // Math.abs(Integer.MIN_VALUE) is negative, which would yield a negative word index.
-            int seed = (int) (Long.parseLong(hex.substring(0, 8), 16) & 0x0FFFFFFFL);
+            int index = (int) (Long.parseLong(hex.substring(0, 8), 16) % DICTIONARY.size());
             String tail = hex.substring(8, 16);
 
-            RandomNameGenerator generator = new RandomNameGenerator(seed);
             String name = nameTransformer
-                    .apply(generator.next())
+                    .apply(DICTIONARY.word(index))
                     .toLowerCase(Locale.ENGLISH)
                     .replace(' ', '_');
             return name + "_" + tail;

--- a/src/main/java/com/cloudbees/jenkins/support/filter/DataFaker.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/DataFaker.java
@@ -28,6 +28,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.function.Function;
 import jenkins.security.HMACConfidentialKey;
@@ -40,16 +41,14 @@ import org.kohsuke.randname.Dictionary;
  *
  * <p>Derives stable pseudonyms from originals using HMAC-keyed word pairs and hex tails.
  * Same original always produces the same pseudonym within one installation (stable across
- * restarts and HA replicas sharing JENKINS_HOME). Deliberately differs across installations
+ * restarts and CloudBees CI HA replicas sharing JENKINS_HOME). Deliberately differs across installations
  * with different secret keys, preventing brute-force attacks on guessable originals.
- *
- * @since TODO
  */
 @Extension
 @Restricted(NoExternalUse.class)
 public class DataFaker implements ExtensionPoint, Function<Function<String, String>, Function<String, String>> {
 
-    private static final HMACConfidentialKey PSEUDONYMS = new HMACConfidentialKey(DataFaker.class, "pseudonyms");
+    private static final HMACConfidentialKey PSEUDONYMS = new HMACConfidentialKey(DataFaker.class, "pseudonyms", 8);
     private static final Dictionary DICTIONARY = new Dictionary();
 
     /**
@@ -57,6 +56,21 @@ public class DataFaker implements ExtensionPoint, Function<Function<String, Stri
      */
     public static DataFaker get() {
         return ExtensionList.lookupSingleton(DataFaker.class);
+    }
+
+    /**
+     * Maps MAC-derived bits to a dictionary word, guaranteed never to produce a negative index.
+     *
+     * <p>Uses {@code Math.floorMod} rather than {@code %} because Java's {@code %} operator
+     * takes the sign of the dividend, so a negative input yields a negative index.
+     * {@code floorMod} takes the sign of the divisor, guaranteeing a non-negative result
+     * for any input including {@code Long.MIN_VALUE}.
+     *
+     * @param macBits MAC-derived value to map to dictionary index
+     * @return dictionary word at the computed index
+     */
+    static String wordFor(long macBits) {
+        return DICTIONARY.word(Math.floorMod(macBits, DICTIONARY.size()));
     }
 
     /**
@@ -68,14 +82,16 @@ public class DataFaker implements ExtensionPoint, Function<Function<String, Stri
     @Override
     public Function<String, String> apply(@NonNull Function<String, String> nameTransformer) {
         return original -> {
-            String hex = PSEUDONYMS.mac(original).toLowerCase(Locale.ROOT);
-            // Index Dictionary directly rather than RandomNameGenerator.next() because next()
-            // computes Math.abs(pos + prime) % size and Math.abs(Integer.MIN_VALUE) is negative.
-            int index = (int) (Long.parseLong(hex.substring(0, 8), 16) % DICTIONARY.size());
-            String tail = hex.substring(8, 16);
+            byte[] mac = PSEUDONYMS.mac(original.getBytes(StandardCharsets.UTF_8));
+            // First 4 bytes for dictionary index, next 4 for the 8-hex-character tail
+            long idx = ((long) (mac[0] & 0xFF) << 24)
+                    | ((long) (mac[1] & 0xFF) << 16)
+                    | ((long) (mac[2] & 0xFF) << 8)
+                    | (mac[3] & 0xFF);
+            String tail = String.format("%02x%02x%02x%02x", mac[4] & 0xFF, mac[5] & 0xFF, mac[6] & 0xFF, mac[7] & 0xFF);
 
             String name = nameTransformer
-                    .apply(DICTIONARY.word(index))
+                    .apply(wordFor(idx))
                     .toLowerCase(Locale.ENGLISH)
                     .replace(' ', '_');
             return name + "_" + tail;

--- a/src/main/java/com/cloudbees/jenkins/support/filter/DataFaker.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/DataFaker.java
@@ -30,19 +30,24 @@ import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 import java.util.Locale;
 import java.util.function.Function;
-import java.util.function.Supplier;
+import jenkins.security.HMACConfidentialKey;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.randname.RandomNameGenerator;
 
 /**
- * Provides a way to generate random names.
+ * Provides deterministic pseudonym generation for anonymization.
+ *
+ * <p>Derives stable pseudonyms from originals using HMAC-keyed word pairs and hex tails.
+ * Same original always produces the same pseudonym across instances and over time.
  *
  * @since TODO
  */
 @Extension
 @Restricted(NoExternalUse.class)
-public class DataFaker implements ExtensionPoint, Function<Function<String, String>, Supplier<String>> {
+public class DataFaker implements ExtensionPoint, Function<Function<String, String>, Function<String, String>> {
+
+    private static final HMACConfidentialKey PSEUDONYMS = new HMACConfidentialKey(DataFaker.class, "pseudonyms");
 
     /**
      * @return the singleton instance
@@ -51,16 +56,27 @@ public class DataFaker implements ExtensionPoint, Function<Function<String, Stri
         return ExtensionList.lookupSingleton(DataFaker.class);
     }
 
-    private final RandomNameGenerator generator = new RandomNameGenerator();
-
     /**
-     * Applies the provided function to a random name and normalizes the result.
+     * Applies the provided function to a deterministic name derived from the original and normalizes the result.
+     *
+     * @param nameTransformer function to apply to the generated word pair (e.g., adds prefix like "user_")
+     * @return function that maps original strings to stable pseudonyms
      */
     @Override
-    public Supplier<String> apply(@NonNull Function<String, String> nameTransformer) {
-        return () -> nameTransformer
-                .apply(generator.next())
-                .toLowerCase(Locale.ENGLISH)
-                .replace(' ', '_');
+    public Function<String, String> apply(@NonNull Function<String, String> nameTransformer) {
+        return original -> {
+            String hex = PSEUDONYMS.mac(original);
+            // Masked because RandomNameGenerator computes Math.abs(pos + prime) % size, and
+            // Math.abs(Integer.MIN_VALUE) is negative, which would yield a negative word index.
+            int seed = (int) (Long.parseLong(hex.substring(0, 8), 16) & 0x0FFFFFFFL);
+            String tail = hex.substring(8, 16);
+
+            RandomNameGenerator generator = new RandomNameGenerator(seed);
+            String name = nameTransformer
+                    .apply(generator.next())
+                    .toLowerCase(Locale.ENGLISH)
+                    .replace(' ', '_');
+            return name + "_" + tail;
+        };
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/filter/DataFaker.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/DataFaker.java
@@ -39,7 +39,9 @@ import org.kohsuke.randname.Dictionary;
  * Provides deterministic pseudonym generation for anonymization.
  *
  * <p>Derives stable pseudonyms from originals using HMAC-keyed word pairs and hex tails.
- * Same original always produces the same pseudonym across instances and over time.
+ * Same original always produces the same pseudonym within one installation (stable across
+ * restarts and HA replicas sharing JENKINS_HOME). Deliberately differs across installations
+ * with different secret keys, preventing brute-force attacks on guessable originals.
  *
  * @since TODO
  */
@@ -66,7 +68,9 @@ public class DataFaker implements ExtensionPoint, Function<Function<String, Stri
     @Override
     public Function<String, String> apply(@NonNull Function<String, String> nameTransformer) {
         return original -> {
-            String hex = PSEUDONYMS.mac(original);
+            String hex = PSEUDONYMS.mac(original).toLowerCase(Locale.ROOT);
+            // Index Dictionary directly rather than RandomNameGenerator.next() because next()
+            // computes Math.abs(pos + prime) % size and Math.abs(Integer.MIN_VALUE) is negative.
             int index = (int) (Long.parseLong(hex.substring(0, 8), 16) % DICTIONARY.size());
             String tail = hex.substring(8, 16);
 

--- a/src/main/java/com/cloudbees/jenkins/support/filter/InetAddressContentFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/InetAddressContentFilter.java
@@ -90,6 +90,6 @@ public class InetAddressContentFilter implements ContentFilter {
 
     private static ContentMapping newMapping(String original) {
         return ContentMapping.of(
-                original, DataFaker.get().apply(name -> "ip_" + name).get());
+                original, DataFaker.get().apply(name -> "ip_" + name).apply(original));
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/filter/NameProvider.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/NameProvider.java
@@ -32,6 +32,7 @@ import hudson.model.Label;
 import hudson.model.User;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -48,9 +49,9 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 @Restricted(NoExternalUse.class)
 public class NameProvider implements ExtensionPoint {
     private final Supplier<Stream<String>> names;
-    private final Supplier<String> fakes;
+    private final Function<String, String> fakes;
 
-    private NameProvider(@NonNull Supplier<Stream<String>> names, @NonNull Supplier<String> fakes) {
+    private NameProvider(@NonNull Supplier<Stream<String>> names, @NonNull Function<String, String> fakes) {
         this.names = names;
         this.fakes = fakes;
     }
@@ -63,10 +64,13 @@ public class NameProvider implements ExtensionPoint {
     }
 
     /**
-     * @return a new fake name to use for anonymization
+     * Generates a stable pseudonym for the given original string.
+     *
+     * @param original the original string to anonymize
+     * @return a deterministic pseudonym derived from the original
      */
-    public @NonNull String generateFake() {
-        return fakes.get();
+    public @NonNull String generateFake(@NonNull String original) {
+        return fakes.apply(original);
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilter.java
@@ -100,7 +100,7 @@ public class SensitiveContentFilter implements ContentFilter {
                     // container)
                     if (!stopWords.contains(lowerCaseOriginal)) {
                         ContentMapping mapping = mappings.getMappingOrCreate(
-                                name, original -> ContentMapping.of(original, provider.generateFake()));
+                                name, original -> ContentMapping.of(original, provider.generateFake(original)));
                         // Matcher#appendReplacement needs to have the `\` and `$` escaped.
                         replacementsMap.putIfAbsent(
                                 lowerCaseOriginal,

--- a/src/test/java/com/cloudbees/jenkins/support/filter/DataFakerTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/filter/DataFakerTest.java
@@ -1,0 +1,179 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.support.filter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+import jenkins.security.HMACConfidentialKey;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.kohsuke.randname.RandomNameGenerator;
+
+@WithJenkins
+class DataFakerTest {
+
+    @Test
+    void pseudonymsMatchExpectedFormat(JenkinsRule r) {
+        DataFaker faker = new DataFaker();
+        Pattern expectedPattern = Pattern.compile("^[a-z]+_[a-z_-]+_[0-9a-f]{8}$");
+
+        for (int i = 0; i < 100; i++) {
+            String pseudonym = faker.apply(name -> "user_" + name).apply("test" + i);
+            assertTrue(
+                    expectedPattern.matcher(pseudonym).matches(),
+                    "Pseudonym '" + pseudonym + "' does not match expected format");
+        }
+    }
+
+    @Test
+    void tailIsExactlyEightHexChars(JenkinsRule r) {
+        DataFaker faker = new DataFaker();
+
+        for (int i = 0; i < 100; i++) {
+            String pseudonym = faker.apply(name -> "user_" + name).apply("test" + i);
+            assertTrue(pseudonym.matches("^.+_[0-9a-f]{8}$"), "Pseudonym should end with underscore and 8 hex chars");
+
+            String tail = pseudonym.substring(pseudonym.lastIndexOf('_') + 1);
+            assertEquals(8, tail.length(), "Tail should be exactly 8 characters");
+            assertTrue(tail.matches("[0-9a-f]{8}"), "Tail should be 8 lowercase hex characters");
+        }
+    }
+
+    @Test
+    void deterministicPseudonymGeneration(JenkinsRule r) {
+        DataFaker faker = new DataFaker();
+        String original = "testuser";
+
+        String pseudonym1 = faker.apply(name -> "user_" + name).apply(original);
+        String pseudonym2 = faker.apply(name -> "user_" + name).apply(original);
+
+        assertEquals(pseudonym1, pseudonym2, "Same original should produce identical pseudonym");
+    }
+
+    @Test
+    void orderIndependence(JenkinsRule r) {
+        DataFaker faker1 = new DataFaker();
+        String original1 = "foo";
+        String original2 = "bar";
+
+        String foo1 = faker1.apply(name -> "user_" + name).apply(original1);
+        String bar1 = faker1.apply(name -> "user_" + name).apply(original2);
+
+        DataFaker faker2 = new DataFaker();
+        String bar2 = faker2.apply(name -> "user_" + name).apply(original2);
+        String foo2 = faker2.apply(name -> "user_" + name).apply(original1);
+
+        assertEquals(foo1, foo2, "Order of minting should not affect pseudonym for 'foo'");
+        assertEquals(bar1, bar2, "Order of minting should not affect pseudonym for 'bar'");
+    }
+
+    @Test
+    void collisionSanityCheck(JenkinsRule r) {
+        DataFaker faker = new DataFaker();
+        Set<String> pseudonyms = new HashSet<>();
+        int iterations = 200000;
+
+        for (int i = 0; i < iterations; i++) {
+            String pseudonym = faker.apply(name -> "user_" + name).apply("original" + i);
+            pseudonyms.add(pseudonym);
+        }
+
+        assertEquals(iterations, pseudonyms.size(), "Expected zero collisions in " + iterations + " iterations");
+    }
+
+    @Test
+    void legacyPseudonymPreservation(JenkinsRule r) {
+        ContentMappings mappings = ContentMappings.get();
+        String original = "testuser";
+        String legacyPseudonym = "user_sad_cat";
+
+        ContentMapping legacyMapping = ContentMapping.of(original, legacyPseudonym);
+        mappings.getMappingOrCreate(original, o -> legacyMapping);
+
+        ContentMapping retrieved = mappings.getMappingOrCreate(
+                original,
+                o -> ContentMapping.of(
+                        o, DataFaker.get().apply(name -> "user_" + name).apply(o)));
+
+        assertEquals(legacyPseudonym, retrieved.getReplacement(), "Legacy pseudonym should be preserved");
+    }
+
+    @Test
+    void seedOverflowRegression(JenkinsRule r) {
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> new RandomNameGenerator(2144220205).next(),
+                "Seed 2144220205 causes pos+prime overflow, yielding negative index");
+
+        long hazardousSeed = 2144220205L;
+        long mask = 0x0FFFFFFFL;
+        String[] testInputs = {"00000000", "7fffffff", String.format("%08x", hazardousSeed), "ffffffff"};
+
+        for (String hexInput : testInputs) {
+            long value = Long.parseLong(hexInput, 16);
+            long masked = value & mask;
+
+            assertTrue(
+                    masked <= mask,
+                    String.format("Masked value %d exceeds mask bound %d for input %s", masked, mask, hexInput));
+            assertNotEquals(
+                    hazardousSeed,
+                    masked,
+                    String.format("Masked value equals hazardous seed %d for input %s", hazardousSeed, hexInput));
+        }
+
+        DataFaker faker = new DataFaker();
+        for (int i = 0; i < 1000; i++) {
+            faker.apply(name -> "user_" + name).apply("test" + i);
+        }
+    }
+
+    @Test
+    void keyedPseudonyms(JenkinsRule r) {
+        HMACConfidentialKey key1 = new HMACConfidentialKey(DataFaker.class, "pseudonyms");
+        HMACConfidentialKey key2 = new HMACConfidentialKey(DataFaker.class, "something-else");
+
+        String original = "testuser";
+        String mac1 = key1.mac(original);
+        String mac2 = key2.mac(original);
+
+        assertNotEquals(mac1, mac2, "Different keys should produce different MACs for same original");
+    }
+
+    @Test
+    void macLengthSufficient(JenkinsRule r) {
+        HMACConfidentialKey key = new HMACConfidentialKey(DataFaker.class, "pseudonyms");
+        String mac = key.mac("test");
+
+        assertTrue(
+                mac.length() >= 16,
+                "MAC must be at least 16 hex chars to safely extract seed (8 chars) and tail (8 chars). Got: "
+                        + mac.length());
+        assertEquals(64, mac.length(), "Full HMAC-SHA256 should be 64 hex chars (32 bytes)");
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/support/filter/DataFakerTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/filter/DataFakerTest.java
@@ -124,27 +124,23 @@ class DataFakerTest {
     }
 
     @Test
-    void seedOverflowRegression(JenkinsRule r) {
+    void avoidsLibraryCursorHazard(JenkinsRule r) {
         assertThrows(
                 IndexOutOfBoundsException.class,
                 () -> new RandomNameGenerator(2144220205).next(),
-                "Seed 2144220205 causes pos+prime overflow, yielding negative index");
+                "Seed 2144220205 causes pos+prime overflow in RandomNameGenerator, yielding negative index");
 
-        long hazardousSeed = 2144220205L;
-        long mask = 0x0FFFFFFFL;
-        String[] testInputs = {"00000000", "7fffffff", String.format("%08x", hazardousSeed), "ffffffff"};
+        org.kohsuke.randname.Dictionary dict = new org.kohsuke.randname.Dictionary();
+        int dictSize = dict.size();
+        String[] testInputs = {"00000000", "ffffffff"};
 
         for (String hexInput : testInputs) {
             long value = Long.parseLong(hexInput, 16);
-            long masked = value & mask;
+            long index = value % dictSize;
 
             assertTrue(
-                    masked <= mask,
-                    String.format("Masked value %d exceeds mask bound %d for input %s", masked, mask, hexInput));
-            assertNotEquals(
-                    hazardousSeed,
-                    masked,
-                    String.format("Masked value equals hazardous seed %d for input %s", hazardousSeed, hexInput));
+                    index >= 0 && index < dictSize,
+                    String.format("Index %d not in [0, %d) for input %s", index, dictSize, hexInput));
         }
 
         DataFaker faker = new DataFaker();

--- a/src/test/java/com/cloudbees/jenkins/support/filter/DataFakerTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/filter/DataFakerTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2018, CloudBees, Inc.
+ * Copyright (c) 2026, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,20 +25,24 @@ package com.cloudbees.jenkins.support.filter;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import hudson.ExtensionList;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
-import jenkins.security.HMACConfidentialKey;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.JenkinsSessionExtension;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.jvnet.hudson.test.recipes.LocalData;
 
 @WithJenkins
 class DataFakerTest {
 
     @Test
     void pseudonymsMatchExpectedFormat(JenkinsRule r) {
-        DataFaker faker = new DataFaker();
+        DataFaker faker = ExtensionList.lookupSingleton(DataFaker.class);
         Pattern expectedPattern = Pattern.compile("^[a-z]+_[a-z_-]+_[0-9a-f]{8}$");
 
         for (int i = 0; i < 100; i++) {
@@ -51,39 +55,47 @@ class DataFakerTest {
 
     @Test
     void tailIsExactlyEightHexChars(JenkinsRule r) {
-        DataFaker faker = new DataFaker();
+        DataFaker faker = ExtensionList.lookupSingleton(DataFaker.class);
 
         for (int i = 0; i < 100; i++) {
             String pseudonym = faker.apply(name -> "user_" + name).apply("test" + i);
-            assertTrue(pseudonym.matches("^.+_[0-9a-f]{8}$"), "Pseudonym should end with underscore and 8 hex chars");
-
             String tail = pseudonym.substring(pseudonym.lastIndexOf('_') + 1);
-            assertEquals(8, tail.length(), "Tail should be exactly 8 characters");
             assertTrue(tail.matches("[0-9a-f]{8}"), "Tail should be 8 lowercase hex characters");
         }
     }
 
-    @Test
-    void deterministicPseudonymGeneration(JenkinsRule r) {
-        DataFaker faker = new DataFaker();
-        String original = "testuser";
+    @Nested
+    class SessionTests {
+        @RegisterExtension
+        JenkinsSessionExtension session = new JenkinsSessionExtension();
 
-        String pseudonym1 = faker.apply(name -> "user_" + name).apply(original);
-        String pseudonym2 = faker.apply(name -> "user_" + name).apply(original);
+        @Test
+        void deterministicPseudonymGenerationAcrossRestarts() throws Throwable {
+            String[] holder = new String[1];
 
-        assertEquals(pseudonym1, pseudonym2, "Same original should produce identical pseudonym");
+            session.then(r -> {
+                DataFaker faker = ExtensionList.lookupSingleton(DataFaker.class);
+                holder[0] = faker.apply(name -> "user_" + name).apply("testuser");
+            });
+
+            session.then(r -> {
+                DataFaker faker = ExtensionList.lookupSingleton(DataFaker.class);
+                String pseudonym2 = faker.apply(name -> "user_" + name).apply("testuser");
+                assertEquals(holder[0], pseudonym2, "Same original should produce identical pseudonym across restarts");
+            });
+        }
     }
 
     @Test
     void orderIndependence(JenkinsRule r) {
-        DataFaker faker1 = new DataFaker();
+        DataFaker faker1 = ExtensionList.lookupSingleton(DataFaker.class);
         String original1 = "foo";
         String original2 = "bar";
 
         String foo1 = faker1.apply(name -> "user_" + name).apply(original1);
         String bar1 = faker1.apply(name -> "user_" + name).apply(original2);
 
-        DataFaker faker2 = new DataFaker();
+        DataFaker faker2 = ExtensionList.lookupSingleton(DataFaker.class);
         String bar2 = faker2.apply(name -> "user_" + name).apply(original2);
         String foo2 = faker2.apply(name -> "user_" + name).apply(original1);
 
@@ -93,7 +105,7 @@ class DataFakerTest {
 
     @Test
     void collisionSanityCheck(JenkinsRule r) {
-        DataFaker faker = new DataFaker();
+        DataFaker faker = ExtensionList.lookupSingleton(DataFaker.class);
         Set<String> pseudonyms = new HashSet<>();
         int iterations = 200000;
 
@@ -105,14 +117,12 @@ class DataFakerTest {
         assertEquals(iterations, pseudonyms.size(), "Expected zero collisions in " + iterations + " iterations");
     }
 
+    @LocalData
     @Test
     void legacyPseudonymPreservation(JenkinsRule r) {
         ContentMappings mappings = ContentMappings.get();
         String original = "testuser";
         String legacyPseudonym = "user_sad_cat";
-
-        ContentMapping legacyMapping = ContentMapping.of(original, legacyPseudonym);
-        mappings.getMappingOrCreate(original, o -> legacyMapping);
 
         ContentMapping retrieved = mappings.getMappingOrCreate(
                 original,
@@ -123,26 +133,12 @@ class DataFakerTest {
     }
 
     @Test
-    void keyedPseudonyms(JenkinsRule r) {
-        HMACConfidentialKey key1 = new HMACConfidentialKey(DataFaker.class, "pseudonyms");
-        HMACConfidentialKey key2 = new HMACConfidentialKey(DataFaker.class, "something-else");
-
-        String original = "testuser";
-        String mac1 = key1.mac(original);
-        String mac2 = key2.mac(original);
-
-        assertNotEquals(mac1, mac2, "Different keys should produce different MACs for same original");
-    }
-
-    @Test
-    void macLengthSufficient(JenkinsRule r) {
-        HMACConfidentialKey key = new HMACConfidentialKey(DataFaker.class, "pseudonyms");
-        String mac = key.mac("test");
-
-        assertTrue(
-                mac.length() >= 16,
-                "MAC must be at least 16 hex chars to safely extract seed (8 chars) and tail (8 chars). Got: "
-                        + mac.length());
-        assertEquals(64, mac.length(), "Full HMAC-SHA256 should be 64 hex chars (32 bytes)");
+    void floorModGuaranteesNonNegativeIndices(JenkinsRule r) {
+        // Guards against negative-index bugs: Java's % takes the sign of the dividend,
+        // so wordFor must use floorMod to guarantee non-negative results for any input.
+        for (long hostile : new long[] {Long.MIN_VALUE, -1L, Integer.MIN_VALUE, 0L, 0xFFFFFFFFL, Long.MAX_VALUE}) {
+            String word = DataFaker.wordFor(hostile); // must not throw
+            assertNotNull(word, "hostile input " + hostile);
+        }
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/support/filter/DataFakerTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/filter/DataFakerTest.java
@@ -32,7 +32,6 @@ import jenkins.security.HMACConfidentialKey;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
-import org.kohsuke.randname.RandomNameGenerator;
 
 @WithJenkins
 class DataFakerTest {
@@ -121,32 +120,6 @@ class DataFakerTest {
                         o, DataFaker.get().apply(name -> "user_" + name).apply(o)));
 
         assertEquals(legacyPseudonym, retrieved.getReplacement(), "Legacy pseudonym should be preserved");
-    }
-
-    @Test
-    void avoidsLibraryCursorHazard(JenkinsRule r) {
-        assertThrows(
-                IndexOutOfBoundsException.class,
-                () -> new RandomNameGenerator(2144220205).next(),
-                "Seed 2144220205 causes pos+prime overflow in RandomNameGenerator, yielding negative index");
-
-        org.kohsuke.randname.Dictionary dict = new org.kohsuke.randname.Dictionary();
-        int dictSize = dict.size();
-        String[] testInputs = {"00000000", "ffffffff"};
-
-        for (String hexInput : testInputs) {
-            long value = Long.parseLong(hexInput, 16);
-            long index = value % dictSize;
-
-            assertTrue(
-                    index >= 0 && index < dictSize,
-                    String.format("Index %d not in [0, %d) for input %s", index, dictSize, hexInput));
-        }
-
-        DataFaker faker = new DataFaker();
-        for (int i = 0; i < 1000; i++) {
-            faker.apply(name -> "user_" + name).apply("test" + i);
-        }
     }
 
     @Test

--- a/src/test/resources/com/cloudbees/jenkins/support/filter/DataFakerTest/legacyPseudonymPreservation/com.cloudbees.jenkins.support.filter.ContentMappings.xml
+++ b/src/test/resources/com/cloudbees/jenkins/support/filter/DataFakerTest/legacyPseudonymPreservation/com.cloudbees.jenkins.support.filter.ContentMappings.xml
@@ -1,0 +1,10 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<com.cloudbees.jenkins.support.filter.ContentMappings resolves-to="com.cloudbees.jenkins.support.filter.ContentMappings$XmlProxy">
+  <stopWords/>
+  <mappings>
+    <com.cloudbees.jenkins.support.filter.ContentMapping resolves-to="com.cloudbees.jenkins.support.filter.ContentMapping$SerializationProxy">
+      <original>testuser</original>
+      <replacement>user_sad_cat</replacement>
+    </com.cloudbees.jenkins.support.filter.ContentMapping>
+  </mappings>
+</com.cloudbees.jenkins.support.filter.ContentMappings>


### PR DESCRIPTION
Pseudonyms are an `adjective_noun` pair drawn from `wordnet-random-name`, so only 611 * 2407 = 1,470,677 distinct values exist. `RandomNameGenerator.next()` walks a cursor (`pos = Math.abs(pos + prime) % size`, and `gcd(prime, size) == 1`), making it an exact permutation: collision-free until it exhausts the space, then it repeats in the same order. Tables larger than that reuse pseudonyms, and nothing checks `getReplacement()` for uniqueness - two distinct originals render identically, and reversing a pseudonym through the mappings table is ambiguous.

A pseudonym is a function of *when* an original was first seen - its position in the cursor walk - not of the original itself, and the walk starts at `System.currentTimeMillis()`. So the same original gets a different pseudonym on another instance, or after the mappings file is lost.

Both parts now derive from `HMACConfidentialKey.mac(byte[])`. The new 8-character hex tail carries the uniqueness - a third word would still leave ~1000 expected collisions at 1.5M entries, since hashing costs you the cursor's collision-freedom and puts you on the birthday bound - while the word pair stays for readability. Keying it from the instance secret is load-bearing: an unsalted hash would let anyone holding a bundle brute-force guessable names.

Existing mappings are untouched. `getMappingOrCreate` does `computeIfAbsent(original, generator)`, and the map is keyed by original, so the generator never runs for an original already in the table - already-minted pseudonyms are preserved and a table just holds a mix of both formats.

That does mean reproducibility only applies to newly-minted entries. A pre-existing original keeps whatever random pseudonym it was given, so two instances that already have divergent entries for it stay divergent, and losing the mappings file re-mints it to a stable but different value. Neither is a regression - both cases produce a random value today - but the guarantee arrives as entries turn over rather than retroactively. The same is true of collisions: a table that has already exhausted the namespace keeps whatever duplicate pseudonyms it accumulated, since those entries are preserved. Widening the namespace prevents new collisions rather than resolving existing ones - clearing the mappings file is the only way to retire them, at the cost of every pseudonym changing.

Two `@Restricted(NoExternalUse.class)` signatures change rather than gaining overloads: `DataFaker.apply` differs only in return type so it can't be overloaded, and a no-arg `NameProvider.generateFake()` can't satisfy the reproducibility invariant - it could only return something random, which is the bug. 

### From review

The MAC is now sized to what it uses. An 8-byte MAC is requested via the three-argument constructor and all of it is consumed: four bytes for the dictionary index, four for the hex tail. Previously a full 256-bit MAC was requested and 64 bits used.

Four bytes rather than three for the index also removes a modulo bias: 2^24 over a 1,470,677-word dictionary left some words roughly 9% likelier than others, where 2^32 brings that to about 0.03%.

The index derivation is funnelled through one method using `Math.floorMod`, which takes the sign of the divisor and therefore cannot return a negative index for any input. Java's `%` takes the sign of the *dividend*, which is the same trapdoor behind the library's own `Math.abs(Integer.MIN_VALUE)` path — reachable there because `Math.abs` returns `Integer.MIN_VALUE` unchanged. A test feeds hostile values straight to that method and fails with `IndexOutOfBoundsException` if `floorMod` is reverted to `%`.

On `Dictionary.INSTANCE` — it is package-private, so constructing our own `Dictionary` is the only option without reflection. `javap -p` confirms: the class, its no-argument constructor, `size()` and `word(int)` are all public; `INSTANCE` is not.

Determinism is now proven across an actual restart via `JenkinsSessionExtension` rather than within a single JVM, which is the property being claimed. The two tests exercising `HMACConfidentialKey` rather than this class are gone.

Fixes #985

### Related

Five PRs from the same pass over the anonymization code, plus the original report in #811:

- #980
- #984
- #986 *(this one)*
- #987
- #988
