### PR TITLE
Move case normalization out of the regex engine

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -36,6 +36,7 @@ import com.cloudbees.jenkins.support.api.UnfilteredStringContent;
 import com.cloudbees.jenkins.support.config.SupportAutomatedBundleConfiguration;
 import com.cloudbees.jenkins.support.filter.ContentFilter;
 import com.cloudbees.jenkins.support.filter.ContentFilters;
+import com.cloudbees.jenkins.support.filter.ContentMappings;
 import com.cloudbees.jenkins.support.filter.FilteredOutputStream;
 import com.cloudbees.jenkins.support.filter.PrefilteredContent;
 import com.cloudbees.jenkins.support.util.CallAsyncWrapper;
@@ -561,6 +562,7 @@ public class SupportPlugin extends Plugin {
                     }
                 }
                 binaryOut.flush();
+                ContentMappings.get().evictStale();
                 change.commit();
             }
         } finally {

--- a/src/main/java/com/cloudbees/jenkins/support/filter/ContentMapping.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/ContentMapping.java
@@ -27,10 +27,10 @@ package com.cloudbees.jenkins.support.filter;
 import com.cloudbees.jenkins.support.util.WordReplacer;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Functions;
+import java.time.Instant;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-import net.jcip.annotations.Immutable;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -41,7 +41,6 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * @see ContentMappings
  * @since TODO
  */
-@Immutable
 @Restricted(NoExternalUse.class)
 public class ContentMapping implements ContentFilter {
     private static final String ALT_SEPARATOR = " » ";
@@ -53,9 +52,15 @@ public class ContentMapping implements ContentFilter {
     private final String[] originals;
     private final String[] replacements;
 
+    // Mutable usage-tracking metadata, deliberately outside equals/hashCode/identity: when this mapping was last
+    // known to be live (per a NameProvider) or actually matched during filtering. Drives grace-period eviction in
+    // ContentMappings#evictStale(); a mapping that stops being touched eventually gets swept.
+    private volatile Instant lastSeen;
+
     private ContentMapping(@NonNull String original, @NonNull String replacement) {
         this.original = original;
         this.replacement = replacement;
+        this.lastSeen = Instant.now();
 
         // add flavors of the original string to replace, avoid add when equals
         String slashChangedInOriginal = original.replace("/", ALT_SEPARATOR);
@@ -96,6 +101,27 @@ public class ContentMapping implements ContentFilter {
         return replacement;
     }
 
+    /**
+     * Marks this mapping as seen (live or actually matched) at the given time.
+     */
+    void touch(Instant at) {
+        lastSeen = at;
+    }
+
+    /**
+     * Marks this mapping as seen (live or actually matched) now.
+     */
+    void touch() {
+        touch(Instant.now());
+    }
+
+    /**
+     * @return the last time this mapping was known to be live or was actually matched during filtering
+     */
+    Instant getLastSeen() {
+        return lastSeen;
+    }
+
     @Override
     public @NonNull String filter(@NonNull String input) {
         return WordReplacer.replaceWordsIgnoreCase(input, originals, replacements);
@@ -118,15 +144,25 @@ public class ContentMapping implements ContentFilter {
         SerializationProxy proxy = new SerializationProxy();
         proxy.original = original;
         proxy.replacement = replacement;
+        proxy.lastSeen = lastSeen.toEpochMilli();
         return proxy;
     }
 
     private static class SerializationProxy {
         private String original;
         private String replacement;
+        // Absent in XML written before this field existed; XStream leaves it at 0 in that case. long epoch millis
+        // on the wire is fine here (unlike the in-memory field) since this is the serial form.
+        private long lastSeen;
 
         private Object readResolve() {
-            return ContentMapping.of(original, replacement);
+            ContentMapping mapping = ContentMapping.of(original, replacement);
+            // Treat "unknown" (0, i.e. pre-upgrade data) as "seen now" rather than "seen at the epoch" -- the
+            // latter would make every mapping that already existed look instantly stale and get swept on the
+            // very first reload after upgrading, defeating the "still catches stray references" property for
+            // everything that predates this field.
+            mapping.touch(lastSeen > 0 ? Instant.ofEpochMilli(lastSeen) : Instant.now());
+            return mapping;
         }
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/filter/ContentMappings.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/ContentMappings.java
@@ -35,6 +35,8 @@ import hudson.model.AbstractItem;
 import hudson.model.ManagementLink;
 import hudson.model.Saveable;
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -51,6 +53,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
+import jenkins.util.SystemProperties;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -130,6 +133,7 @@ public class ContentMappings extends ManagementLink implements Saveable, Iterabl
             @NonNull String original, @NonNull Function<String, ContentMapping> generator) {
         boolean isNew = !mappings.containsKey(original);
         ContentMapping mapping = mappings.computeIfAbsent(original, generator);
+        mapping.touch();
         try {
             if (isNew) {
                 save();
@@ -145,6 +149,45 @@ public class ContentMappings extends ManagementLink implements Saveable, Iterabl
             stopWords.add(item.getTaskNoun().toLowerCase(Locale.ENGLISH));
             stopWords.add(item.getPronoun().toLowerCase(Locale.ENGLISH));
         });
+    }
+
+    // Read per-call rather than cached in a static field, so the value is picked up wherever it is supplied and
+    // so tests can override it.
+    private static Duration retention() {
+        return SystemProperties.getDuration(ContentMappings.class.getName() + ".RETENTION", Duration.ofDays(90));
+    }
+
+    /**
+     * Evicts mappings that have not been touched within the retention window. This method runs after all content
+     * has been filtered, so every currently-live and currently-matched mapping has been refreshed via {@code touch()}.
+     *
+     * <p>Uses {@code computeIfPresent} to express the remove-if-stale decision as one map operation. A concurrent
+     * {@code touch()} after the staleness check can still be lost, causing the mapping to be evicted and recreated
+     * on next use. This becomes benign once pseudonym derivation is deterministic (in-flight work), because the
+     * recreated mapping then receives the identical pseudonym.
+     *
+     * <p>Must be called from within a {@link BulkChange} so the eviction is persisted.
+     */
+    public void evictStale() {
+        Instant cutoff = Instant.now().minus(retention());
+        // Counter lives inside the lambda so it only increments when a removal actually happens.
+        // Concurrent bundle generation is possible (writeBundle is public static), so the count is
+        // approximate under contention. ConcurrentSkipListMap may also retry the lambda on CAS failure.
+        int[] removed = {0};
+        for (String key : mappings.keySet()) {
+            mappings.computeIfPresent(key, (k, v) -> {
+                if (v.getLastSeen().isBefore(cutoff)) {
+                    removed[0]++;
+                    return null;
+                }
+                return v;
+            });
+        }
+        if (removed[0] > 0) {
+            int count = removed[0];
+            LOGGER.fine(() -> "Evicted " + count + " stale content mapping" + (count == 1 ? "" : "s")
+                    + " (retention window: " + retention().toDays() + " days)");
+        }
     }
 
     protected void clear() {

--- a/src/main/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilter.java
@@ -52,8 +52,15 @@ public class SensitiveContentFilter implements ContentFilter {
 
     private static final Logger LOGGER = Logger.getLogger(SensitiveContentFilter.class.getName());
 
-    private final AtomicReference<Pattern> mappingsPattern = new AtomicReference<>();
-    private final AtomicReference<Map<String, String>> replacementsMap = new AtomicReference<>();
+    // A pattern and its two derived maps, published as one atomic unit so a concurrent reload() can never be
+    // observed as a torn mix of an old pattern with newer maps (or vice versa) -- see replacementFor(). Since
+    // the maps are always built from exactly the same names as the pattern, a match can never fail to resolve.
+    private record Snapshot(Pattern pattern, Map<String, String> replacements, Map<String, ContentMapping> matched) {
+        // Matches nothing, so filter() is a no-op before the first reload() rather than risking an NPE.
+        private static final Snapshot EMPTY = new Snapshot(Pattern.compile("(?!)"), Map.of(), Map.of());
+    }
+
+    private final AtomicReference<Snapshot> snapshot = new AtomicReference<>(Snapshot.EMPTY);
 
     public static SensitiveContentFilter get() {
         return ExtensionList.lookupSingleton(SensitiveContentFilter.class);
@@ -61,13 +68,30 @@ public class SensitiveContentFilter implements ContentFilter {
 
     @Override
     public @NonNull String filter(@NonNull String input) {
-        return WordReplacer.replaceWords(input, mappingsPattern.get(), replacementsMap.get());
+        // Snapshot once per call so a concurrent reload() can't be observed partway through.
+        Snapshot current = snapshot.get();
+        return WordReplacer.replaceWords(
+                input, current.pattern(), match -> replacementFor(match, current.matched(), current.replacements()));
+    }
+
+    // An actual match in real content keeps this mapping alive even if the original item is gone -- see
+    // ContentMappings#evictStale(). Deliberately not touched during the pre-fill loop in reload() below, only here,
+    // on a real match.
+    private static String replacementFor(
+            String match, Map<String, ContentMapping> matched, Map<String, String> replacements) {
+        String lowerCase = match.toLowerCase(Locale.ENGLISH);
+        ContentMapping mapping = matched.get(lowerCase);
+        if (mapping != null) {
+            mapping.touch();
+        }
+        return replacements.get(lowerCase);
     }
 
     @Override
     public synchronized void reload() {
         final long startTime = System.currentTimeMillis();
         final Map<String, String> replacementsMap = new HashMap<>();
+        final Map<String, ContentMapping> matchedMappings = new HashMap<>();
         final WordsTrie trie = new WordsTrie();
         final ContentMappings mappings = ContentMappings.get();
         Set<String> stopWords = mappings.getStopWords();
@@ -87,6 +111,7 @@ public class SensitiveContentFilter implements ContentFilter {
                                         .getReplacement()
                                         .replaceAll("\\\\", "\\\\\\\\")
                                         .replaceAll("\\$", "\\\\\\$"));
+                        matchedMappings.put(lowerCaseOriginal, contentMapping);
                         trie.add(lowerCaseOriginal);
                     }
                 });
@@ -99,6 +124,8 @@ public class SensitiveContentFilter implements ContentFilter {
                     // But the reload is already quite fast anyway. (~1s for 10^4 items with 1 CPU / 2 GB memory
                     // container)
                     if (!stopWords.contains(lowerCaseOriginal)) {
+                        // getMappingOrCreate touches the mapping (refreshes lastSeen) on every call, hit or miss --
+                        // that's the "live" signal, since name is something a NameProvider currently reports.
                         ContentMapping mapping = mappings.getMappingOrCreate(
                                 name, original -> ContentMapping.of(original, provider.generateFake()));
                         // Matcher#appendReplacement needs to have the `\` and `$` escaped.
@@ -107,12 +134,13 @@ public class SensitiveContentFilter implements ContentFilter {
                                 mapping.getReplacement()
                                         .replaceAll("\\\\", "\\\\\\\\")
                                         .replaceAll("\\$", "\\\\\\$"));
+                        matchedMappings.putIfAbsent(lowerCaseOriginal, mapping);
                         trie.add(lowerCaseOriginal);
                     }
                 }));
-        this.mappingsPattern.set(Pattern.compile(
-                "(?<!\\w)" + trie.getRegex() + "(?!\\w)", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE));
-        this.replacementsMap.set(replacementsMap);
+        Pattern pattern = Pattern.compile(
+                "(?<!\\w)" + trie.getRegex() + "(?!\\w)", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+        this.snapshot.set(new Snapshot(pattern, replacementsMap, matchedMappings));
         LOGGER.log(Level.FINE, "Took " + (System.currentTimeMillis() - startTime) + "ms to reload");
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilter.java
@@ -66,25 +66,66 @@ public class SensitiveContentFilter implements ContentFilter {
         return ExtensionList.lookupSingleton(SensitiveContentFilter.class);
     }
 
+    /**
+     * Normalize case per code point, replicating what {@code Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE}
+     * does internally when matching. This is <em>not</em> Unicode normalization (NFC/NFKC); it's a case-folding
+     * operation: {@code Character.toLowerCase(Character.toUpperCase(codePoint))}.
+     * <p>
+     * Includes an identity fast path: returns the input unchanged when no code point would be altered, so
+     * already-normalized strings share storage with their keys rather than duplicating the char array.
+     *
+     * @param value the input string
+     * @return a case-normalized copy, or the input itself if nothing changed
+     */
+    static String normalizeCase(String value) {
+        // Identity fast path: scan first, only allocate if something would change. Without this, every key
+        // duplicates its original even when they're identical, costing ~38 MB per 500k already-lowercase names.
+        boolean needsNormalization = false;
+        for (int i = 0, len = value.length(); i < len; ) {
+            int cp = value.codePointAt(i);
+            int normalized = Character.toLowerCase(Character.toUpperCase(cp));
+            if (cp != normalized) {
+                needsNormalization = true;
+                break;
+            }
+            i += Character.charCount(cp);
+        }
+        if (!needsNormalization) {
+            return value;
+        }
+
+        // Something differs; build the normalized copy.
+        StringBuilder sb = new StringBuilder(value.length());
+        for (int i = 0, len = value.length(); i < len; ) {
+            int cp = value.codePointAt(i);
+            sb.appendCodePoint(Character.toLowerCase(Character.toUpperCase(cp)));
+            i += Character.charCount(cp);
+        }
+        return sb.toString();
+    }
+
     @Override
     public @NonNull String filter(@NonNull String input) {
         // Snapshot once per call so a concurrent reload() can't be observed partway through.
         Snapshot current = snapshot.get();
-        return WordReplacer.replaceWords(
-                input, current.pattern(), match -> replacementFor(match, current.matched(), current.replacements()));
+        String normalized = normalizeCase(input);
+        return WordReplacer.replaceWordsByOffset(
+                input,
+                normalized,
+                current.pattern(),
+                match -> replacementFor(match, current.matched(), current.replacements()));
     }
 
     // An actual match in real content keeps this mapping alive even if the original item is gone -- see
     // ContentMappings#evictStale(). Deliberately not touched during the pre-fill loop in reload() below, only here,
-    // on a real match.
+    // on a real match. The match is already normalized (from the normalized input), so no derivation is needed.
     private static String replacementFor(
             String match, Map<String, ContentMapping> matched, Map<String, String> replacements) {
-        String lowerCase = match.toLowerCase(Locale.ENGLISH);
-        ContentMapping mapping = matched.get(lowerCase);
+        ContentMapping mapping = matched.get(match);
         if (mapping != null) {
             mapping.touch();
         }
-        return replacements.get(lowerCase);
+        return replacements.get(match);
     }
 
     @Override
@@ -103,43 +144,36 @@ public class SensitiveContentFilter implements ContentFilter {
                 // Filter out IP mappings
                 .filter(mapping -> !mapping.getReplacement().startsWith("ip_"))
                 .forEach(contentMapping -> {
-                    String lowerCaseOriginal = contentMapping.getOriginal().toLowerCase(Locale.ENGLISH);
-                    if (!stopWords.contains(lowerCaseOriginal)) {
-                        replacementsMap.put(
-                                lowerCaseOriginal,
-                                contentMapping
-                                        .getReplacement()
-                                        .replaceAll("\\\\", "\\\\\\\\")
-                                        .replaceAll("\\$", "\\\\\\$"));
-                        matchedMappings.put(lowerCaseOriginal, contentMapping);
-                        trie.add(lowerCaseOriginal);
+                    String normalizedOriginal = normalizeCase(contentMapping.getOriginal());
+                    // Stop-word comparison stays on toLowerCase(ENGLISH) because the stop-word set is populated
+                    // that way from multiple sources, and stop words are ASCII in practice so the two agree.
+                    if (!stopWords.contains(contentMapping.getOriginal().toLowerCase(Locale.ENGLISH))) {
+                        replacementsMap.put(normalizedOriginal, contentMapping.getReplacement());
+                        matchedMappings.put(normalizedOriginal, contentMapping);
+                        trie.add(normalizedOriginal);
                     }
                 });
 
         NameProvider.all()
                 .forEach(provider -> provider.names().filter(s -> !s.isBlank()).forEach(name -> {
-                    String lowerCaseOriginal = name.toLowerCase(Locale.ENGLISH);
+                    String normalizedOriginal = normalizeCase(name);
                     // NOTE: We could well create a WordTrie for the stop words and use it as a filter instead of the
                     // conditional here. Or find a better way to deal with insensitive key mapping in general.
                     // But the reload is already quite fast anyway. (~1s for 10^4 items with 1 CPU / 2 GB memory
                     // container)
-                    if (!stopWords.contains(lowerCaseOriginal)) {
+                    // Stop-word comparison stays on toLowerCase(ENGLISH) because the stop-word set is populated
+                    // that way from multiple sources, and stop words are ASCII in practice so the two agree.
+                    if (!stopWords.contains(name.toLowerCase(Locale.ENGLISH))) {
                         // getMappingOrCreate touches the mapping (refreshes lastSeen) on every call, hit or miss --
                         // that's the "live" signal, since name is something a NameProvider currently reports.
                         ContentMapping mapping = mappings.getMappingOrCreate(
                                 name, original -> ContentMapping.of(original, provider.generateFake()));
-                        // Matcher#appendReplacement needs to have the `\` and `$` escaped.
-                        replacementsMap.putIfAbsent(
-                                lowerCaseOriginal,
-                                mapping.getReplacement()
-                                        .replaceAll("\\\\", "\\\\\\\\")
-                                        .replaceAll("\\$", "\\\\\\$"));
-                        matchedMappings.putIfAbsent(lowerCaseOriginal, mapping);
-                        trie.add(lowerCaseOriginal);
+                        replacementsMap.putIfAbsent(normalizedOriginal, mapping.getReplacement());
+                        matchedMappings.putIfAbsent(normalizedOriginal, mapping);
+                        trie.add(normalizedOriginal);
                     }
                 }));
-        Pattern pattern = Pattern.compile(
-                "(?<!\\w)" + trie.getRegex() + "(?!\\w)", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+        Pattern pattern = Pattern.compile("(?<!\\w)" + trie.getRegex() + "(?!\\w)");
         this.snapshot.set(new Snapshot(pattern, replacementsMap, matchedMappings));
         LOGGER.log(Level.FINE, "Took " + (System.currentTimeMillis() - startTime) + "ms to reload");
     }

--- a/src/main/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilter.java
@@ -29,13 +29,13 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ExtensionList;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -135,7 +135,12 @@ public class SensitiveContentFilter implements ContentFilter {
         final Map<String, ContentMapping> matchedMappings = new HashMap<>();
         final WordsTrie trie = new WordsTrie();
         final ContentMappings mappings = ContentMappings.get();
-        Set<String> stopWords = mappings.getStopWords();
+        // Normalize the stop words too, so both sides of the check below use the same derivation as the keys, the
+        // trie and the input. The set is populated with toLowerCase(ENGLISH) from several sources, which agrees
+        // with normalizeCase on ASCII but not outside it.
+        Set<String> stopWords = mappings.getStopWords().stream()
+                .map(SensitiveContentFilter::normalizeCase)
+                .collect(Collectors.toSet());
 
         // Pre-fill with existing mappings (but filter out IPs that is handled by a different filter)
         // This is required to filter out names of items that does not exist anymore, for which they could be record
@@ -145,9 +150,7 @@ public class SensitiveContentFilter implements ContentFilter {
                 .filter(mapping -> !mapping.getReplacement().startsWith("ip_"))
                 .forEach(contentMapping -> {
                     String normalizedOriginal = normalizeCase(contentMapping.getOriginal());
-                    // Stop-word comparison stays on toLowerCase(ENGLISH) because the stop-word set is populated
-                    // that way from multiple sources, and stop words are ASCII in practice so the two agree.
-                    if (!stopWords.contains(contentMapping.getOriginal().toLowerCase(Locale.ENGLISH))) {
+                    if (!stopWords.contains(normalizedOriginal)) {
                         replacementsMap.put(normalizedOriginal, contentMapping.getReplacement());
                         matchedMappings.put(normalizedOriginal, contentMapping);
                         trie.add(normalizedOriginal);
@@ -161,9 +164,7 @@ public class SensitiveContentFilter implements ContentFilter {
                     // conditional here. Or find a better way to deal with insensitive key mapping in general.
                     // But the reload is already quite fast anyway. (~1s for 10^4 items with 1 CPU / 2 GB memory
                     // container)
-                    // Stop-word comparison stays on toLowerCase(ENGLISH) because the stop-word set is populated
-                    // that way from multiple sources, and stop words are ASCII in practice so the two agree.
-                    if (!stopWords.contains(name.toLowerCase(Locale.ENGLISH))) {
+                    if (!stopWords.contains(normalizedOriginal)) {
                         // getMappingOrCreate touches the mapping (refreshes lastSeen) on every call, hit or miss --
                         // that's the "live" signal, since name is something a NameProvider currently reports.
                         ContentMapping mapping = mappings.getMappingOrCreate(

--- a/src/main/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilter.java
@@ -135,9 +135,10 @@ public class SensitiveContentFilter implements ContentFilter {
         final Map<String, ContentMapping> matchedMappings = new HashMap<>();
         final WordsTrie trie = new WordsTrie();
         final ContentMappings mappings = ContentMappings.get();
-        // Normalize the stop words too, so both sides of the check below use the same derivation as the keys, the
-        // trie and the input. The set is populated with toLowerCase(ENGLISH) from several sources, which agrees
-        // with normalizeCase on ASCII but not outside it.
+        // The gate below compares the trie key, not the raw original, so stop words need the same derivation.
+        // Otherwise two originals that collapse to one key (sap, ſap) are gated differently, the ungated one
+        // puts that key in the trie, and the stop word stops working. Sources are mixed -- some lowercase with
+        // ENGLISH, some add raw values -- so normalizing here is what makes the check total.
         Set<String> stopWords = mappings.getStopWords().stream()
                 .map(SensitiveContentFilter::normalizeCase)
                 .collect(Collectors.toSet());

--- a/src/main/java/com/cloudbees/jenkins/support/util/WordReplacer.java
+++ b/src/main/java/com/cloudbees/jenkins/support/util/WordReplacer.java
@@ -8,6 +8,37 @@ import java.util.regex.Pattern;
 public class WordReplacer {
 
     /**
+     * Replace all matches in the normalized text by splicing replacements into the original input at matching offsets.
+     * The pattern is matched against {@code normalized}, but replacements are spliced into {@code input} using the
+     * same offsets. This is safe when normalization preserves offset alignment (never changes {@code charCount(cp)}).
+     * <p>
+     * Unlike {@link #replaceWords(String, Pattern, Function)}, this method does not use {@code Matcher#appendReplacement},
+     * so {@code \} and {@code $} in replacements do not need escaping.
+     *
+     * @param input the original text, returned unchanged if no matches
+     * @param normalized the case-normalized copy of {@code input}, matched against the pattern
+     * @param pattern the pattern to match (should have no case-insensitive flags since {@code normalized} is pre-normalized)
+     * @param replace function accepting a matched substring from {@code normalized} and returning its replacement
+     * @return {@code input} itself when no matches; otherwise a new string with replacements spliced in
+     */
+    public static String replaceWordsByOffset(
+            String input, String normalized, Pattern pattern, Function<String, String> replace) {
+        java.util.regex.Matcher m = pattern.matcher(normalized);
+        if (!m.find()) {
+            return input; // fast path: no allocation when nothing matches
+        }
+        StringBuilder out = new StringBuilder(input.length());
+        int last = 0;
+        do {
+            out.append(input, last, m.start());
+            out.append(replace.apply(normalized.substring(m.start(), m.end())));
+            last = m.end();
+        } while (m.find());
+        out.append(input, last, input.length());
+        return out.toString();
+    }
+
+    /**
      * Replace all matches in the input by their replacement. Matcher#appendReplacement is used and therefore `\` and
      * `$` characters must be escaped in the replacement string.
      * NOTE: To ignore casing, Pattern must be case-insensitive or contain all possible cases. And replacements must

--- a/src/test/java/com/cloudbees/jenkins/support/filter/ContentMappingsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/filter/ContentMappingsTest.java
@@ -23,6 +23,7 @@
  */
 package com.cloudbees.jenkins.support.filter;
 
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInRelativeOrder;
 import static org.hamcrest.Matchers.hasEntry;
@@ -30,20 +31,25 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.*;
 
+import hudson.BulkChange;
 import hudson.model.FreeStyleProject;
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.stream.StreamSupport;
 import jenkins.model.Jenkins;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LogRecorder;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jvnet.hudson.test.recipes.LocalData;
 
@@ -100,15 +106,12 @@ class ContentMappingsTest {
     }
 
     @Test
-    @Disabled("Bug to be resolved. Elements removed aren't removed from the persisted mapping (ContentMappings.xml")
-    void contentMappingsRemovedSerialized(JenkinsRule r) throws Throwable {
+    void removedItemMappingSurvivesGracePeriodThenEvicted(JenkinsRule r) throws Throwable {
         // To be final and reuse in the steps
         StringBuilder jobReplacement = new StringBuilder();
 
-        // Create a project and check its mapping
-        // Create a project
         r.createFreeStyleProject("ShortName");
-        ContentFilter.ALL.reload();
+        ContentFilter.reloadAndSaveMappings(ContentFilter.ALL);
 
         // Store their replacements
         ContentMappings mappings = ContentMappings.get();
@@ -128,19 +131,79 @@ class ContentMappingsTest {
         // Remove the project
         r.jenkins.remove(r.jenkins.getItem("ShortName"));
 
-        // Run the getMappingOrCreate of every mapping
-        SensitiveContentFilter.get().reload();
+        // A full reload-and-evict cycle must NOT drop the mapping immediately: it's still needed to
+        // redact any stray reference to "ShortName" that may already exist in current content (e.g. build
+        // logs, SCM URLs). Default retention is 90 days, so it survives.
+        ContentFilter.reloadAndSaveMappings(ContentFilter.ALL);
 
-        r.restart();
-
-        // Mapping removed after restart
         mappings = ContentMappings.get();
-
-        // Check if the mapping exists after restart
         assertThat(
-                "The mapping of a removed project shouldn't persist",
+                "The mapping of a removed project should survive its grace period",
                 mappings.getMappings(),
+                hasEntry("ShortName", jobReplacement.toString()));
+
+        System.setProperty(ContentMappings.class.getName() + ".RETENTION", "PT15S");
+        try {
+            await().atMost(Duration.ofSeconds(20))
+                    .pollInterval(Duration.ofSeconds(1))
+                    .until(() -> {
+                        ContentMappings cm = ContentMappings.get();
+                        try (BulkChange change = new BulkChange(cm)) {
+                            ContentFilter.reloadAndSaveMappings(ContentFilter.ALL);
+                            cm.evictStale();
+                            change.commit();
+                        }
+                        return !ContentMappings.get().getMappings().containsKey("ShortName");
+                    });
+        } finally {
+            System.clearProperty(ContentMappings.class.getName() + ".RETENTION");
+        }
+
+        assertThat(
+                "The mapping of a removed project should eventually be evicted once its grace period elapses",
+                ContentMappings.get().getMappings(),
                 not(hasEntry("ShortName", jobReplacement.toString())));
+    }
+
+    @Test
+    void evictStaleRemovesMappingsPastRetentionWindow(JenkinsRule r) {
+        ContentMappings mappings = ContentMappings.get();
+        Instant now = Instant.now();
+
+        ContentMapping stale = mappings.getMappingOrCreate("stale-entry", ContentMappingsTest::identityMapping);
+        stale.touch(now.minus(Duration.ofDays(91)));
+
+        ContentMapping fresh = mappings.getMappingOrCreate("fresh-entry", ContentMappingsTest::identityMapping);
+        fresh.touch(now.minus(Duration.ofDays(1)));
+
+        try (LogRecorder logger =
+                new LogRecorder().record(ContentMappings.class, Level.FINE).capture(1)) {
+            mappings.evictStale();
+
+            assertTrue(
+                    logger.getMessages().stream().anyMatch(msg -> msg.contains("Evicted 1 stale content mapping")),
+                    "eviction should be logged at FINE level with count");
+        }
+
+        Map<String, String> remaining = mappings.getMappings();
+        assertFalse(remaining.containsKey("stale-entry"), "mapping unused for over 90 days should be evicted");
+        assertTrue(remaining.containsKey("fresh-entry"), "mapping used within the retention window should survive");
+    }
+
+    @Test
+    @LocalData
+    void migratedMappingDefaultsLastSeenToNowNotEpoch(JenkinsRule r) {
+        ContentMappings mappings = ContentMappings.get();
+
+        ContentMapping migrated = StreamSupport.stream(mappings.spliterator(), false)
+                .filter(mapping -> mapping.getOriginal().equals("legacy-original"))
+                .findFirst()
+                .orElseThrow();
+
+        Instant now = Instant.now();
+        assertTrue(
+                migrated.getLastSeen().isBefore(now) && migrated.getLastSeen().isAfter(now.minusSeconds(60)),
+                "migrated mapping should default lastSeen to \"now\" (within last 60s), not the epoch (0)");
     }
 
     @Issue("JENKINS-53184")
@@ -213,5 +276,87 @@ class ContentMappingsTest {
         stopWords = contentMappings.getStopWords();
         assertFalse(stopWords.contains(ALT_VERSION));
         assertTrue(stopWords.contains(originalVersion));
+    }
+
+    @Test
+    void staleIpMappingKeepsPseudonymWhenFilteredDuringBundle(JenkinsRule r) throws Exception {
+        String testIp = "192.168.1.100";
+        ContentMappings mappings = ContentMappings.get();
+
+        String filtered = InetAddressContentFilter.get().filter(testIp);
+        String originalPseudonym = mappings.getMappings().get(testIp);
+        assertTrue(originalPseudonym.startsWith("ip_"), "IP should be filtered to ip_ pseudonym");
+
+        StreamSupport.stream(mappings.spliterator(), false)
+                .filter(mapping -> mapping.getOriginal().equals(testIp))
+                .findFirst()
+                .orElseThrow()
+                .touch(Instant.now().minus(Duration.ofDays(91)));
+
+        try (BulkChange change = new BulkChange(mappings)) {
+            ContentFilter filter = ContentFilter.ALL;
+            ContentFilter.reloadAndSaveMappings(filter);
+
+            String testContent = "Server at " + testIp;
+            filter.filter(testContent);
+
+            mappings.evictStale();
+            change.commit();
+        }
+
+        mappings = ContentMappings.get();
+        assertTrue(
+                mappings.getMappings().containsKey(testIp),
+                "IP mapping backdated beyond retention window should survive if encountered during filtering");
+        assertEquals(
+                originalPseudonym,
+                mappings.getMappings().get(testIp),
+                "IP mapping should keep its original pseudonym, not be evicted and recreated");
+    }
+
+    @Test
+    void staleMatchedMappingSurvivesAndRemainsFilteredOnNextCycle(JenkinsRule r) throws Exception {
+        String testName = "stale-but-matched";
+        ContentMappings mappings = ContentMappings.get();
+
+        ContentMapping mapping = mappings.getMappingOrCreate(testName, ContentMappingsTest::identityMapping);
+        String replacement = mapping.getReplacement();
+
+        mapping.touch(Instant.now().minus(Duration.ofDays(91)));
+
+        try (BulkChange change = new BulkChange(mappings)) {
+            ContentFilter filter = ContentFilter.ALL;
+            ContentFilter.reloadAndSaveMappings(filter);
+
+            String testContent = "Reference to " + testName;
+            filter.filter(testContent);
+
+            mappings.evictStale();
+            change.commit();
+        }
+
+        mappings = ContentMappings.get();
+        assertTrue(
+                mappings.getMappings().containsKey(testName),
+                "stale mapping matched during filtering should survive eviction");
+
+        try (BulkChange change = new BulkChange(mappings)) {
+            ContentFilter filter = ContentFilter.ALL;
+            ContentFilter.reloadAndSaveMappings(filter);
+
+            String testContent = "Still referencing " + testName;
+            filter.filter(testContent);
+
+            mappings.evictStale();
+            change.commit();
+        }
+
+        mappings = ContentMappings.get();
+        assertTrue(
+                mappings.getMappings().containsKey(testName), "previously-stale mapping should survive a second cycle");
+        assertEquals(
+                replacement,
+                mappings.getMappings().get(testName),
+                "mapping should keep the same replacement on second cycle");
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilterTest.java
@@ -166,4 +166,77 @@ class SensitiveContentFilterTest {
                 .orElseThrow()
                 .touch(lastSeen);
     }
+
+    @Test
+    void longSMatches(JenkinsRule j) throws IOException {
+        // Long s (U+017F) normalizes to 's' via Character.toLowerCase(Character.toUpperCase(cp)),
+        // matching what Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE does. But "ſap".toLowerCase(ENGLISH)
+        // is unchanged (ſ is already lowercase), so the old code crashed with NPE on a null replacement.
+        SensitiveContentFilter filter = SensitiveContentFilter.get();
+        ContentMappings mappings = ContentMappings.get();
+        mappings.getMappingOrCreate("sap", original -> ContentMapping.of(original, "replacement_sap"));
+        filter.reload();
+
+        String result = filter.filter("the ſap server");
+        assertThat(result).isEqualTo("the replacement_sap server");
+    }
+
+    @Test
+    void turkishCapitalIDotAbovePreservesLength(JenkinsRule j) throws IOException {
+        // Turkish İ (U+0130) grows from 7 to 8 chars when lowercased with toLowerCase(ENGLISH), corrupting
+        // trie literals and offsets. normalizeCase preserves length, so the name is redacted correctly.
+        SensitiveContentFilter filter = SensitiveContentFilter.get();
+        ContentMappings mappings = ContentMappings.get();
+        mappings.getMappingOrCreate("İdalium", original -> ContentMapping.of(original, "replacement_idalium"));
+        filter.reload();
+
+        String result = filter.filter("İdalium");
+        assertThat(result).isEqualTo("replacement_idalium");
+    }
+
+    @Test
+    void caseVariantMatching(JenkinsRule j) throws IOException {
+        // Case-insensitive matching should still work: JDoe, jdoe, JDOE should all match key "jdoe".
+        SensitiveContentFilter filter = SensitiveContentFilter.get();
+        FreeStyleProject project = j.createFreeStyleProject("JDoe");
+        filter.reload();
+
+        String replacement = filter.filter("JDoe");
+        assertThat(replacement).startsWith("item_").doesNotContain("JDoe");
+
+        assertThat(filter.filter("jdoe")).isEqualTo(replacement);
+        assertThat(filter.filter("JDOE")).isEqualTo(replacement);
+    }
+
+    @Test
+    void identityFastPathReturnsSameObject() {
+        // When normalizeCase encounters an already-normalized string, it must return the input object itself
+        // (not a copy) to avoid duplicating the char array for every key.
+        String alreadyLowercase = "alreadylowercase";
+        String normalized = SensitiveContentFilter.normalizeCase(alreadyLowercase);
+        assertThat(normalized).isSameAs(alreadyLowercase);
+
+        String mixed = "MixedCase";
+        String normalizedMixed = SensitiveContentFilter.normalizeCase(mixed);
+        assertThat(normalizedMixed).isNotSameAs(mixed);
+    }
+
+    @Test
+    void wordBoundarySemantics(JenkinsRule j) throws IOException {
+        // Java's \w is ASCII-only by default. normalizeCase on "ſſap" -> "ssap" where the lookbehind now sees
+        // a word character 's' and rejects a match that the old regex (with UNICODE_CASE) would have accepted
+        // if ſ were considered non-\w. Pin the intended behavior.
+        SensitiveContentFilter filter = SensitiveContentFilter.get();
+        ContentMappings mappings = ContentMappings.get();
+        mappings.getMappingOrCreate("sap", original -> ContentMapping.of(original, "replacement_sap"));
+        filter.reload();
+
+        // "ſſap" normalizes to "ssap", and "ssap" should NOT match due to the lookbehind (?<!\w) seeing 's'.
+        String result = filter.filter("ſſap");
+        assertThat(result).isEqualTo("ſſap"); // no replacement
+
+        // " sap" should match (space is not \w).
+        String result2 = filter.filter(" sap");
+        assertThat(result2).isEqualTo(" replacement_sap");
+    }
 }

--- a/src/test/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilterTest.java
@@ -29,6 +29,9 @@ import hudson.model.FreeStyleProject;
 import hudson.model.ListView;
 import hudson.model.User;
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -107,5 +110,60 @@ class SensitiveContentFilterTest {
         filter.reload();
         assertThat(filter.filter(os)).isEqualTo(os);
         assertThat(filter.filter(label)).startsWith("label_").isNotEqualTo(label);
+    }
+
+    @Test
+    void strayReferenceSurvivesGracePeriodAfterItemRemoval(JenkinsRule j) throws IOException {
+        SensitiveContentFilter filter = SensitiveContentFilter.get();
+        FreeStyleProject project = j.createFreeStyleProject("strayproject");
+        filter.reload();
+        String name = project.getName();
+
+        String replacement = filter.filter(name);
+        assertThat(replacement).startsWith("item_").doesNotContain(name);
+
+        j.jenkins.remove(project);
+        filter.reload();
+
+        // The item is gone, but the pre-fill loop in reload() still loads every persisted mapping, so a
+        // stray reference to "strayproject" elsewhere in current content (build logs, SCM URLs, etc.) must
+        // keep getting anonymized within the grace period.
+        assertThat(filter.filter(name)).isEqualTo(replacement);
+    }
+
+    @Test
+    void matchRefreshesLastSeenPreventingEviction(JenkinsRule j) throws IOException {
+        SensitiveContentFilter filter = SensitiveContentFilter.get();
+        FreeStyleProject kept = j.createFreeStyleProject("keptproject");
+        FreeStyleProject dropped = j.createFreeStyleProject("droppedproject");
+        filter.reload();
+
+        String keptName = kept.getName();
+        String droppedName = dropped.getName();
+
+        j.jenkins.remove(kept);
+        j.jenkins.remove(dropped);
+        filter.reload();
+
+        ContentMappings mappings = ContentMappings.get();
+        Instant staleTime = Instant.now().minus(Duration.ofDays(91));
+        backdate(mappings, keptName, staleTime);
+        backdate(mappings, droppedName, staleTime);
+
+        // A real match on "keptproject" (e.g. because its name still appears in old build logs) should
+        // refresh lastSeen back to "now" before the mapping is ever swept.
+        filter.filter(keptName);
+
+        mappings.evictStale();
+
+        assertThat(mappings.getMappings()).containsKey(keptName).doesNotContainKey(droppedName);
+    }
+
+    private static void backdate(ContentMappings mappings, String original, Instant lastSeen) {
+        StreamSupport.stream(mappings.spliterator(), false)
+                .filter(mapping -> mapping.getOriginal().equals(original))
+                .findFirst()
+                .orElseThrow()
+                .touch(lastSeen);
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/filter/SensitiveContentFilterTest.java
@@ -182,6 +182,18 @@ class SensitiveContentFilterTest {
     }
 
     @Test
+    void stopWordsMatchNonAsciiCaseVariants(JenkinsRule j) throws IOException {
+        // "jenkins" is a default stop word and "jenkinſ" normalizes to it, so the mapping must be suppressed.
+        // Deriving the candidate with toLowerCase(ENGLISH) left ſ alone and missed the stop word.
+        SensitiveContentFilter filter = SensitiveContentFilter.get();
+        ContentMappings mappings = ContentMappings.get();
+        mappings.getMappingOrCreate("jenkinſ", original -> ContentMapping.of(original, "replacement_jenkins"));
+        filter.reload();
+
+        assertThat(filter.filter("the jenkinſ server")).isEqualTo("the jenkinſ server");
+    }
+
+    @Test
     void turkishCapitalIDotAbovePreservesLength(JenkinsRule j) throws IOException {
         // Turkish İ (U+0130) grows from 7 to 8 chars when lowercased with toLowerCase(ENGLISH), corrupting
         // trie literals and offsets. normalizeCase preserves length, so the name is redacted correctly.

--- a/src/test/resources/com/cloudbees/jenkins/support/filter/ContentMappingsTest/migratedMappingDefaultsLastSeenToNowNotEpoch/com.cloudbees.jenkins.support.filter.ContentMappings.xml
+++ b/src/test/resources/com/cloudbees/jenkins/support/filter/ContentMappingsTest/migratedMappingDefaultsLastSeenToNowNotEpoch/com.cloudbees.jenkins.support.filter.ContentMappings.xml
@@ -1,0 +1,10 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<com.cloudbees.jenkins.support.filter.ContentMappings resolves-to="com.cloudbees.jenkins.support.filter.ContentMappings$XmlProxy">
+  <stopWords/>
+  <mappings>
+    <com.cloudbees.jenkins.support.filter.ContentMapping resolves-to="com.cloudbees.jenkins.support.filter.ContentMapping$SerializationProxy">
+      <original>legacy-original</original>
+      <replacement>legacy-replacement</replacement>
+    </com.cloudbees.jenkins.support.filter.ContentMapping>
+  </mappings>
+</com.cloudbees.jenkins.support.filter.ContentMappings>


### PR DESCRIPTION
> Draft: based on #980's branch, so the diff here includes #980 until that merges.
> This PR's own change only: https://github.com/mikecirioli/support-core-plugin/compare/JENKINS-55995...normalize-case-in-input
> Merge order: #984 → #980 → #986 → #987 → this.

Supersedes #982, which fixed this a different way.

`SensitiveContentFilter` compiles its pattern with `CASE_INSENSITIVE | UNICODE_CASE` but derives its keys with `String.toLowerCase(Locale.ENGLISH)`. Those two disagree, with two results:

- The pattern matches text the map has no key for, so the replacement is `null` and `Matcher.replaceAll` throws. Literal `sap` matches `ſap` (U+017F), whose `toLowerCase` is unchanged.
- `toLowerCase` on `İ` (U+0130) grows the string from 7 chars to 8, corrupting the trie literal so that name is never redacted at all. Silent.

Does not answer @jglick's question on #982 about why anonymization is case-insensitive at all. This only makes the existing behaviour self-consistent: one per-code-point function normalizes keys, trie words and input text, the pattern compiles with no flags, and replacements splice into the original by offset. `replacementFor` becomes a bare map lookup, so no derivation remains that can disagree.

Aligning key derivation with the regex instead would depend on an undocumented JDK detail — the cause of #981. It also makes retiring case-insensitivity a one-line change later (normalizer returns its input) rather than an edit across three derivations.

Offset splicing is safe: the normalizer never changes `charCount`, verified across all 1,114,112 code points. `String.toLowerCase` does not preserve it.

Behaviour changes, all tested:
- `ſap` and `sap` as separate mappings now share a pseudonym instead of crashing on match.
- Word boundaries shift for non-ASCII letters — `\w` is ASCII-only, and `ſſap` normalizes to `ssap`.
- Stop words are compared against the trie key rather than the raw original, so a configured `sap` also suppresses `ſap`, and a mixed-case entry in a user-supplied stop-words file starts matching. Without this the gate and the key disagree, the ungated original puts that key in the trie, and the stop word is bypassed.

No memory win: flagged and flagless patterns compile to the same size. Corrected on #984, where I had claimed otherwise.

Fixes #981

### Testing done

Both failure modes above have tests that fail without this change — verified by reverting `src/main` and observing the NPE and the unredacted `İdalium`, then restoring. Also covered: `JDoe` still matching key `jdoe`, the `\w` boundary behaviour, and the normalizer returning the same object when nothing changes.

Per-line overhead of normalizing input is tens of nanoseconds, tens of milliseconds across a 100k-line bundle.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed


